### PR TITLE
Harden PyTorch-family conversion skills and artifact resolution

### DIFF
--- a/examples/hello-world/agent-skills/huggingface-conversion/README.md
+++ b/examples/hello-world/agent-skills/huggingface-conversion/README.md
@@ -44,7 +44,9 @@ Open this directory in Codex or Claude Code and use this prompt:
 
 ```text
 I have an existing Hugging Face Trainer project in ./source. Convert it to
-federated learning and validate it locally.
+federated learning and validate it locally. You may download any required
+public model, tokenizer, and configuration artifacts if they are not already
+cached. Proceed without asking for additional confirmation.
 ```
 
 ## Run the Starting Project

--- a/examples/hello-world/agent-skills/huggingface-conversion/README.md
+++ b/examples/hello-world/agent-skills/huggingface-conversion/README.md
@@ -45,8 +45,8 @@ Open this directory in Codex or Claude Code and use this prompt:
 ```text
 I have an existing Hugging Face Trainer project in ./source. Convert it to
 federated learning and validate it locally. You may download any required
-public model, tokenizer, and configuration artifacts if they are not already
-cached. Proceed without asking for additional confirmation.
+public model artifacts, including tokenizer and configuration files, if they
+are not already cached. Proceed without asking for additional confirmation.
 ```
 
 ## Run the Starting Project

--- a/examples/hello-world/agent-skills/lightning-conversion/README.md
+++ b/examples/hello-world/agent-skills/lightning-conversion/README.md
@@ -42,7 +42,9 @@ Open this directory in Codex or Claude Code and use this prompt:
 
 ```text
 I have an existing PyTorch Lightning training project in ./source. Convert it
-to federated learning and validate it locally.
+to federated learning and validate it locally. You may download any required
+public model artifacts, including tokenizer and configuration files, if they
+are not already cached. Proceed without asking for additional confirmation.
 ```
 
 ## Run the Starting Project

--- a/examples/hello-world/agent-skills/pytorch-conversion/README.md
+++ b/examples/hello-world/agent-skills/pytorch-conversion/README.md
@@ -46,7 +46,9 @@ Open this directory in Codex or Claude Code and use this prompt:
 
 ```text
 I have an existing PyTorch training project in ./source. Convert it to
-federated learning and validate it locally.
+federated learning and validate it locally. You may download any required
+public model artifacts, including tokenizer and configuration files, if they
+are not already cached. Proceed without asking for additional confirmation.
 ```
 
 ## Run the Starting Project

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -95,10 +95,11 @@ user's purpose is to understand data distribution; handle conversion later as a 
    packaged project-local modules in the same writable source directory. Never
    use `..` in `train_script`, `add_server_file()`, or `add_client_file()`; use
    an existing resolved absolute path when co-location is impossible. Keep the
-   server and Trainer model factory and exchange keyspace identical. Follow the
-   shared "Recipe Model Config" policy; a direct instance must not use
-   `from_pretrained()`, downloads, or checkpoint loading during job
-   construction. Apply only options confirmed by the construction reference.
+   server and Trainer model factory and exchange keyspace identical. Use explicit
+   `class_path`/`args` for required or overridden constructor values; a direct
+   zero-argument instance must not use `from_pretrained()`, downloads, or
+   checkpoint loading during job construction. Apply only options confirmed by
+   the construction reference.
    Preserve the job asset's recipe-before-parser
    ordering, `ArgumentParser(allow_abbrev=False)`, and strict `parse_args()`; do
    not use `parse_known_args()`.
@@ -171,8 +172,9 @@ user's purpose is to understand data distribution; handle conversion later as a 
 - Must initialize `torch.distributed` before patching when rank environment
   variables declare multiple ranks. All ranks must call patched Trainer methods
   in identical order.
-- Must use the maintained HF validation resolver. Must not copy it into
-  generated job code, set `trust_remote_code=True`, download model/data
+- Must use the maintained HF validation resolver with an explicit local/Hub
+  source and a full commit-SHA revision for authorized downloads. Must not copy
+  it into generated job code, set `trust_remote_code=True`, download model/data
   artifacts unless requested, or recover from a cache-only miss by going
   online. Cache misses, remote identifiers, and validation requests do not
   authorize online retries. This narrows

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-convert-huggingface
-description: "Convert existing Hugging Face Transformers Trainer or TRL SFTTrainer training code into an NVFLARE federated job using flare.patch(trainer), local validation, and job export; do not use for manual PyTorch loops, Lightning, inference-only pipelines, deployment, or experiment workflows."
+description: "Convert existing Hugging Face Transformers Trainer or TRL SFTTrainer training code into an NVFLARE federated job using flare.patch(trainer), local validation, and job export; use when the user names Hugging Face or preliminary source inspection identifies one Hugging Face owner, and not for manual PyTorch loops, Lightning, inference-only pipelines, deployment, or experiment workflows."
 license: Apache-2.0
 version: "0.1.0"
 metadata:

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -171,10 +171,11 @@ user's purpose is to understand data distribution; handle conversion later as a 
 - Must initialize `torch.distributed` before patching when rank environment
   variables declare multiple ranks. All ranks must call patched Trainer methods
   in identical order.
-- Must not set `trust_remote_code=True`, download model/data artifacts unless
-  requested, or recover from an offline/cache-only miss by going online. Cache
-  misses, offline errors, remote identifiers, and validation requests do not
-  authorize online retries. This narrows the authorization rules in
+- Must use the maintained HF validation resolver. Must not copy it into
+  generated job code, set `trust_remote_code=True`, download model/data
+  artifacts unless requested, or recover from a cache-only miss by going
+  online. Cache misses, remote identifiers, and validation requests do not
+  authorize online retries. This narrows
   `../nvflare-shared/references/conversion-common.md`.
 - Site partitioning, custom aggregation, the Source Of Truth Boundary, and user
   input/authorization follow `../nvflare-shared/references/conversion-common.md`.

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -173,12 +173,12 @@ user's purpose is to understand data distribution; handle conversion later as a 
   variables declare multiple ranks. All ranks must call patched Trainer methods
   in identical order.
 - Must use the maintained HF validation resolver with an explicit local/Hub
-  source and a full commit-SHA revision for authorized downloads. Must not copy
-  it into generated job code, set `trust_remote_code=True`, download model/data
+  source. For authorized downloads it obtains or validates a full commit-SHA
+  revision before downloading. Must not copy it into
+  generated job code, set `trust_remote_code=True`, download model/data
   artifacts unless requested, or recover from a cache-only miss by going
   online. Cache misses, remote identifiers, and validation requests do not
-  authorize online retries. This narrows
-  `../nvflare-shared/references/conversion-common.md`.
+  authorize online retries; see `../nvflare-shared/references/conversion-common.md`.
 - Site partitioning, custom aggregation, the Source Of Truth Boundary, and user
   input/authorization follow `../nvflare-shared/references/conversion-common.md`.
 

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -95,12 +95,12 @@ user's purpose is to understand data distribution; handle conversion later as a 
    packaged project-local modules in the same writable source directory. Never
    use `..` in `train_script`, `add_server_file()`, or `add_client_file()`; use
    an existing resolved absolute path when co-location is impossible. Keep the
-   server and Trainer model factory and exchange keyspace identical. Use explicit
-   `class_path`/`args` for required or overridden constructor values; a direct
-   zero-argument instance must not use `from_pretrained()`, downloads, or
+   server and Trainer model factory and exchange keyspace identical. Use the
+   recipe's documented `class_path` or `path` key plus complete `args` for
+   required or overridden values; a direct zero-argument instance must not use
+   `from_pretrained()`, downloads, or
    checkpoint loading during job construction. Apply only options confirmed by
-   the construction reference.
-   Preserve the job asset's recipe-before-parser
+   the construction reference. Preserve the job asset's recipe-before-parser
    ordering, `ArgumentParser(allow_abbrev=False)`, and strict `parse_args()`; do
    not use `parse_known_args()`.
 7. Only after generated files exist, load

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -103,12 +103,12 @@ user's purpose is to understand data distribution; handle conversion later as a 
    the construction reference. Preserve the job asset's recipe-before-parser
    ordering, `ArgumentParser(allow_abbrev=False)`, and strict `parse_args()`; do
    not use `parse_known_args()`.
-7. Only after generated files exist, load
-   `../nvflare-shared/references/validation-evidence.md`, then
-   `references/huggingface-validation.md`. Follow the shared compile,
-   construction, export, package-inspection, simulation, and terminal-evidence
-   ladder; apply only the standard Trainer checks from the HF reference. Stop
-   at the first failed rung. Review and exercise the maintained assets directly;
+7. Only after generated files exist, load `../nvflare-shared/references/validation-evidence.md`
+   and `references/huggingface-validation.md`. Follow the shared compile,
+   construction, simulation, and terminal-evidence ladder. Inspect export/package
+   evidence only for an exported final target; inspect a local target's
+   materialized evidence after its run. Apply only the standard HF Trainer checks
+   and stop at the first failed rung. Review and exercise the maintained assets directly;
    do not inspect NVFLARE implementation source, improvise Recipe API probes, or
    write one-off AST programs to re-prove them. Use
    `references/huggingface-state-and-distributed.md`

--- a/skills/nvflare-convert-huggingface/assets/job.py
+++ b/skills/nvflare-convert-huggingface/assets/job.py
@@ -181,19 +181,13 @@ def build_sim_env(
     if per_site_config is None:
         return SimEnv(
             num_clients=num_clients,
-            num_threads=num_clients,
             workspace_root=str(workspace_root),
         )
 
     clients = list(per_site_config)
-    if len(clients) != num_clients:
-        raise ValueError(
-            f"per_site_config defines {len(clients)} site(s), but num_clients={num_clients}; "
-            "the named topology must match the requested client count"
-        )
     return SimEnv(
+        num_clients=num_clients,
         clients=clients,
-        num_threads=len(clients),
         workspace_root=str(workspace_root),
     )
 

--- a/skills/nvflare-convert-huggingface/assets/job.py
+++ b/skills/nvflare-convert-huggingface/assets/job.py
@@ -171,6 +171,33 @@ def build_recipe(
     return recipe
 
 
+def build_sim_env(
+    num_clients: int,
+    workspace_root: Path,
+    *,
+    per_site_config: dict[str, dict] | None = None,
+) -> SimEnv:
+    """Build a simulator environment with exactly one client-topology owner."""
+    if per_site_config is None:
+        return SimEnv(
+            num_clients=num_clients,
+            num_threads=num_clients,
+            workspace_root=str(workspace_root),
+        )
+
+    clients = list(per_site_config)
+    if len(clients) != num_clients:
+        raise ValueError(
+            f"per_site_config defines {len(clients)} site(s), but num_clients={num_clients}; "
+            "the named topology must match the requested client count"
+        )
+    return SimEnv(
+        clients=clients,
+        num_threads=len(clients),
+        workspace_root=str(workspace_root),
+    )
+
+
 def main():
     # Importing the Recipe API before parsing lets it consume --export and
     # --export-dir; this parser owns only the generated job's local options.
@@ -209,13 +236,7 @@ def main():
         key_metric=args.key_metric,
     )
     workspace_root = _simulation_workspace(args.workspace_root)
-    run = recipe.execute(
-        SimEnv(
-            num_clients=args.num_clients,
-            num_threads=args.num_clients,
-            workspace_root=str(workspace_root),
-        )
-    )
+    run = recipe.execute(build_sim_env(args.num_clients, workspace_root))
     print("Job Status is:", run.get_status())
     print("Result can be found in:", run.get_result())
 

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -137,7 +137,7 @@
           },
           {
             "id": "single-simulator-topology-owner",
-            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or makes clients=list(per_site_config) the topology owner for genuinely different named-site arguments; any accompanying num_clients is matching consistency evidence only"
           },
           {
             "id": "guard-optional-host-diagnostics",
@@ -243,7 +243,7 @@
           },
           {
             "id": "no-mixed-named-and-generated-client-topology",
-            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
+            "description": "does not generate unnamed SimEnv clients after set_per_site_config creates named targets, pass an inconsistent num_clients with clients, or recover from a mismatch with num_clients=None"
           }
         ],
         "process_metrics": [

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -56,7 +56,7 @@
         "The generated job imports FedAvgRecipe from nvflare.app_opt.pt.recipes.fedavg after recipe show confirms it.",
         "The agent treats recipe show as recipe metadata only, uses SimEnv with recipe.execute for local validation and standard export flags, and does not guess a separate export environment, private class-loader helper, internal command splitter, or another recipe-adjacent API.",
         "The agent establishes host-provided NVFLARE availability separately through nvflare agent inspect source, nvflare --version, or a public capability check before generic package inventory; it never includes nvflare in a batch of importlib.metadata lookups, handles missing non-product metadata as an inventory result rather than a failed command, and skips installation when all applicable requirements are already compatible.",
-        "When public checkpoint download is authorized if uncached, the agent uses one normal cache-aware load or download instead of an unguarded cache-only probe that fails on a normal miss.",
+        "The agent tells the maintained resolver whether each model identifier is a local path or Hub repository ID instead of inferring from slash syntax. When public checkpoint download is authorized if uncached, it uses one normal cache-aware load pinned to a full immutable commit SHA instead of an unguarded cache-only probe that fails on a normal miss.",
         "A generated or preserved HfArgumentParser is constructed with allow_abbrev=False. Intentional typo and abbreviation rejection checks run through assertion wrappers whose top-level commands succeed only when the generated parser rejects them; the wrapper accepts an expected unused-argument ValueError only when its diagnostic names the rejected argument.",
         "Standalone preflight may construct the Trainer but does not call flare.init(), flare.patch(), flare.is_running(), or patched Trainer methods without a launcher-created Client API context; the first bounded simulation validates runtime patch acceptance.",
         "The generated recipe model is an explicit class_path and args mapping, not a live model instance. Validation reconstructs the source and server models through the same importable factory path and arguments and compares keys, shapes, and dtypes. Before comparing values, it uses source or load-report evidence to distinguish checkpoint-loaded parameters from missing or newly initialized parameters, requires exact values or a stable state hash only for parameters proven deterministic, and does not create a failed top-level command by unconditionally comparing independently initialized keys.",
@@ -121,11 +121,11 @@
           },
           {
             "id": "cache-aware-authorized-model-resolution",
-            "description": "uses one normal cache-aware model load or download when an uncached public checkpoint download is authorized"
+            "description": "selects local path or Hub repository source explicitly and uses one normal cache-aware model load pinned to a full commit SHA when an uncached public checkpoint download is authorized"
           },
           {
             "id": "explicit-server-model-config",
-            "description": "uses the same importable factory path and arguments for source and server models, validates matching state-dict keys, shapes, and dtypes, requires exact values or a stable state hash for checkpoint-loaded or otherwise proven deterministic parameters, treats missing or newly initialized parameters as schema-only unless initialization state is explicitly reset, and ensures server-only model modules are exported"
+            "description": "uses explicit class_path plus complete args so source and server models have the same importable factory path and arguments, verifies the exported server config retains them, validates matching state-dict keys, shapes, and dtypes, requires exact values or a stable state hash for checkpoint-loaded or otherwise proven deterministic parameters, treats missing or newly initialized parameters as schema-only unless initialization state is explicitly reset, and ensures server-only model modules are exported"
           },
           {
             "id": "preserve-tensor-dtypes",
@@ -192,6 +192,14 @@
           {
             "id": "no-raising-cache-only-model-probe",
             "description": "does not run an unguarded local-files-only checkpoint lookup before an authorized cache-aware download"
+          },
+          {
+            "id": "no-ambiguous-model-source",
+            "description": "does not infer whether a missing slash-containing identifier is a local path or Hub repository ID"
+          },
+          {
+            "id": "no-unpinned-hub-download",
+            "description": "does not authorize a Hub download without a full immutable commit-SHA revision"
           },
           {
             "id": "no-unguarded-platform-specific-diagnostic",

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -148,6 +148,10 @@
             "description": "runs the validation ladder and reports commands, status, metrics, and exact artifact paths"
           },
           {
+            "id": "single-final-validation-path",
+            "description": "selects python job.py as the one final target for this local-simulation prompt and obtains config evidence from its completed simulation workspace without an explicit export"
+          },
+          {
             "id": "validate-patch-in-client-context",
             "description": "validates runtime flare.patch acceptance through the launched recipe or simulator client rather than a standalone Python preflight without Client API context"
           },
@@ -220,6 +224,14 @@
           {
             "id": "no-ad-hoc-structure-or-recipe-probes",
             "description": "does not replace the maintained client template or public recipe metadata with improvised AST programs, Recipe-source inspection, or guessed adjacent APIs"
+          },
+          {
+            "id": "no-unrequested-explicit-export",
+            "description": "does not invoke an explicit export or exported-folder simulator for this local-simulation prompt"
+          },
+          {
+            "id": "no-generated-export-system-arguments",
+            "description": "does not declare, parse, or branch on NVFLARE's reserved --export or --export-dir system arguments or a private alias in generated job code"
           },
           {
             "id": "no-unconditional-equality-for-newly-initialized-parameters",

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -121,7 +121,7 @@
           },
           {
             "id": "cache-aware-authorized-model-resolution",
-            "description": "selects local path or Hub repository source explicitly and uses one normal cache-aware model load pinned to a full commit SHA when an uncached public checkpoint download is authorized"
+            "description": "selects local path or Hub repository source explicitly, resolves relative local paths against an absolute original source root, uses the resolver's positional identifier, and uses one normal cache-aware model load pinned to a full commit SHA when an uncached public checkpoint download is authorized"
           },
           {
             "id": "explicit-server-model-config",
@@ -134,6 +134,10 @@
           {
             "id": "site-local-training-data",
             "description": "preserves site data or creates deterministic seeded site-local partitions, stratified when labels exist, and reports the split decision"
+          },
+          {
+            "id": "single-simulator-topology-owner",
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
           },
           {
             "id": "guard-optional-host-diagnostics",
@@ -198,6 +202,10 @@
             "description": "does not infer whether a missing slash-containing identifier is a local path or Hub repository ID"
           },
           {
+            "id": "no-invented-resolver-model-option",
+            "description": "does not invent a --model option for the maintained resolver, whose model identifier is positional"
+          },
+          {
             "id": "no-unpinned-hub-download",
             "description": "does not authorize a Hub download without a full immutable commit-SHA revision"
           },
@@ -220,6 +228,10 @@
           {
             "id": "no-orient-for-single-owner-conversion",
             "description": "does not route an explicit conversion through nvflare-orient merely because its prompt omits the framework when inspection finds one Hugging Face Trainer owner"
+          },
+          {
+            "id": "no-mixed-named-and-generated-client-topology",
+            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
           }
         ],
         "process_metrics": [

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "huggingface-convert-basic",
-      "prompt": "Convert this Hugging Face Trainer sequence-classification script into an NVFLARE FedAvg job for 2 simulated sites and 2 rounds. Preserve evaluation accuracy and run a bounded local validation.",
+      "prompt": "Convert the training code in the current directory into an NVFLARE FedAvg job for 2 simulated sites and 2 rounds. Preserve evaluation accuracy and run a bounded local validation.",
       "expected_output": "A standard client.py/model.py/job.py conversion that statically inspects the source, uses the PyTorch FedAvg recipe, preserves the Trainer/model/datasets/compute_metrics setup, applies nvflare.client.hf.patch(trainer) once, evaluates the received global model before local training, uses site-local training partitions, preserves PyTorch tensor exchange, validates locally, preserves existing non-generated source, and reports exact artifact paths.",
       "files": [
         "files/trainer-basic/train.py",
@@ -43,6 +43,7 @@
       ],
       "assertions": [
         "The agent runs nvflare agent inspect source on the target before editing and confirms active Hugging Face Trainer ownership.",
+        "The agent routes directly to nvflare-convert-huggingface after preliminary inspection finds one Hugging Face Trainer owner; it does not load nvflare-orient merely because the prompt omitted the framework.",
         "The agent preserves existing non-generated source unless the user explicitly requested a specific overwrite.",
         "The generated client uses nvflare.client.hf and exactly one flare.patch(trainer) call.",
         "The agent completes inspect, dependency handling, recipe show and capability construction, conversion, job construction, and validation in order without preloading advanced or validation references.",
@@ -207,6 +208,10 @@
           {
             "id": "no-unconditional-equality-for-newly-initialized-parameters",
             "description": "does not run a failing full-state equality assertion across independently constructed models when load evidence reports missing or newly initialized parameters; it retains schema checks and exact comparison for parameters proven deterministic"
+          },
+          {
+            "id": "no-orient-for-single-owner-conversion",
+            "description": "does not route an explicit conversion through nvflare-orient merely because its prompt omits the framework when inspection finds one Hugging Face Trainer owner"
           }
         ],
         "process_metrics": [

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -144,11 +144,14 @@ internal command-splitting helpers.
 `train_script` names the primary client entry point in the runtime config; it
 does not provide a separate source root for caller-cwd-independent packaging.
 Use its portable app-local name in the constructor and add the resolved source
-once with `recipe.add_client_file(...)`. Export and inspect the job before
-simulation. Reject absolute `task_script_path` values in generated configs
-because exported apps must launch their packaged client script portably.
+once with `recipe.add_client_file(...)`. For an exported-artifact target, export
+and inspect that job before running it with the simulator CLI. For a local
+`python job.py` target, do not export; after the run, inspect the materialized
+simulation workspace for the same config and packaging evidence. Reject
+absolute `task_script_path` values in generated configs because runtime apps
+must launch their packaged client script portably.
 
-Exported app layout is owned by
+For an exported-artifact target, exported app layout is owned by
 `../../nvflare-shared/references/conversion-workflow.md`: inspect the exported
 job root and enumerate the app directories it actually contains before asserting
 any path.

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -130,10 +130,11 @@ Every site uses the same packaged `client.py`; do not include `train_script` in
 the per-site mapping. The asset rejects both relative and absolute site-specific
 script overrides because it cannot package them while preserving one portable
 app-local runtime path.
-Pass that same mapping to the asset's `build_sim_env(...)`: it selects
-`SimEnv(clients=list(per_site_config), ...)` for named targets instead of also
-setting `num_clients`. Leave the mapping unset for ordinary generated
-partitions, and derive their indices from the initialized `site-N` name.
+Pass that same mapping to the asset's `build_sim_env(...)`, which implements the
+single-topology-owner rule from
+`../../nvflare-shared/references/conversion-common.md`. Leave the mapping unset
+for ordinary generated partitions, and derive their indices from the initialized
+`site-N` name.
 Follow the shared construction reference's client-argument transport rule.
 `train_args` is not necessarily shell parsed: use unquoted whitespace-free
 tokens for the default in-process executor, and use shell quoting only for a

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -130,6 +130,10 @@ Every site uses the same packaged `client.py`; do not include `train_script` in
 the per-site mapping. The asset rejects both relative and absolute site-specific
 script overrides because it cannot package them while preserving one portable
 app-local runtime path.
+Pass that same mapping to the asset's `build_sim_env(...)`: it selects
+`SimEnv(clients=list(per_site_config), ...)` for named targets instead of also
+setting `num_clients`. Leave the mapping unset for ordinary generated
+partitions, and derive their indices from the initialized `site-N` name.
 Follow the shared construction reference's client-argument transport rule.
 `train_args` is not necessarily shell parsed: use unquoted whitespace-free
 tokens for the default in-process executor, and use shell quoting only for a

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -64,15 +64,18 @@ reaches the applicable phase, and stop at the first failure.
   rerun the Hub resolver once with the complete canonical invocation:
 
   ```bash
-  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --allow-download --revision <commit-sha> <org/model>
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --allow-download <org/model>
   ```
 
-  The revision is the full immutable 40-character commit SHA. Use its
-  immutable `resolved_path` for the server and every client. Do not run a
-  preceding `snapshot_download(..., local_files_only=True)` probe, copy resolver
-  logic into generated `job.py`, or download without authorization. Resolve
-  datasets through their source-prescribed local path or cache with the same
-  policy.
+  In that authorized invocation, the resolver uses the public
+  `HfApi().model_info(...).sha` result, validates the full immutable
+  40-character commit SHA, and passes it to `snapshot_download`. An already
+  audited full SHA may instead be supplied with `--revision`. Use the returned
+  immutable `revision` and `resolved_path` for the server and every client. Do
+  not run a preceding `snapshot_download(..., local_files_only=True)` probe,
+  copy resolver logic into generated `job.py`, or download without
+  authorization. Resolve datasets through their source-prescribed local path or
+  cache with the same policy.
 - Never recover from an offline/cache-only miss by removing
   `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`, dropping `local_files_only=True`, or
   rerunning online unless the user explicitly requested the download. Do not

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -54,33 +54,44 @@ reaches the applicable phase, and stop at the first failure.
   ```bash
   python <skill-dir>/scripts/resolve_model_snapshot.py --source local --source-root <absolute-source-root> <configured-path>
   python <skill-dir>/scripts/resolve_model_snapshot.py --source hub <org/model>
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --repo-type dataset <org/dataset>
   ```
 
   A relative local identifier requires the absolute original source-project
   root so resolution never depends on the validation command's working
   directory. An absolute local identifier must omit `--source-root`; the option
   resolves relative identifiers and is not a sandbox boundary.
-- Only when the user authorizes downloading a public checkpoint if uncached,
-  rerun the Hub resolver once with the complete canonical invocation:
+- Only when the user authorizes downloading the specific public Hub artifact if
+  uncached, rerun its resolver once with the matching canonical invocation:
 
   ```bash
   python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --allow-download <org/model>
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --repo-type dataset --allow-download <org/dataset>
   ```
 
-  In that authorized invocation, the resolver uses the public
-  `HfApi().model_info(...).sha` result, validates the full immutable
+  In that authorized invocation, the resolver uses the matching public
+  `HfApi().model_info(...).sha` or
+  `HfApi().dataset_info(...).sha` result, validates the full immutable
   40-character commit SHA, and passes it to `snapshot_download`. An already
-  audited full SHA may instead be supplied with `--revision`. Use the returned
-  immutable `revision` and `resolved_path` for the server and every client. Do
-  not run a preceding `snapshot_download(..., local_files_only=True)` probe,
-  copy resolver logic into generated `job.py`, or download without
-  authorization. Resolve datasets through their source-prescribed local path or
-  cache with the same policy.
+  audited full SHA may instead be supplied with `--revision`. For a model
+  repository, use the returned immutable `revision` and `resolved_path` for the
+  server and every client. For a dataset repository, pass `resolved_path` only
+  to a source-compatible local dataset loader; if the source cannot load that
+  snapshot layout, ask or fail closed rather than inventing a loader. Do not run
+  a preceding `snapshot_download(..., local_files_only=True)` probe, copy
+  resolver logic into generated `job.py`, or download without authorization.
+  For a configured Hub dataset ID, use the same resolver with
+  `--repo-type dataset`; for a source-prescribed local dataset path, use the
+  existing local path without a Hub lookup.
 - Never recover from an offline/cache-only miss by removing
   `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`, dropping `local_files_only=True`, or
   rerunning online unless the user explicitly requested the download. Do not
   substitute another local checkpoint. Keep the job as a draft and report
   full-model validation blocked when the required artifact is unavailable.
+  A cache-only Hugging Face error can mention `huggingface.co` while reporting
+  a local cache miss; that URL alone is not evidence that a network request was
+  attempted. Judge the configured offline flags, `local_files_only` setting,
+  and exception/result type instead.
 - Pass the same resolved local model path and cache configuration from the
   resolver to the server model and every client. Do not validate with a cached
   Hub identifier and export a job that depends on an unverified online lookup.

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -58,7 +58,8 @@ reaches the applicable phase, and stop at the first failure.
 
   A relative local identifier requires the absolute original source-project
   root so resolution never depends on the validation command's working
-  directory. An absolute local identifier does not require `--source-root`.
+  directory. An absolute local identifier must omit `--source-root`; the option
+  resolves relative identifiers and is not a sandbox boundary.
 - Only when the user authorizes downloading a public checkpoint if uncached,
   rerun the Hub resolver once with the complete canonical invocation:
 

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -42,15 +42,20 @@ reaches the applicable phase, and stop at the first failure.
 ## Hugging Face Artifacts And Compatibility
 
 - Before constructing a model or tokenizer/processor, run the maintained
-  `../scripts/resolve_model_snapshot.py` for its configured local path or Hub
-  identifier. Its cache-only default catches `LocalEntryNotFoundError`, emits a
-  structured `missing` result, and exits zero; report that result as a blocker.
+  `../scripts/resolve_model_snapshot.py` with `--source local` for a configured
+  path or `--source hub` for a Hub repository ID. Never infer the source type
+  from slash syntax: `models/checkpoint` and `org/model` are intentionally
+  distinguished by that required option. The cache-only Hub path catches
+  `LocalEntryNotFoundError`, emits a structured `missing` result, and exits zero;
+  report that result as a blocker.
 - Only when the user authorizes downloading a public checkpoint if uncached,
-  rerun the resolver once with `--allow-download`. Use its immutable
-  `resolved_path` for the server and every client. Do not run a preceding
-  `snapshot_download(..., local_files_only=True)` probe, copy resolver logic
-  into generated `job.py`, or download without authorization. Resolve datasets
-  through their source-prescribed local path or cache with the same policy.
+  rerun the Hub resolver once with `--allow-download --revision <commit-sha>`,
+  where the revision is the full immutable 40-character commit SHA. Use its
+  immutable `resolved_path` for the server and every client. Do not run a
+  preceding `snapshot_download(..., local_files_only=True)` probe, copy resolver
+  logic into generated `job.py`, or download without authorization. Resolve
+  datasets through their source-prescribed local path or cache with the same
+  policy.
 - Never recover from an offline/cache-only miss by removing
   `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`, dropping `local_files_only=True`, or
   rerunning online unless the user explicitly requested the download. Do not

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -48,9 +48,25 @@ reaches the applicable phase, and stop at the first failure.
   distinguished by that required option. The cache-only Hub path catches
   `LocalEntryNotFoundError`, emits a structured `missing` result, and exits zero;
   report that result as a blocker.
+- Use the identifier as the positional argument; do not invent a `--model`
+  option. These are the canonical invocations:
+
+  ```bash
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source local --source-root <absolute-source-root> <configured-path>
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub <org/model>
+  ```
+
+  A relative local identifier requires the absolute original source-project
+  root so resolution never depends on the validation command's working
+  directory. An absolute local identifier does not require `--source-root`.
 - Only when the user authorizes downloading a public checkpoint if uncached,
-  rerun the Hub resolver once with `--allow-download --revision <commit-sha>`,
-  where the revision is the full immutable 40-character commit SHA. Use its
+  rerun the Hub resolver once with the complete canonical invocation:
+
+  ```bash
+  python <skill-dir>/scripts/resolve_model_snapshot.py --source hub --allow-download --revision <commit-sha> <org/model>
+  ```
+
+  The revision is the full immutable 40-character commit SHA. Use its
   immutable `resolved_path` for the server and every client. Do not run a
   preceding `snapshot_download(..., local_files_only=True)` probe, copy resolver
   logic into generated `job.py`, or download without authorization. Resolve

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -41,28 +41,24 @@ reaches the applicable phase, and stop at the first failure.
 
 ## Hugging Face Artifacts And Compatibility
 
-- Before constructing a model, tokenizer/processor, or dataset, resolve its
-  configured identifier to an existing local path or verify that every required
-  file is present in the intended cache. Without download authorization, probe
-  remote-style identifiers with `local_files_only=True` or the existing offline
-  environment. An error that mentions `https://huggingface.co` during an offline
-  probe can mean only that the local cache entry is missing; it is not evidence
-  of a network request.
-- When the user authorizes downloading a public checkpoint if it is not cached,
-  invoke the selected library's normal cache-aware load or download once. Do
-  not first run an unguarded
-  `snapshot_download(..., local_files_only=True)` probe: a normal cache miss
-  raises and creates false recovery evidence. When validation must remain
-  cache-only, catch `LocalEntryNotFoundError` inside an exit-zero wrapper,
-  report the miss as a blocker, and do not download without authorization.
+- Before constructing a model or tokenizer/processor, run the maintained
+  `../scripts/resolve_model_snapshot.py` for its configured local path or Hub
+  identifier. Its cache-only default catches `LocalEntryNotFoundError`, emits a
+  structured `missing` result, and exits zero; report that result as a blocker.
+- Only when the user authorizes downloading a public checkpoint if uncached,
+  rerun the resolver once with `--allow-download`. Use its immutable
+  `resolved_path` for the server and every client. Do not run a preceding
+  `snapshot_download(..., local_files_only=True)` probe, copy resolver logic
+  into generated `job.py`, or download without authorization. Resolve datasets
+  through their source-prescribed local path or cache with the same policy.
 - Never recover from an offline/cache-only miss by removing
   `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`, dropping `local_files_only=True`, or
   rerunning online unless the user explicitly requested the download. Do not
   substitute another local checkpoint. Keep the job as a draft and report
   full-model validation blocked when the required artifact is unavailable.
-- Pass the same resolved local model path and cache configuration to the server
-  model and every client. Do not validate with a cached Hub identifier and
-  export a job that depends on an unverified online lookup.
+- Pass the same resolved local model path and cache configuration from the
+  resolver to the server model and every client. Do not validate with a cached
+  Hub identifier and export a job that depends on an unverified online lookup.
 - Do not call `flare.init()`, `flare.patch()`, `flare.is_running()`, or patched
   Trainer methods in a standalone preflight; they require the Client API context
   created by the recipe or simulator launcher. Construct the Trainer without

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -33,6 +33,15 @@ def _load_huggingface_hub():
     return snapshot_download, LocalEntryNotFoundError
 
 
+def _resolve_hub_revision(identifier: str) -> str:
+    from huggingface_hub import HfApi
+
+    revision = HfApi().model_info(repo_id=identifier).sha
+    if not _COMMIT_SHA_RE.fullmatch(revision or ""):
+        raise ValueError("Hub revision lookup did not return a 40-character commit SHA")
+    return revision
+
+
 def resolve_model_snapshot(
     identifier: str,
     *,
@@ -79,8 +88,11 @@ def resolve_model_snapshot(
 
     if source_root is not None:
         raise ValueError("source_root can only be used with source='local'")
-    if allow_download and not _COMMIT_SHA_RE.fullmatch(revision or ""):
-        raise ValueError("authorized Hub downloads require a 40-character commit SHA revision")
+    if allow_download:
+        if revision is None:
+            revision = _resolve_hub_revision(identifier)
+        elif not _COMMIT_SHA_RE.fullmatch(revision):
+            raise ValueError("authorized Hub downloads require a 40-character commit SHA revision")
 
     snapshot_download, local_entry_not_found = _load_huggingface_hub()
     try:
@@ -122,7 +134,7 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Absolute original source-project root used to resolve a relative local identifier",
     )
     parser.add_argument("--allow-download", action="store_true", help="Permit one normal cache-aware Hub download")
-    parser.add_argument("--revision", help="Hub revision; a full commit SHA is required for downloads")
+    parser.add_argument("--revision", help="Optional full Hub commit SHA; authorized downloads resolve it when omitted")
     parser.add_argument("--cache-dir", help="Optional Hugging Face cache directory")
     return parser.parse_args(argv)
 

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resolve a local or Hugging Face model snapshot without false failures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+
+def _load_huggingface_hub():
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    return snapshot_download, LocalEntryNotFoundError
+
+
+def _looks_like_local_path(identifier: str) -> bool:
+    return Path(identifier).is_absolute() or identifier.startswith(("./", "../", "~"))
+
+
+def resolve_model_snapshot(
+    identifier: str,
+    *,
+    allow_download: bool = False,
+    revision: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return structured resolution evidence; an expected cache miss is not an error."""
+    candidate = Path(identifier).expanduser()
+    if candidate.exists():
+        return {
+            "download_authorized": allow_download,
+            "identifier": identifier,
+            "resolved_path": str(candidate.resolve()),
+            "source": "local",
+            "status": "available",
+        }
+    if _looks_like_local_path(identifier):
+        return {
+            "download_authorized": allow_download,
+            "identifier": identifier,
+            "reason": "local_path_not_found",
+            "resolved_path": None,
+            "source": "local",
+            "status": "missing",
+        }
+
+    snapshot_download, local_entry_not_found = _load_huggingface_hub()
+    kwargs: Dict[str, Any] = {
+        "local_files_only": not allow_download,
+        "repo_id": identifier,
+    }
+    if revision is not None:
+        kwargs["revision"] = revision
+    if cache_dir is not None:
+        kwargs["cache_dir"] = cache_dir
+
+    try:
+        resolved_path = snapshot_download(**kwargs)
+    except local_entry_not_found:
+        if allow_download:
+            raise
+        return {
+            "download_authorized": False,
+            "identifier": identifier,
+            "reason": "not_cached",
+            "resolved_path": None,
+            "source": "hub_cache",
+            "status": "missing",
+        }
+
+    return {
+        "download_authorized": allow_download,
+        "identifier": identifier,
+        "resolved_path": str(Path(resolved_path).resolve()),
+        "source": "hub_download_or_cache" if allow_download else "hub_cache",
+        "status": "available",
+    }
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("identifier", help="Local model path or Hugging Face model repository ID")
+    parser.add_argument("--allow-download", action="store_true", help="Permit one normal cache-aware Hub download")
+    parser.add_argument("--revision", help="Optional Hub revision")
+    parser.add_argument("--cache-dir", help="Optional Hugging Face cache directory")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    result = resolve_model_snapshot(
+        args.identifier,
+        allow_download=args.allow_download,
+        revision=args.revision,
+        cache_dir=args.cache_dir,
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -19,8 +19,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
+
+_COMMIT_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 
 
 def _load_huggingface_hub():
@@ -30,30 +33,32 @@ def _load_huggingface_hub():
     return snapshot_download, LocalEntryNotFoundError
 
 
-def _looks_like_local_path(identifier: str) -> bool:
-    return Path(identifier).is_absolute() or identifier.startswith(("./", "../", "~"))
-
-
 def resolve_model_snapshot(
     identifier: str,
     *,
+    source: str,
     allow_download: bool = False,
     revision: Optional[str] = None,
     cache_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return structured resolution evidence; an expected cache miss is not an error."""
-    candidate = Path(identifier).expanduser()
-    if candidate.exists():
+    if source not in {"hub", "local"}:
+        raise ValueError("source must be 'local' or 'hub'")
+
+    if source == "local":
+        if allow_download or revision is not None or cache_dir is not None:
+            raise ValueError("Hub download, revision, and cache options cannot be used with source='local'")
+        candidate = Path(identifier).expanduser()
+        if candidate.exists():
+            return {
+                "download_authorized": False,
+                "identifier": identifier,
+                "resolved_path": str(candidate.resolve()),
+                "source": "local",
+                "status": "available",
+            }
         return {
-            "download_authorized": allow_download,
-            "identifier": identifier,
-            "resolved_path": str(candidate.resolve()),
-            "source": "local",
-            "status": "available",
-        }
-    if _looks_like_local_path(identifier):
-        return {
-            "download_authorized": allow_download,
+            "download_authorized": False,
             "identifier": identifier,
             "reason": "local_path_not_found",
             "resolved_path": None,
@@ -61,18 +66,17 @@ def resolve_model_snapshot(
             "status": "missing",
         }
 
-    snapshot_download, local_entry_not_found = _load_huggingface_hub()
-    kwargs: Dict[str, Any] = {
-        "local_files_only": not allow_download,
-        "repo_id": identifier,
-    }
-    if revision is not None:
-        kwargs["revision"] = revision
-    if cache_dir is not None:
-        kwargs["cache_dir"] = cache_dir
+    if allow_download and not _COMMIT_SHA_RE.fullmatch(revision or ""):
+        raise ValueError("authorized Hub downloads require a 40-character commit SHA revision")
 
+    snapshot_download, local_entry_not_found = _load_huggingface_hub()
     try:
-        resolved_path = snapshot_download(**kwargs)
+        resolved_path = snapshot_download(
+            repo_id=identifier,
+            revision=revision,
+            cache_dir=cache_dir,
+            local_files_only=not allow_download,
+        )
     except local_entry_not_found:
         if allow_download:
             raise
@@ -81,6 +85,7 @@ def resolve_model_snapshot(
             "identifier": identifier,
             "reason": "not_cached",
             "resolved_path": None,
+            "revision": revision,
             "source": "hub_cache",
             "status": "missing",
         }
@@ -89,6 +94,7 @@ def resolve_model_snapshot(
         "download_authorized": allow_download,
         "identifier": identifier,
         "resolved_path": str(Path(resolved_path).resolve()),
+        "revision": revision,
         "source": "hub_download_or_cache" if allow_download else "hub_cache",
         "status": "available",
     }
@@ -96,9 +102,10 @@ def resolve_model_snapshot(
 
 def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    parser.add_argument("identifier", help="Local model path or Hugging Face model repository ID")
+    parser.add_argument("identifier", help="Local model path or Hugging Face Hub repository ID")
+    parser.add_argument("--source", choices=("local", "hub"), required=True, help="Identifier source type")
     parser.add_argument("--allow-download", action="store_true", help="Permit one normal cache-aware Hub download")
-    parser.add_argument("--revision", help="Optional Hub revision")
+    parser.add_argument("--revision", help="Hub revision; a full commit SHA is required for downloads")
     parser.add_argument("--cache-dir", help="Optional Hugging Face cache directory")
     return parser.parse_args(argv)
 
@@ -107,6 +114,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = _parse_args(argv)
     result = resolve_model_snapshot(
         args.identifier,
+        source=args.source,
         allow_download=args.allow_download,
         revision=args.revision,
         cache_dir=args.cache_dir,

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Resolve a local or Hugging Face model snapshot without false failures."""
+"""Resolve a local or Hugging Face model/dataset snapshot without false failures."""
 
 from __future__ import annotations
 
@@ -33,10 +33,16 @@ def _load_huggingface_hub():
     return snapshot_download, LocalEntryNotFoundError
 
 
-def _resolve_hub_revision(identifier: str) -> str:
+def _resolve_hub_revision(identifier: str, repo_type: str) -> str:
     from huggingface_hub import HfApi
 
-    revision = HfApi().model_info(repo_id=identifier).sha
+    api = HfApi()
+    if repo_type == "model":
+        revision = api.model_info(repo_id=identifier).sha
+    elif repo_type == "dataset":
+        revision = api.dataset_info(repo_id=identifier).sha
+    else:
+        raise ValueError("repo_type must be 'model' or 'dataset'")
     if not _COMMIT_SHA_RE.fullmatch(revision or ""):
         raise ValueError("Hub revision lookup did not return a 40-character commit SHA")
     return revision
@@ -50,12 +56,17 @@ def resolve_model_snapshot(
     allow_download: bool = False,
     revision: Optional[str] = None,
     cache_dir: Optional[str] = None,
+    repo_type: str = "model",
 ) -> Dict[str, Any]:
     """Return structured resolution evidence; an expected cache miss is not an error."""
     if source not in {"hub", "local"}:
         raise ValueError("source must be 'local' or 'hub'")
+    if repo_type not in {"model", "dataset"}:
+        raise ValueError("repo_type must be 'model' or 'dataset'")
 
     if source == "local":
+        if repo_type != "model":
+            raise ValueError("repo_type only applies to source='hub'")
         if allow_download or revision is not None or cache_dir is not None:
             raise ValueError("Hub download, revision, and cache options cannot be used with source='local'")
         candidate = Path(identifier).expanduser()
@@ -90,17 +101,22 @@ def resolve_model_snapshot(
         raise ValueError("source_root can only be used with source='local'")
     if allow_download:
         if revision is None:
-            revision = _resolve_hub_revision(identifier)
+            revision = _resolve_hub_revision(identifier, repo_type)
         elif not _COMMIT_SHA_RE.fullmatch(revision):
             raise ValueError("authorized Hub downloads require a 40-character commit SHA revision")
 
     snapshot_download, local_entry_not_found = _load_huggingface_hub()
     try:
+        download_args: Dict[str, Any] = {
+            "repo_id": identifier,
+            "revision": revision,
+            "cache_dir": cache_dir,
+            "local_files_only": not allow_download,
+        }
+        if repo_type != "model":
+            download_args["repo_type"] = repo_type
         resolved_path = snapshot_download(
-            repo_id=identifier,
-            revision=revision,
-            cache_dir=cache_dir,
-            local_files_only=not allow_download,
+            **download_args,
         )
     except local_entry_not_found:
         if allow_download:
@@ -109,6 +125,7 @@ def resolve_model_snapshot(
             "download_authorized": False,
             "identifier": identifier,
             "reason": "not_cached",
+            "repo_type": repo_type,
             "resolved_path": None,
             "revision": revision,
             "source": "hub_cache",
@@ -119,6 +136,7 @@ def resolve_model_snapshot(
         "download_authorized": allow_download,
         "identifier": identifier,
         "resolved_path": str(Path(resolved_path).resolve()),
+        "repo_type": repo_type,
         "revision": revision,
         "source": "hub_download_or_cache" if allow_download else "hub_cache",
         "status": "available",
@@ -127,7 +145,7 @@ def resolve_model_snapshot(
 
 def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    parser.add_argument("identifier", help="Local model path or Hugging Face Hub repository ID")
+    parser.add_argument("identifier", help="Local artifact path or Hugging Face Hub repository ID")
     parser.add_argument("--source", choices=("local", "hub"), required=True, help="Identifier source type")
     parser.add_argument(
         "--source-root",
@@ -136,6 +154,12 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--allow-download", action="store_true", help="Permit one normal cache-aware Hub download")
     parser.add_argument("--revision", help="Optional full Hub commit SHA; authorized downloads resolve it when omitted")
     parser.add_argument("--cache-dir", help="Optional Hugging Face cache directory")
+    parser.add_argument(
+        "--repo-type",
+        choices=("model", "dataset"),
+        default="model",
+        help="Hugging Face Hub repository type; applies only to --source hub",
+    )
     return parser.parse_args(argv)
 
 
@@ -148,6 +172,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         allow_download=args.allow_download,
         revision=args.revision,
         cache_dir=args.cache_dir,
+        repo_type=args.repo_type,
     )
     print(json.dumps(result, sort_keys=True))
     return 0

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -37,6 +37,7 @@ def resolve_model_snapshot(
     identifier: str,
     *,
     source: str,
+    source_root: Optional[str] = None,
     allow_download: bool = False,
     revision: Optional[str] = None,
     cache_dir: Optional[str] = None,
@@ -49,6 +50,13 @@ def resolve_model_snapshot(
         if allow_download or revision is not None or cache_dir is not None:
             raise ValueError("Hub download, revision, and cache options cannot be used with source='local'")
         candidate = Path(identifier).expanduser()
+        if not candidate.is_absolute():
+            if source_root is None:
+                raise ValueError("relative local identifiers require an absolute source_root")
+            root = Path(source_root).expanduser()
+            if not root.is_absolute():
+                raise ValueError("source_root must be an absolute path")
+            candidate = root / candidate
         if candidate.exists():
             return {
                 "download_authorized": False,
@@ -66,6 +74,8 @@ def resolve_model_snapshot(
             "status": "missing",
         }
 
+    if source_root is not None:
+        raise ValueError("source_root can only be used with source='local'")
     if allow_download and not _COMMIT_SHA_RE.fullmatch(revision or ""):
         raise ValueError("authorized Hub downloads require a 40-character commit SHA revision")
 
@@ -104,6 +114,10 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     parser.add_argument("identifier", help="Local model path or Hugging Face Hub repository ID")
     parser.add_argument("--source", choices=("local", "hub"), required=True, help="Identifier source type")
+    parser.add_argument(
+        "--source-root",
+        help="Absolute original source-project root used to resolve a relative local identifier",
+    )
     parser.add_argument("--allow-download", action="store_true", help="Permit one normal cache-aware Hub download")
     parser.add_argument("--revision", help="Hub revision; a full commit SHA is required for downloads")
     parser.add_argument("--cache-dir", help="Optional Hugging Face cache directory")
@@ -115,6 +129,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     result = resolve_model_snapshot(
         args.identifier,
         source=args.source,
+        source_root=args.source_root,
         allow_download=args.allow_download,
         revision=args.revision,
         cache_dir=args.cache_dir,

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -28,7 +28,7 @@ _COMMIT_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 
 def _load_huggingface_hub():
     from huggingface_hub import snapshot_download
-    from huggingface_hub.errors import LocalEntryNotFoundError
+    from huggingface_hub.utils import LocalEntryNotFoundError
 
     return snapshot_download, LocalEntryNotFoundError
 
@@ -50,7 +50,10 @@ def resolve_model_snapshot(
         if allow_download or revision is not None or cache_dir is not None:
             raise ValueError("Hub download, revision, and cache options cannot be used with source='local'")
         candidate = Path(identifier).expanduser()
-        if not candidate.is_absolute():
+        if candidate.is_absolute():
+            if source_root is not None:
+                raise ValueError("source_root can only be used with a relative local identifier")
+        else:
             if source_root is None:
                 raise ValueError("relative local identifiers require an absolute source_root")
             root = Path(source_root).expanduser()

--- a/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
+++ b/skills/nvflare-convert-huggingface/scripts/resolve_model_snapshot.py
@@ -109,13 +109,13 @@ def resolve_model_snapshot(
     try:
         download_args: Dict[str, Any] = {
             "repo_id": identifier,
-            "revision": revision,
             "cache_dir": cache_dir,
             "local_files_only": not allow_download,
         }
         if repo_type != "model":
             download_args["repo_type"] = repo_type
         resolved_path = snapshot_download(
+            revision=revision,
             **download_args,
         )
     except local_entry_not_found:

--- a/skills/nvflare-convert-huggingface/tests/helper_scripts.md
+++ b/skills/nvflare-convert-huggingface/tests/helper_scripts.md
@@ -3,5 +3,6 @@
 The Hugging Face model resolver is covered by
 `tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py`.
 
-The focused tests cover existing local paths, exit-zero cache misses, and one
-normal cache-aware resolution only when download is authorized.
+The focused tests cover explicit local/Hub source selection, bare relative local
+paths, exit-zero cache misses, and one commit-pinned cache-aware resolution only
+when download is authorized.

--- a/skills/nvflare-convert-huggingface/tests/helper_scripts.md
+++ b/skills/nvflare-convert-huggingface/tests/helper_scripts.md
@@ -3,6 +3,6 @@
 The Hugging Face model resolver is covered by
 `tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py`.
 
-The focused tests cover explicit local/Hub source selection, bare relative local
-paths, exit-zero cache misses, and one commit-pinned cache-aware resolution only
-when download is authorized.
+The focused tests cover explicit local/Hub source selection, model and dataset
+repository types, bare relative local paths, exit-zero cache misses, and one
+commit-pinned cache-aware resolution per authorized artifact type.

--- a/skills/nvflare-convert-huggingface/tests/helper_scripts.md
+++ b/skills/nvflare-convert-huggingface/tests/helper_scripts.md
@@ -1,0 +1,7 @@
+# Helper Script Coverage
+
+The Hugging Face model resolver is covered by
+`tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py`.
+
+The focused tests cover existing local paths, exit-zero cache misses, and one
+normal cache-aware resolution only when download is authorized.

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -102,8 +102,8 @@ distribution; handle conversion later as a separate request.
    algorithm uses explicit validation for server metrics and, for training,
    best-model selection. Verify the key in server evidence or fail closed.
 7. Add or update `job.py` under the shared constructor-serialization rule. Use
-   explicit `class_path`/`args` whenever reconstruction needs constructor values;
-   a permitted zero-argument instance is the complete `LightningModule`. Add
+   the recipe's `class_path` or `path` key plus complete `args` when values are
+   needed; a permitted zero-argument instance is the complete module. Add
    requested `aggregator=` wiring and the metric, tensor-transport, server
    offload, and execution settings derived from the shared PyTorch-family
    construction profile. If sites need distinct `train_args`, make every site
@@ -152,9 +152,9 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   `LightningModule.__init__` signature and the selected recipe's `model`
   parameter from `nvflare recipe show <recipe-name> --format json`, not by
-  reading NVFLARE library source. Emit explicit `class_path`/`args` for every
-  required or overridden constructor value; a direct `LightningModule` is
-  allowed only when unchanged zero-argument defaults reconstruct it. Values
+  reading NVFLARE library source. Emit the recipe-documented `class_path` or
+  `path` key plus complete `args` for every required or overridden value. Direct
+  `LightningModule` use is allowed only when unchanged zero-argument defaults reconstruct it. Values
   must be clear from source, configuration, or supplied metadata. Otherwise ask
   one semantic question when an answer channel exists or fail closed.
 - Must use the PyTorch recipe family; must not invent a Lightning-only recipe.

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -80,8 +80,7 @@ distribution; handle conversion later as a separate request.
 5. Reuse the PyTorch recipe family; Lightning is not a separate recipe family.
    For the standard case — the user explicitly requests FedAvg and inspection
    identifies Lightning — run `nvflare recipe show fedavg-pt --format json`
-   directly and construct it. Use the returned module, class, and parameters;
-   for `fedavg-pt`, import `FedAvgRecipe` from
+   directly and construct it. For `fedavg-pt`, import `FedAvgRecipe` only from
    `nvflare.app_opt.pt.recipes.fedavg`, never from `nvflare.recipe`. Load
    `../nvflare-shared/references/pytorch-family-recipe-selection.md` (discovery,
    algorithm guide, catalog-based selection, HE-not-supported rule; FedAvg,
@@ -89,9 +88,10 @@ distribution; handle conversion later as a separate request.
    non-FedAvg algorithms, reserving `nvflare recipe list` for those cases. Use
    FedEval for evaluation-only. After every `recipe show`, load
    `../nvflare-shared/references/pytorch-family-recipe-construction.md` and
-   derive the recipe's construction capabilities. Do not inspect recipe source,
-   signatures, or docstrings to rediscover parameters already returned by
-   `recipe show`.
+   derive its construction capabilities. Do not inspect recipe source,
+   signatures, or docstrings. After success, do not import `Recipe` from
+   `nvflare.recipe`, inspect or call `nvflare.recipe.run`, or probe `export`,
+   `run`, or lifecycle APIs. Call `recipe.execute(SimEnv(...))`.
 6. Convert the training entry point to the Lightning Client API: build the
    `Trainer`, call `flare.patch(trainer)`, and let the patched trainer own
    model exchange. Keep evaluation inside Lightning per

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -101,10 +101,10 @@ distribution; handle conversion later as a separate request.
    "cyclic"`: Cyclic persists only its final sequential model; every other
    algorithm uses explicit validation for server metrics and, for training,
    best-model selection. Verify the key in server evidence or fail closed.
-7. Add or update `job.py` under the shared "Recipe Model Config" policy. A
-   direct instance, when allowed by that policy, must be the complete
-   `LightningModule`, not its inner network. Add the requested `aggregator=`
-   wiring and the metric, tensor-transport, server
+7. Add or update `job.py` under the shared constructor-serialization rule. Use
+   explicit `class_path`/`args` whenever reconstruction needs constructor values;
+   a permitted zero-argument instance is the complete `LightningModule`. Add
+   requested `aggregator=` wiring and the metric, tensor-transport, server
    offload, and execution settings derived from the shared PyTorch-family
    construction profile. If sites need distinct `train_args`, make every site
    override the complete argument string; never split shared arguments and a
@@ -152,11 +152,11 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   `LightningModule.__init__` signature and the selected recipe's `model`
   parameter from `nvflare recipe show <recipe-name> --format json`, not by
-  reading NVFLARE library source. The shared "Recipe Model Config" policy
-  governs whether to emit `class_path`/`args` config or a direct
-  `LightningModule`; required values must be statically clear from literal
-  source, configuration, or supplied metadata. Otherwise ask one semantic
-  question when an answer channel exists or fail closed on that missing value.
+  reading NVFLARE library source. Emit explicit `class_path`/`args` for every
+  required or overridden constructor value; a direct `LightningModule` is
+  allowed only when unchanged zero-argument defaults reconstruct it. Values
+  must be clear from source, configuration, or supplied metadata. Otherwise ask
+  one semantic question when an answer channel exists or fail closed.
 - Must use the PyTorch recipe family; must not invent a Lightning-only recipe.
 - Must apply
   `../nvflare-shared/references/pytorch-family-recipe-construction.md` after

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -88,10 +88,10 @@ distribution; handle conversion later as a separate request.
    non-FedAvg algorithms, reserving `nvflare recipe list` for those cases. Use
    FedEval for evaluation-only. After every `recipe show`, load
    `../nvflare-shared/references/pytorch-family-recipe-construction.md` and
-   derive its construction capabilities. Do not inspect recipe source,
-   signatures, or docstrings. After success, do not import `Recipe` from
-   `nvflare.recipe`, inspect or call `nvflare.recipe.run`, or probe `export`,
-   `run`, or lifecycle APIs. Call `recipe.execute(SimEnv(...))`.
+   derive its construction capabilities. After `recipe show` succeeds, use that documented
+   path: do not run exploratory NVFLARE imports or use `inspect`, `hasattr`, constant
+   discovery, SDK source/docstring reads, or lifecycle probes. If a required detail is absent,
+   report a skill gap or fail closed instead of guessing. Call `recipe.execute(SimEnv(...))`.
 6. Convert the training entry point to the Lightning Client API: build the
    `Trainer`, call `flare.patch(trainer)`, and let the patched trainer own
    model exchange. Keep evaluation inside Lightning per

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-convert-lightning
-description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; do not use for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
+description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use when the user names PyTorch Lightning or preliminary source inspection identifies one Lightning owner, and not for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
 version: "0.1.0"
 metadata:
@@ -110,7 +110,7 @@ distribution; handle conversion later as a separate request.
    override the complete argument string; never split shared arguments and a
    site-specific data path across recipe-level and per-site values expecting a
    merge.
-8. Only after generated files exist, load
+8. Immediately after generated files exist and before any preflight, smoke test, cleanup, validation, or execution command, load
    `../nvflare-shared/references/validation-evidence.md`, then
    `references/lightning-validation.md`. Before executing a full run, select and
    record exactly one final validation target:

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -119,6 +119,10 @@
             "description": "for multiple simulated/federated sites, trains each site on a deterministic local training partition by default and does not make every site train on the full source training set unless the user explicitly requested shared training data"
           },
           {
+            "id": "single-simulator-topology-owner",
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
+          },
+          {
             "id": "standard-generated-layout",
             "description": "uses standard generated file names such as client.py, job.py, and model.py"
           },
@@ -263,6 +267,10 @@
           {
             "id": "no-second-manual-flare-send",
             "description": "does not add a second manual flare.send with FLModel for normal Lightning training because the patched trainer owns model exchange"
+          },
+          {
+            "id": "no-mixed-named-and-generated-client-topology",
+            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
           }
         ],
         "optional_behavior": [

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -50,6 +50,7 @@
         "If generated Lightning client code calls flare.get_site_name(), flare.get_config(), or flare.receive() before patched-trainer execution, it calls flare.init() before the first such Client API context access.",
         "Because Lightning and FedAvg are explicit, the agent runs nvflare recipe show fedavg-pt --format json directly and does not run recipe list before constructing it.",
         "The generated job.py imports the selected recipe class from the module returned by recipe show, using nvflare.app_opt.pt.recipes.fedavg.FedAvgRecipe for fedavg-pt and not nvflare.recipe.FedAvgRecipe.",
+        "After recipe show succeeds for this local simulation, the agent does not import Recipe from nvflare.recipe, inspect or call nvflare.recipe.run, or probe export, run, or lifecycle APIs; it calls recipe.execute(SimEnv(...)).",
         "The agent selects the PyTorch FedAvg recipe for standard horizontal training instead of inventing a Lightning-only recipe.",
         "The agent generates explicit recipe model config with class_path plus args instead of passing a live LightningModule instance, asking or failing closed when constructor args are not statically clear.",
         "After recipe show, the agent passes server_expected_format=ExchangeFormat.PYTORCH and enable_tensor_disk_offload=True only when each parameter is exposed, registers nvflare.app_opt.pt.decomposers.TensorDecomposer when tensor-native exchange is selected, and chooses external execution only from process-spawning or distributed-launch evidence; Lightning dp stays in-process.",
@@ -199,6 +200,10 @@
           {
             "id": "no-source-discovered-strategy-override",
             "description": "follows the source-of-truth boundary: public checks can stop the skill path but cannot license a source-discovered replacement, and does not replace the public contract with ad hoc SDK-internal APIs based on local source or docstring inspection"
+          },
+          {
+            "id": "no-recipe-lifecycle-probes",
+            "description": "after successful recipe show for a local simulation, does not import Recipe from nvflare.recipe, inspect or call nvflare.recipe.run, or probe export, run, or lifecycle APIs; uses recipe.execute(SimEnv(...))"
           },
           {
             "id": "no-orient-for-explicit-conversion",

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -120,7 +120,7 @@
           },
           {
             "id": "single-simulator-topology-owner",
-            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or makes clients=list(per_site_config) the topology owner for genuinely different named-site arguments; any accompanying num_clients is matching consistency evidence only"
           },
           {
             "id": "standard-generated-layout",
@@ -278,7 +278,7 @@
           },
           {
             "id": "no-mixed-named-and-generated-client-topology",
-            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
+            "description": "does not generate unnamed SimEnv clients after set_per_site_config creates named targets, pass an inconsistent num_clients with clients, or recover from a mismatch with num_clients=None"
           }
         ],
         "optional_behavior": [

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -104,7 +104,7 @@
           },
           {
             "id": "explicit-model-config-with-args",
-            "description": "generates explicit recipe model config with class_path plus args instead of a live LightningModule instance, asking or failing closed when constructor args are not statically clear"
+            "description": "generates explicit recipe model config with class_path plus complete args instead of using a live LightningModule to carry constructor values, verifies the exported server config retains them, and asks or fails closed when they are not statically clear"
           },
           {
             "id": "tensor-offload-decomposer-profile",
@@ -531,7 +531,7 @@
           },
           {
             "id": "explicit-model-config-with-args",
-            "description": "uses explicit recipe model config with class_path plus args for required constructor arguments"
+            "description": "uses explicit recipe model config with class_path plus complete args for required constructor values and verifies the exported server config retains them"
           },
           {
             "id": "use-lightning-patched-trainer",

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -241,6 +241,14 @@
             "description": "does not run both python job.py and an exported-folder simulator after the first selected full validation path succeeds"
           },
           {
+            "id": "no-unrequested-explicit-export",
+            "description": "does not invoke an explicit export or exported-folder simulator for this local-simulation prompt"
+          },
+          {
+            "id": "no-generated-export-system-arguments",
+            "description": "does not declare, parse, or branch on NVFLARE's reserved --export or --export-dir system arguments or a private alias in generated job code"
+          },
+          {
             "id": "no-compound-cleanup-and-execution",
             "description": "does not combine recursive cleanup, export, and simulation in one command; each is a separate tool call"
           },

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -203,7 +203,7 @@
           },
           {
             "id": "no-recipe-lifecycle-probes",
-            "description": "after successful recipe show for a local simulation, does not import Recipe from nvflare.recipe, inspect or call nvflare.recipe.run, or probe export, run, or lifecycle APIs; uses recipe.execute(SimEnv(...))"
+            "description": "after successful recipe show and loading the construction reference, uses that documented path and does not run exploratory NVFLARE imports, inspect, hasattr, constant discovery, source/docstring reads, or lifecycle probes; reports a skill gap or fails closed instead of guessing when required construction details are absent, and uses recipe.execute(SimEnv(...))"
           },
           {
             "id": "no-orient-for-explicit-conversion",

--- a/skills/nvflare-convert-lightning/references/lightning-conversion.md
+++ b/skills/nvflare-convert-lightning/references/lightning-conversion.md
@@ -215,16 +215,32 @@ those values into recipe `model` args just because architecture args must be
 shared.
 
 If such a local value is a persistent model parameter or buffer, recomputing it
-before the round loop does not keep it local: the patched trainer's received
-model state can overwrite it. Exclude the named state key with the selected
-recipe's supported `exclude_vars` setting and pair that exclusion with
-`flare.patch(trainer, load_state_dict_strict=False)`, because the received state
-intentionally omits the key. Use non-strict loading only for those explicitly
-excluded local keys, verify that no other state keys are missing or mismatched,
-and confirm the excluded value remains the site-computed value. Do not claim a
-persistent value is site-local merely because it was initially computed from a
-site partition. If `recipe show` does not expose a supported exclusion setting,
-ask or fail closed instead of silently exchanging the value.
+before the round loop does not keep it local: the patched trainer sends its full
+`state_dict()` and the received model can overwrite the value. The FedAvg recipe
+`exclude_vars` argument is only an aggregation rule; it is not a bidirectional
+payload filter and is not a locality or privacy control.
+
+For a FedAvg `train` task, keep an explicitly named state key local only by
+filtering both network directions with separate filters:
+
+```python
+from nvflare.app_common.filters import ExcludeVars
+
+recipe.add_server_output_filter(ExcludeVars([local_key]), tasks=["train"])
+recipe.add_client_output_filter(ExcludeVars([local_key]), tasks=["train"])
+```
+
+Pair those filters with
+`flare.patch(trainer, load_state_dict_strict=False)`, because each received
+global model intentionally omits the local key. Non-strict loading does not
+suppress outbound state by itself. Apply the same two-direction rule to every
+model-bearing task selected by a different recipe. Verify exported server and
+client filter configuration, then verify that the exact key is absent from both
+directions—including the initial and later server-to-client payloads—and the
+site-computed value is not overwritten in the first or later rounds. If the
+selected recipe does not expose supported filters for every
+model-bearing direction, ask or fail closed. Do not substitute aggregation-only
+`exclude_vars` or silently exchange the value.
 
 Report the split policy, seed, and where local training-policy values are
 computed.

--- a/skills/nvflare-convert-lightning/references/lightning-conversion.md
+++ b/skills/nvflare-convert-lightning/references/lightning-conversion.md
@@ -228,8 +228,8 @@ remain shared only when that matches the source's validation/test semantics.
 
 Follow the shared model-config and construction-consistency rule in
 `../../nvflare-shared/references/conversion-workflow.md` ("Recipe Model Config"):
-same class and constructor args on server and client, an allowed recipe model
-form, and derive-or-ask/fail-closed for required values.
+same class and constructor args on server and client, explicit config whenever
+reconstruction needs a constructor value, and derive-or-ask/fail-closed for it.
 
 Lightning-specific delta: the exchanged unit is the whole `LightningModule`
 managed by the patched trainer, so construct the identical `LightningModule` on

--- a/skills/nvflare-convert-lightning/references/lightning-conversion.md
+++ b/skills/nvflare-convert-lightning/references/lightning-conversion.md
@@ -214,6 +214,18 @@ unless the user explicitly requests one global training policy. Do not move
 those values into recipe `model` args just because architecture args must be
 shared.
 
+If such a local value is a persistent model parameter or buffer, recomputing it
+before the round loop does not keep it local: the patched trainer's received
+model state can overwrite it. Exclude the named state key with the selected
+recipe's supported `exclude_vars` setting and pair that exclusion with
+`flare.patch(trainer, load_state_dict_strict=False)`, because the received state
+intentionally omits the key. Use non-strict loading only for those explicitly
+excluded local keys, verify that no other state keys are missing or mismatched,
+and confirm the excluded value remains the site-computed value. Do not claim a
+persistent value is site-local merely because it was initially computed from a
+site partition. If `recipe show` does not expose a supported exclusion setting,
+ask or fail closed instead of silently exchanging the value.
+
 Report the split policy, seed, and where local training-policy values are
 computed.
 

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -83,9 +83,10 @@ distribution; handle conversion later as a separate request.
    evaluation code into the packaged evaluation template; if evaluation is
    required but missing, ask or fail closed. Apply the step-1 data-location
    rules to the generated client's data argument.
-6. Add or update `job.py` under the shared "Recipe Model Config" policy,
-   requested `aggregator=` wiring, and the metric, tensor-transport, server
-   offload, and execution settings derived from the shared PyTorch-family
+6. Add or update `job.py` under the shared constructor-serialization rule:
+   use explicit `class_path`/`args` whenever reconstruction needs constructor
+   values. Add requested `aggregator=` wiring and the metric, tensor-transport,
+   server offload, and execution settings derived from the shared PyTorch-family
    construction profile.
 7. Validate in a ladder per `../nvflare-shared/references/validation-evidence.md`:
    compile checks, recipe construction, one final full-run path chosen by the
@@ -104,11 +105,11 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   model module's `__init__` and the selected recipe's `model` parameter from
   `nvflare recipe show <recipe-name> --format json`, not by reading NVFLARE
-  library source. The shared "Recipe Model Config" policy governs whether to
-  emit `class_path`/`args` config or a direct `torch.nn.Module`; required
-  values must be statically clear from literal source, configuration, or
-  supplied metadata. Otherwise ask one semantic question when an answer channel
-  exists or fail closed on that missing value.
+  library source. Emit explicit `class_path`/`args` for every required or
+  overridden constructor value; a direct `torch.nn.Module` is allowed only when
+  unchanged zero-argument defaults reconstruct it. Values must be statically
+  clear from literal source, configuration, or supplied metadata. Otherwise ask
+  one semantic question when an answer channel exists or fail closed.
 - Must follow `../nvflare-shared/references/pytorch-model-exchange.md` and
   `references/pytorch-client-api-conversion.md` for the canonical plain-PyTorch
   payload and round-loop pattern.

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -90,7 +90,9 @@ distribution; handle conversion later as a separate request.
    from the shared PyTorch-family construction profile.
 7. Validate in a ladder per `../nvflare-shared/references/validation-evidence.md`:
    compile checks, recipe construction, one final full-run path chosen by the
-   artifact being validated, and export inspection; use
+   artifact being validated, with export and package inspection only for the
+   selected exported-artifact path. For a local target, inspect the materialized
+   configs and packaging evidence after that run. Use
    `references/job-validation.md` for PyTorch-specific failures. Stop at the
    first failed rung and report the product error. Use the environment and
    permission mechanisms supplied by the agent host; do not inspect or enforce

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -84,10 +84,10 @@ distribution; handle conversion later as a separate request.
    required but missing, ask or fail closed. Apply the step-1 data-location
    rules to the generated client's data argument.
 6. Add or update `job.py` under the shared constructor-serialization rule:
-   use explicit `class_path`/`args` whenever reconstruction needs constructor
-   values. Add requested `aggregator=` wiring and the metric, tensor-transport,
-   server offload, and execution settings derived from the shared PyTorch-family
-   construction profile.
+   use explicit `class_path` (or documented `path` alias) plus complete `args`
+   whenever reconstruction needs values. Add requested `aggregator=` wiring,
+   metric, tensor-transport, server offload, and execution settings derived
+   from the shared PyTorch-family construction profile.
 7. Validate in a ladder per `../nvflare-shared/references/validation-evidence.md`:
    compile checks, recipe construction, one final full-run path chosen by the
    artifact being validated, and export inspection; use
@@ -105,8 +105,9 @@ distribution; handle conversion later as a separate request.
 - Must audit model constructor arguments before writing `job.py` by reading the
   model module's `__init__` and the selected recipe's `model` parameter from
   `nvflare recipe show <recipe-name> --format json`, not by reading NVFLARE
-  library source. Emit explicit `class_path`/`args` for every required or
-  overridden constructor value; a direct `torch.nn.Module` is allowed only when
+  library source. Emit the selected recipe's documented `class_path` or `path`
+  key plus complete `args` for every required or overridden constructor value;
+  a direct `torch.nn.Module` is allowed only when
   unchanged zero-argument defaults reconstruct it. Values must be statically
   clear from literal source, configuration, or supplied metadata. Otherwise ask
   one semantic question when an answer channel exists or fail closed.

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-convert-pytorch
-description: "Convert existing PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; do not use for other frameworks, deployment, POC/production lifecycle, or experiment workflows."
+description: "Convert existing plain or manual PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; use when the user names plain PyTorch or preliminary source inspection identifies one plain-PyTorch owner, and not for Lightning, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
 version: "0.1.0"
 metadata:

--- a/skills/nvflare-convert-pytorch/evals/evals.json
+++ b/skills/nvflare-convert-pytorch/evals/evals.json
@@ -104,6 +104,10 @@
             "description": "for multiple simulated/federated sites, trains each site on a deterministic local training partition by default and does not make every site train on the full source training set unless the user explicitly requested shared training data"
           },
           {
+            "id": "single-simulator-topology-owner",
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
+          },
+          {
             "id": "safe-pandas-partitioning",
             "description": "when generating a Pandas partition, shuffles a writable copy of positional row indices and selects rows with iloc rather than shuffling a potentially read-only Index array or using loc with positions"
           },
@@ -252,6 +256,10 @@
           {
             "id": "no-unneeded-per-site-recipe-config",
             "description": "does not add per-site recipe configuration unless sites actually differ in scripts, arguments, data splits, or launch behavior"
+          },
+          {
+            "id": "no-mixed-named-and-generated-client-topology",
+            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
           },
           {
             "id": "no-numpy-outbound-model-weights",

--- a/skills/nvflare-convert-pytorch/evals/evals.json
+++ b/skills/nvflare-convert-pytorch/evals/evals.json
@@ -113,7 +113,7 @@
           },
           {
             "id": "explicit-model-config-with-args",
-            "description": "generates explicit recipe model config with class_path plus args instead of a live model instance, asking or failing closed when constructor args are not statically clear"
+            "description": "generates explicit recipe model config with class_path plus complete args instead of using a live model instance to carry constructor values, verifies the exported server config retains them, and asks or fails closed when they are not statically clear"
           },
           {
             "id": "use-client-api-for-training-exchange",

--- a/skills/nvflare-convert-pytorch/evals/evals.json
+++ b/skills/nvflare-convert-pytorch/evals/evals.json
@@ -156,6 +156,10 @@
             "description": "reads and audits applicable requirements, presents a redacted combined install plan, obtains explicit user confirmation before installing missing dependencies into the host-provided environment, and only then runs import-level preflight, recipe-construction probes, export, simulation, or python job.py; an explicitly requested unattended run still logs the plan and the host permission system remains an additional gate"
           },
           {
+            "id": "single-final-validation-path",
+            "description": "selects python job.py as the one final target for this local-simulation prompt and obtains config evidence from its completed simulation workspace without an explicit export"
+          },
+          {
             "id": "dependency-install-failure-is-terminal",
             "description": "builds one combined canonical dependency-install command containing every applicable requirements/constraints file plus NVFLARE when missing and not otherwise supplied; on a nonzero exit stops dependency installation and validation for that conversion run, preserves generated source as an unvalidated draft, and reports a redacted failed command and product error"
           },
@@ -240,6 +244,14 @@
           {
             "id": "no-background-final-validation",
             "description": "does not choose background execution for the final validation run and does not describe a timed-out or still-running simulation as done or successful"
+          },
+          {
+            "id": "no-unrequested-explicit-export",
+            "description": "does not invoke an explicit export or exported-folder simulator for this local-simulation prompt"
+          },
+          {
+            "id": "no-generated-export-system-arguments",
+            "description": "does not declare, parse, or branch on NVFLARE's reserved --export or --export-dir system arguments or a private alias in generated job code"
           },
           {
             "id": "no-topology-collapse-or-catalog-guess",

--- a/skills/nvflare-convert-pytorch/evals/evals.json
+++ b/skills/nvflare-convert-pytorch/evals/evals.json
@@ -105,7 +105,7 @@
           },
           {
             "id": "single-simulator-topology-owner",
-            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or SimEnv(clients=list(per_site_config)) for genuinely different named-site arguments, but never both topology forms"
+            "description": "uses SimEnv(num_clients=N) with shared arguments and site-name-derived partitions, or makes clients=list(per_site_config) the topology owner for genuinely different named-site arguments; any accompanying num_clients is matching consistency evidence only"
           },
           {
             "id": "safe-pandas-partitioning",
@@ -271,7 +271,7 @@
           },
           {
             "id": "no-mixed-named-and-generated-client-topology",
-            "description": "does not combine set_per_site_config named targets with SimEnv(num_clients=...), and does not recover from that conflict with num_clients=None"
+            "description": "does not generate unnamed SimEnv clients after set_per_site_config creates named targets, pass an inconsistent num_clients with clients, or recover from a mismatch with num_clients=None"
           },
           {
             "id": "no-numpy-outbound-model-weights",

--- a/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
+++ b/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
@@ -15,7 +15,10 @@ Use this path for plain PyTorch conversion:
    `FLModel(params=...)` as the model exchange path.
 4. Generate `job.py` that builds the selected recipe and calls
    `recipe.execute(SimEnv(...))`.
-5. Validate with `python job.py`, inspect terminal evidence, then export.
+5. Select exactly one final target: run `python job.py` and inspect its
+   materialized simulation workspace for local validation, or, only when the
+   user requests an exported/deployable artifact, export and run that folder
+   with the simulator CLI. Do not run both targets after one succeeds.
 
 HE is not supported at steps 4–5: follow the HE-not-supported rule in
 `../../nvflare-shared/references/pytorch-family-recipe-selection.md`.

--- a/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
+++ b/skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md
@@ -88,8 +88,8 @@ For generated Pandas partition code, follow
 
 Follow the shared model-config and construction-consistency rule in
 `../../nvflare-shared/references/conversion-workflow.md` ("Recipe Model Config"):
-same class and constructor args on server and client, an allowed recipe model
-form, and derive-or-ask/fail-closed for required values.
+same class and constructor args on server and client, explicit config whenever
+reconstruction needs a constructor value, and derive-or-ask/fail-closed for it.
 
 PyTorch-specific delta: the client loads `input_model.params` into the model
 with `load_state_dict`, so the server-initial model and the client model must

--- a/skills/nvflare-convert-pytorch/references/recipe-selection.md
+++ b/skills/nvflare-convert-pytorch/references/recipe-selection.md
@@ -47,8 +47,8 @@ env = SimEnv(num_clients=num_clients, workspace_root=workspace_root)
 run = recipe.execute(env)
 ```
 
-Prefer a recipe model dict with the same constructor arguments used by the
-client-side model:
+Use a recipe model dict with the same constructor arguments used by the
+client-side model whenever reconstruction depends on any constructor value:
 
 ```python
 model={"class_path": "model.ModelClass", "args": model_args}

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-orient
-description: "Route open-ended or ambiguous NVFLARE requests by inspecting the local project and recommending one specific workflow skill without editing files; do not use merely because an explicit conversion omits its framework when preliminary inspection finds one owner, but do use when ownership remains unresolved or conflicts."
+description: "Route open-ended NVFLARE advice and only conversion requests whose preliminary source inspection reports unresolved or conflicting ownership; never load this skill merely to inspect a concrete conversion request before selecting its detected framework converter."
 license: Apache-2.0
 version: "0.1.0"
 metadata:
@@ -19,21 +19,22 @@ metadata:
 ## Use When
 
 Use when the user asks where to start with NVFLARE, how a local project maps to
-FLARE workflows, or which FLARE skill should handle an ambiguous request. Also
-use when inspection explicitly reports unresolved Hugging Face Trainer
-ownership or active Lightning and Hugging Face Trainer owners that require a
-user choice.
+FLARE workflows, or which FLARE skill should handle an ambiguous request. For a
+concrete conversion request, use only after preliminary source inspection
+explicitly reports unresolved ownership or conflicting active training owners
+that require a user choice.
 
 ## Do Not Use When
 
 Do not use when the user already names a specific workflow such as PyTorch
 conversion, federated statistics, job submission, production deployment,
 Kubernetes setup, log diagnosis, or optimization of an existing FLARE job.
-Route to the narrower skill instead. Do not use orientation merely because an
-explicit conversion omits its framework when preliminary inspection identifies
-one training owner; route directly to that owner's converter. Continue to use
-orientation for an inspector-reported ownership conflict or unresolved Trainer
-factory, which requires the read-only choice described above.
+Route to the narrower skill instead. Do not load orientation to perform the
+preliminary inspection for a concrete conversion request: run `nvflare agent
+inspect source <path> --format json` first, then route directly to the one
+detected converter. Continue to use orientation for an inspector-reported
+ownership conflict or unresolved Trainer factory, which requires the read-only
+choice described above.
 
 ## Workflow
 

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-orient
-description: "Route open-ended or ambiguous NVFLARE requests by inspecting the local project and recommending one specific workflow skill without editing files; explicit conversions normally route directly to a converter, except when inspection reports unresolved Trainer ownership or active Lightning and Hugging Face Trainer entrypoints."
+description: "Route open-ended or ambiguous NVFLARE requests by inspecting the local project and recommending one specific workflow skill without editing files; do not use merely because an explicit conversion omits its framework when preliminary inspection finds one owner, but do use when ownership remains unresolved or conflicts."
 license: Apache-2.0
 version: "0.1.0"
 metadata:
@@ -29,11 +29,11 @@ user choice.
 Do not use when the user already names a specific workflow such as PyTorch
 conversion, federated statistics, job submission, production deployment,
 Kubernetes setup, log diagnosis, or optimization of an existing FLARE job.
-Route to the narrower skill instead. An explicit conversion request does not
-need orientation merely to detect the framework when one training owner is
-clear: the converter skill performs static inspection and selects the framework
-itself. The exception is an inspector-reported ownership conflict or unresolved
-Trainer factory, which requires the read-only choice described above.
+Route to the narrower skill instead. Do not use orientation merely because an
+explicit conversion omits its framework when preliminary inspection identifies
+one training owner; route directly to that owner's converter. Continue to use
+orientation for an inspector-reported ownership conflict or unresolved Trainer
+factory, which requires the read-only choice described above.
 
 ## Workflow
 

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -65,7 +65,7 @@ the Recipe API before parsing its own options and must not declare, parse, or
 branch on those arguments or invent aliases such as `--export_only`. A local
 parser uses `argparse.ArgumentParser(allow_abbrev=False)` with strict
 `parse_args()`; it does not use `parse_known_args()` to accommodate system
-arguments.
+arguments. Unknown and abbreviated local options must fail.
 
 Use exactly one owner for the simulated client topology. With a unified recipe,
 let `SimEnv(num_clients=N)` create `site-1` through `site-N`; pass shared data

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -52,6 +52,21 @@ write ``with SimEnv(...):``. Instantiate it, then pass it to the recipe:
 ``recipe.execute(env=env)``). Do not infer cleanup or lifecycle APIs that the
 public Recipe surface does not provide.
 
+For a requested local or first-user simulation, run `python job.py`; the Recipe
+API materializes the job configuration needed by `SimEnv` behind the scenes. Do
+not explicitly export first. Only when the user requests an exported/deployable
+job folder, run `python job.py --export --export-dir <dir>` and validate that
+exported artifact. Creating it does not authorize POC or production submission,
+which remains outside conversion scope.
+
+`--export` and `--export-dir` are NVFLARE system arguments consumed by the
+Recipe API across algorithms and frameworks. Generated `job.py` code must import
+the Recipe API before parsing its own options and must not declare, parse, or
+branch on those arguments or invent aliases such as `--export_only`. A local
+parser uses `argparse.ArgumentParser(allow_abbrev=False)` with strict
+`parse_args()`; it does not use `parse_known_args()` to accommodate system
+arguments.
+
 Use exactly one owner for the simulated client topology. With a unified recipe,
 let `SimEnv(num_clients=N)` create `site-1` through `site-N`; pass shared data
 arguments once and derive a generated partition index from the initialized site
@@ -72,10 +87,13 @@ class while dropping its constructor arguments. A direct instance is allowed
 only when the selected recipe accepts it and zero-argument construction with
 unchanged defaults reproduces the required architecture.
 
-Before the full run, materialize or export the generated server configuration
-without running a second validation target. Verify that its model component
-retains the audited class path and every constructor argument; constructing the
-recipe object alone is insufficient evidence.
+For an exported-artifact target, verify its server model configuration after
+creating the folder and before simulating it. For a local target, let
+`python job.py` materialize the configuration and inspect it in the completed
+simulation workspace. Do not create an export only for this check. In either
+artifact, verify that the model component retains the audited class path and
+every constructor argument; constructing the recipe object alone is
+insufficient evidence.
 
 ## Site Data Partitioning
 

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -73,9 +73,11 @@ arguments once and derive a generated partition index from the initialized site
 name. Do not call `set_per_site_config()` merely to assign partition indices.
 When genuinely different site paths or arguments require
 `set_per_site_config(recipe, config)`, that mapping owns the named targets: use
-`SimEnv(clients=list(config), ...)`, never `SimEnv(num_clients=...)`. Passing
-both named recipe targets and a generated client count is a construction error,
-not a condition to recover from by setting `num_clients=None`.
+`SimEnv(clients=list(config), ...)` rather than a generated topology. A matching
+`num_clients=N` may also be supplied to `SimEnv` only as a consistency assertion;
+`clients` remains the topology owner, and `SimEnv` rejects an inconsistent
+count. Do not pass `num_clients` without `clients` after creating named recipe
+targets, and do not recover from a mismatch by setting `num_clients=None`.
 
 ## Model Constructor Serialization
 

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -52,6 +52,21 @@ write ``with SimEnv(...):``. Instantiate it, then pass it to the recipe:
 ``recipe.execute(env=env)``). Do not infer cleanup or lifecycle APIs that the
 public Recipe surface does not provide.
 
+## Model Constructor Serialization
+
+For every framework, use explicit `class_path` (or `path`) plus complete `args`
+whenever identical server/client reconstruction depends on any constructor
+value, including a required parameter or an overridden default. Never use a
+live model instance to carry those values: job serialization may retain its
+class while dropping its constructor arguments. A direct instance is allowed
+only when the selected recipe accepts it and zero-argument construction with
+unchanged defaults reproduces the required architecture.
+
+Before the full run, materialize or export the generated server configuration
+without running a second validation target. Verify that its model component
+retains the audited class path and every constructor argument; constructing the
+recipe object alone is insufficient evidence.
+
 ## Site Data Partitioning
 
 Train each site on its local partition for multi-site single-node-source

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -52,6 +52,16 @@ write ``with SimEnv(...):``. Instantiate it, then pass it to the recipe:
 ``recipe.execute(env=env)``). Do not infer cleanup or lifecycle APIs that the
 public Recipe surface does not provide.
 
+Use exactly one owner for the simulated client topology. With a unified recipe,
+let `SimEnv(num_clients=N)` create `site-1` through `site-N`; pass shared data
+arguments once and derive a generated partition index from the initialized site
+name. Do not call `set_per_site_config()` merely to assign partition indices.
+When genuinely different site paths or arguments require
+`set_per_site_config(recipe, config)`, that mapping owns the named targets: use
+`SimEnv(clients=list(config), ...)`, never `SimEnv(num_clients=...)`. Passing
+both named recipe targets and a generated client count is a construction error,
+not a condition to recover from by setting `num_clients=None`.
+
 ## Model Constructor Serialization
 
 For every framework, use explicit `class_path` (or `path`) plus complete `args`

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -505,20 +505,11 @@ draft with that real failure as the blocker rather than looping on it.
 
 ## Export
 
-- Use `python job.py --export --export-dir <dir>` to export a generated job.
-  These are NVFLARE job system arguments across recipes, algorithms, and
-  frameworks. Do not declare them as generated job-local arguments, and do not
-  invent alternate export flags such as `--export_only`.
-- If a generated `job.py` defines local command-line options, import the
-  NVFLARE recipe API before local argument parsing. The recipe import removes
-  `--export` and `--export-dir` from `sys.argv`, so `parse_known_args()` is not
-  needed for NVFLARE flags and must not be used. Construct the local parser with
-  `argparse.ArgumentParser(allow_abbrev=False)` and call strict `parse_args()` so
-  unknown and abbreviated options fail. Do not add local `--export` or
-  `--export-dir` arguments or consume them in generated code. Treat this as a
-  generation-time requirement; validation should confirm a standard export
-  invocation plus rejection of both a misspelled option and a unique-prefix
-  abbreviation.
+- The common conversion rules own the canonical Recipe system arguments,
+  generated-parser boundary, and local-versus-exported target selection.
+- When an exported artifact was explicitly requested, validation should confirm
+  the standard export invocation plus rejection of both a misspelled local
+  option and a unique-prefix abbreviation.
 - Default `<dir>` according to `runtime-output-guidance.md` unless the user
   provides an export directory.
 - If writing explicit Job API code without a recipe execution helper, call

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -430,6 +430,13 @@ env = SimEnv(num_clients=num_clients, num_threads=num_clients, workspace_root=wo
 recipe.execute(env)
 ```
 
+This unified-app form is valid only while the recipe has no explicit named
+client targets. If `set_per_site_config(recipe, config)` is required for truly
+different site arguments, use `SimEnv(clients=list(config),
+num_threads=len(config), ...)` instead. The always-loaded common conversion
+reference owns the canonical single-topology-owner rule and partition guidance;
+do not configure both forms or recover with `num_clients=None`.
+
 For normal first-user simulation, `python job.py` is the intended local
 experience because no exported job folder may exist yet. The exported job folder
 is still the deployable artifact: POC or production submission uses the job

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -265,10 +265,9 @@ the framework references show the concrete placement.
 
 ## Recipe Model Config
 
-When a recipe needs a model, use a model form accepted by the selected recipe.
-The two supported forms are explicit model config and a directly constructed
-model instance. Prefer explicit config when it makes a reusable or
-parameterized definition clearer:
+Apply the mandatory framework-neutral "Model Constructor Serialization" rule.
+Whenever identical reconstruction needs any constructor value, use explicit
+model config:
 
 ```python
 recipe = FedAvgRecipe(
@@ -280,16 +279,14 @@ recipe = FedAvgRecipe(
 )
 ```
 
-```python
-recipe = FedAvgRecipe(model=MyModel(num_classes=10), ...)
-```
-
-A direct instance is allowed only when the selected recipe accepts it and its
-construction is local, deterministic, and free of material side effects. Do
-not construct it through downloads, checkpoint loading, private or
-runtime-dependent data, external services, environment lookups, or unavailable
-runtime configuration. Prefer the `class_path` key over `path` for explicit
-config; `path` is the normalized job-config key.
+A direct instance is allowed only when the selected recipe accepts it,
+zero-argument construction with unchanged defaults reproduces the required
+architecture, and construction is local, deterministic, and free of material
+side effects. Never use a live instance to carry required or overridden
+constructor values. Do not construct it through downloads, checkpoint loading,
+private or runtime-dependent data, external services, environment lookups, or
+unavailable runtime configuration. Prefer the `class_path` key over `path` for
+explicit config; `path` is the normalized job-config key.
 
 Treat model constructor args as statically clear only when the class path is an
 importable class or direct local class definition and the constructor values

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -422,20 +422,10 @@ reconstruct either contract from this broad workflow reference.
 
 ## Execution Environment And Local Validation
 
-Conversion validation uses `SimEnv` from `nvflare.recipe`. Build the recipe and
-call `recipe.execute(env)` from `job.py`:
-
-```python
-env = SimEnv(num_clients=num_clients, num_threads=num_clients, workspace_root=workspace_root)
-recipe.execute(env)
-```
-
-This unified-app form is valid only while the recipe has no explicit named
-client targets. If `set_per_site_config(recipe, config)` is required for truly
-different site arguments, use `SimEnv(clients=list(config),
-num_threads=len(config), ...)` instead. The always-loaded common conversion
-reference owns the canonical single-topology-owner rule and partition guidance;
-do not configure both forms or recover with `num_clients=None`.
+Conversion validation uses `SimEnv` from `nvflare.recipe`; build the environment
+under the canonical single-topology-owner rule in the always-loaded common
+conversion reference, then call `recipe.execute(env)` from `job.py`. Do not
+reconstruct that topology policy from this broad workflow reference.
 
 For normal first-user simulation, `python job.py` is the intended local
 experience because no exported job folder may exist yet. The exported job folder

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -39,6 +39,12 @@ non-failing module attribute check such as `hasattr`; if it is absent, report a
 version or skill-contract gap. Do not replace a failed local public check with
 web search or SDK-source discovery.
 
+For ordinary PyTorch-family `SimEnv` execution, do not import or introspect a
+`Run` class, probe its module location, signature, or docstring, or add lifecycle
+calls by guess. `recipe.execute(env)` is sufficient unless a selected maintained
+asset or the public recipe documentation already defines use of its returned
+handle. In that case, preserve the known pattern instead of rediscovering it.
+
 Validate a recipe model's `class_path` through the public recipe construction,
 export inspection, and bounded execution path. Do not import internal class
 loader helpers, guess helper names, or inspect implementation source to build a

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -74,14 +74,10 @@ selected recipe path and the generated client's actual parser.
 
 ### Per-Site Argument Overrides
 
-Use one topology owner. The standard local path leaves `per_site_config` unset
-and runs `SimEnv(num_clients=N, ...)`; generate site partitions from
-`flare.get_site_name()` after `flare.init()` rather than creating one recipe
-target per partition. Use `per_site_config` only for genuinely different site
-paths or arguments. Once `set_per_site_config(recipe, per_site_config)` creates
-named recipe targets, run them with
-`SimEnv(clients=list(per_site_config), num_threads=len(per_site_config), ...)`.
-Never also pass `num_clients`, and never use `num_clients=None` as a workaround.
+Follow the single-topology-owner rule in `conversion-common.md`. For generated
+partitions, derive the site index from `flare.get_site_name()` after
+`flare.init()` rather than creating one recipe target per partition. Use
+`per_site_config` only for genuinely different site paths or arguments.
 
 Treat `per_site_config[site]["train_args"]` as the site's complete argument
 string. When present, it replaces the recipe-level `train_args`; the recipe does

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -64,6 +64,15 @@ selected recipe path and the generated client's actual parser.
 
 ### Per-Site Argument Overrides
 
+Use one topology owner. The standard local path leaves `per_site_config` unset
+and runs `SimEnv(num_clients=N, ...)`; generate site partitions from
+`flare.get_site_name()` after `flare.init()` rather than creating one recipe
+target per partition. Use `per_site_config` only for genuinely different site
+paths or arguments. Once `set_per_site_config(recipe, per_site_config)` creates
+named recipe targets, run them with
+`SimEnv(clients=list(per_site_config), num_threads=len(per_site_config), ...)`.
+Never also pass `num_clients`, and never use `num_clients=None` as a workaround.
+
 Treat `per_site_config[site]["train_args"]` as the site's complete argument
 string. When present, it replaces the recipe-level `train_args`; the recipe does
 not merge shared arguments into the site override. Compose every site value from
@@ -79,7 +88,9 @@ set_per_site_config(recipe, per_site_config)
 ```
 
 Recipe-level `train_args` is only the fallback for a site without its own
-`train_args` entry. Before a full simulation, inspect each composed site value
+`train_args` entry. Use the same mapping for Recipe and `SimEnv` construction so
+both use the same target names. Before a full simulation, inspect each composed
+site value
 and verify that it contains the full expected argument set. For an exported-job
 validation target, also inspect each site's exported client configuration and
 verify that `task_script_args` contains the full expected argument set. For a

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -30,8 +30,11 @@ module/class attribute checks for capability discovery.
 `recipe show` validates only the selected recipe's module, class, and listed
 constructor parameters. It does not advertise other symbols from
 `nvflare.recipe` or define a separate export environment. For supported local
-conversion validation, use `SimEnv` with `recipe.execute(...)`; export through
-`python job.py --export --export-dir <dir>`.
+conversion validation, use `SimEnv` with `recipe.execute(...)`; it materializes
+the simulator job configuration without a separate export step. Export through
+`python job.py --export --export-dir <dir>` only when the user requests an
+exported/deployable job folder. System-argument ownership and parser rules are
+defined in `conversion-common.md`.
 
 Do not guess or directly import additional recipe-adjacent symbols. When the
 selected public workflow genuinely requires another symbol, first use a
@@ -45,10 +48,11 @@ calls by guess. `recipe.execute(env)` is sufficient unless a selected maintained
 asset or the public recipe documentation already defines use of its returned
 handle. In that case, preserve the known pattern instead of rediscovering it.
 
-Validate a recipe model's `class_path` through the public recipe construction,
-export inspection, and bounded execution path. Do not import internal class
-loader helpers, guess helper names, or inspect implementation source to build a
-parallel validation path.
+Validate a recipe model's `class_path` through public recipe construction and
+the artifact produced by the selected bounded validation path: the exported
+configuration for an export target, or the materialized simulation
+configuration for a local target. Do not import internal class loader helpers,
+guess helper names, or inspect implementation source to build a parallel path.
 
 ## Client Argument Transport
 
@@ -245,7 +249,8 @@ Resolve model selection to exactly one state before constructing the recipe:
   client delivers that exact key. Omit `key_metric` and report the resolved
   default; never use this state as a fallback for an unavailable metric.
 
-After export, inspect the server configuration. The disabled state must contain
-no active model-selector component. The metric and recipe-default states must
-contain a selector with the resolved key. Treat a mismatch, or missing-metric
-warnings from a supposedly disabled job, as validation failure.
+Inspect the server configuration produced by the selected validation target.
+The disabled state must contain no active model-selector component. The metric
+and recipe-default states must contain a selector with the resolved key. Treat a
+mismatch, or missing-metric warnings from a supposedly disabled job, as
+validation failure.

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -13,10 +13,17 @@ Choose one final full-run path based on the artifact being validated:
   <exported-job-dir> -w <runtime-dir>/workspace -n <num_clients> -t
   <num_threads> -l concise` (or `-c site-1,site-2,...`).
 
-Do not accept a generated job-local export alias such as `--export_only` as a
-valid replacement for the NVFLARE Recipe interface. If a generated job manually
-branches on a private export flag or calls `recipe.export()` only for that flag,
-report it as a generated-code violation instead of treating the export as valid.
+Unless the user explicitly requests an exported/deployable job folder, select
+the local path and do not export. `recipe.execute(SimEnv(...))` materializes the
+job configuration needed for that simulation behind the scenes. Creating an
+export does not authorize submitting it to POC or production; submission is
+outside conversion-skill scope.
+
+Do not accept generated job-local `--export` or `--export-dir` arguments, or an
+alias such as `--export_only`, as replacements for the NVFLARE Recipe interface.
+If generated code parses or manually branches on those system arguments or a
+private alias, report it as a generated-code violation instead of treating the
+export as valid.
 
 Do not run both full simulations unless the first one failed and the second is a
 scoped rerun after a fix. Do not write Python code to call simulator APIs for

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -78,7 +78,10 @@ are not completion evidence and are not valid final answers.
 Do not pipe the final validation command through `tail`, `grep`, or another
 command that can hide the simulator or `python job.py` exit status. Redirect the
 full log to a runtime log file and print a bounded tail only after the command
-has finished and its exit code has been recorded.
+has finished and its exit code has been recorded. Do not append `; echo
+"EXIT_CODE=$?"`, because the successful `echo` masks a failed simulation from
+the calling tool. When a status line is required, preserve the status with
+`rc=$?; echo "EXIT_CODE=$rc"; exit "$rc"`.
 
 After a full simulation succeeds, do not rerun it solely to make already-wired
 custom-aggregator log lines more visible. Use the first run's terminal evidence
@@ -120,7 +123,12 @@ context. Validate their generated source shape and public signatures
 statically; validate runtime acceptance only through the recipe or simulator
 that launches the client context.
 
-Before spending time on full simulation, run cheap checks when applicable:
+Before spending time on full simulation, run cheap checks when applicable.
+Keep custom checks atomic: reuse inspected project/generated helpers with their
+exact annotated argument types, and do not combine partition,
+model-compatibility, metric, and artifact checks in one hand-written inline
+Python program. Each custom probe should test one contract and produce one
+actionable failure.
 
 - compile generated Python files;
 - construct or instantiate the selected recipe;
@@ -128,16 +136,7 @@ Before spending time on full simulation, run cheap checks when applicable:
   export once, inspect its server/client app folders and expected config files,
   and run that same export; do not create a separate throwaway export;
 - when the selected final target is a local `python job.py` simulation, do not
-  export during preflight. After the run, inspect the materialized server/client
-  configs and packaging evidence in its simulation workspace;
-- in the artifact produced by the selected target, verify the server model
-  retains its audited class path and complete constructor args; recipe
-  construction alone does not prove serialization;
-- compare the resolved model-selection state with the produced server config:
-  disabled means no active model selector, while metric or deliberately
-  accepted recipe-default selection means a selector with the resolved key;
-- verify generated files required by server and client code are packaged in the
-  artifact produced by the selected target;
+  export during preflight;
 - run local partition sanity checks when generated site splits or data
   partitions are introduced;
 - run the framework-specific model compatibility check defined by the framework
@@ -152,6 +151,16 @@ counts inferred by hand from one dataset.
 
 Use preflight results to fix packaging, config, or model-state issues before
 running a full simulation.
+
+After the selected final run succeeds, inspect its materialized artifact to:
+
+- verify the server model retains its audited class path and complete
+  constructor args; recipe construction alone does not prove serialization;
+- compare the resolved model-selection state with the produced server config:
+  disabled means no active model selector, while metric or deliberately
+  accepted recipe-default selection means a selector with the resolved key;
+- verify generated files required by server and client code are packaged in the
+  server/client app folders.
 
 ## Verification And Audit Snippets
 

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -119,6 +119,8 @@ Before spending time on full simulation, run cheap checks when applicable:
 - construct or instantiate the selected recipe;
 - export to a temporary directory;
 - inspect exported server/client app folders and expected config files;
+- verify the exported server model retains its audited class path and complete
+  constructor args; recipe construction alone does not prove serialization;
 - compare the resolved model-selection state with the exported server config:
   disabled means no active model selector, while metric or deliberately accepted
   recipe-default selection means a selector with the resolved key;

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -128,7 +128,8 @@ Keep custom checks atomic: reuse inspected project/generated helpers with their
 exact annotated argument types, and do not combine partition,
 model-compatibility, metric, and artifact checks in one hand-written inline
 Python program. Each custom probe should test one contract and produce one
-actionable failure.
+actionable failure. When a helper parameter is annotated as `Path`, instantiate
+and pass `Path(...)`; do not substitute a string literal.
 
 - compile generated Python files;
 - construct or instantiate the selected recipe;
@@ -147,7 +148,14 @@ track source positions and verify complete, non-overlapping coverage,
 determinism for the same seed, and any stratification or balance guarantee the
 generated algorithm actually makes. Assert exact per-site row counts only when
 the user, source, or a programmatic calculation specifies them; do not hard-code
-counts inferred by hand from one dataset.
+counts inferred by hand from one dataset. When comparing a source `DataFrame`
+with partitions reloaded from CSV, inspect their dtypes and normalize generated
+columns to the source schema before using `DataFrame.equals()`; a dtype-only
+difference is not a coverage failure.
+
+Run a determinism check from the generated project directory. If an isolated
+scratch copy is necessary, copy the complete local import closure; do not copy
+only selected entry-point scripts.
 
 Use preflight results to fix packaging, config, or model-state issues before
 running a full simulation.

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -117,14 +117,20 @@ Before spending time on full simulation, run cheap checks when applicable:
 
 - compile generated Python files;
 - construct or instantiate the selected recipe;
-- export to a temporary directory;
-- inspect exported server/client app folders and expected config files;
-- verify the exported server model retains its audited class path and complete
-  constructor args; recipe construction alone does not prove serialization;
-- compare the resolved model-selection state with the exported server config:
-  disabled means no active model selector, while metric or deliberately accepted
-  recipe-default selection means a selector with the resolved key;
-- verify generated files required by server and client code are packaged;
+- when the selected final target is an exported/deployable artifact, create that
+  export once, inspect its server/client app folders and expected config files,
+  and run that same export; do not create a separate throwaway export;
+- when the selected final target is a local `python job.py` simulation, do not
+  export during preflight. After the run, inspect the materialized server/client
+  configs and packaging evidence in its simulation workspace;
+- in the artifact produced by the selected target, verify the server model
+  retains its audited class path and complete constructor args; recipe
+  construction alone does not prove serialization;
+- compare the resolved model-selection state with the produced server config:
+  disabled means no active model selector, while metric or deliberately
+  accepted recipe-default selection means a selector with the resolved key;
+- verify generated files required by server and client code are packaged in the
+  artifact produced by the selected target;
 - run local partition sanity checks when generated site splits or data
   partitions are introduced;
 - run the framework-specific model compatibility check defined by the framework
@@ -149,6 +155,11 @@ fields, or model-state keys, inspect the actual object (`df.columns`, JSON keys,
 from that evidence. Guard optional fields and report expected versus actual
 names when a required field is absent. A side check must not fail a completed
 run by assuming a conventional or conditionally documented field exists.
+Build validation calls from inspected callable signatures and type annotations,
+and preserve their required argument types. When retrying a failed check, change
+only the failing assumption; preserve prior guards, fallbacks, and already-correct
+arguments. Never replace an optional-field guard with a hard-coded conventional
+name merely to make the retry different.
 For generated Python structure, validate semantic AST nodes rather than textual
 occurrences. Scope traversal to the field being checked; for example, inspect a
 loop's condition and body separately. Filter traversal results by node type

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -57,7 +57,7 @@ def test_huggingface_model_resolver_returns_existing_local_path(tmp_path):
     model_dir = tmp_path / "model"
     model_dir.mkdir()
 
-    result = module.resolve_model_snapshot(str(model_dir))
+    result = module.resolve_model_snapshot(str(model_dir), source="local")
 
     assert result == {
         "download_authorized": False,
@@ -65,6 +65,26 @@ def test_huggingface_model_resolver_returns_existing_local_path(tmp_path):
         "resolved_path": str(model_dir.resolve()),
         "source": "local",
         "status": "available",
+    }
+
+
+def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hub(monkeypatch):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+
+    def unexpected_hub_load():
+        raise AssertionError("an explicit local path must not load huggingface_hub")
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", unexpected_hub_load)
+
+    result = module.resolve_model_snapshot("models/checkpoint", source="local")
+
+    assert result == {
+        "download_authorized": False,
+        "identifier": "models/checkpoint",
+        "reason": "local_path_not_found",
+        "resolved_path": None,
+        "source": "local",
+        "status": "missing",
     }
 
 
@@ -81,15 +101,23 @@ def test_huggingface_model_resolver_reports_cache_miss_without_failing(monkeypat
 
     monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
 
-    assert module.main(["org/model"]) == 0
+    assert module.main(["--source", "hub", "org/model"]) == 0
     result = json.loads(capsys.readouterr().out)
 
-    assert calls == [{"local_files_only": True, "repo_id": "org/model"}]
+    assert calls == [
+        {
+            "cache_dir": None,
+            "local_files_only": True,
+            "repo_id": "org/model",
+            "revision": None,
+        }
+    ]
     assert result == {
         "download_authorized": False,
         "identifier": "org/model",
         "reason": "not_cached",
         "resolved_path": None,
+        "revision": None,
         "source": "hub_cache",
         "status": "missing",
     }
@@ -97,7 +125,8 @@ def test_huggingface_model_resolver_reports_cache_miss_without_failing(monkeypat
 
 def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypatch, tmp_path):
     module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
-    snapshot_dir = tmp_path / "models--org--model" / "snapshots" / "abc123"
+    revision = "a" * 40
+    snapshot_dir = tmp_path / "models--org--model" / "snapshots" / revision
     snapshot_dir.mkdir(parents=True)
     calls = []
 
@@ -112,8 +141,9 @@ def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypa
 
     result = module.resolve_model_snapshot(
         "org/model",
+        source="hub",
         allow_download=True,
-        revision="abc123",
+        revision=revision,
         cache_dir=str(tmp_path),
     )
 
@@ -122,16 +152,30 @@ def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypa
             "cache_dir": str(tmp_path),
             "local_files_only": False,
             "repo_id": "org/model",
-            "revision": "abc123",
+            "revision": revision,
         }
     ]
     assert result == {
         "download_authorized": True,
         "identifier": "org/model",
         "resolved_path": str(snapshot_dir.resolve()),
+        "revision": revision,
         "source": "hub_download_or_cache",
         "status": "available",
     }
+
+
+@pytest.mark.parametrize("revision", [None, "main", "abc123", "g" * 40])
+def test_huggingface_model_resolver_requires_immutable_revision_for_download(monkeypatch, revision):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+
+    def unexpected_hub_load():
+        raise AssertionError("an invalid revision must fail before loading huggingface_hub")
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", unexpected_hub_load)
+
+    with pytest.raises(ValueError, match="40-character commit SHA"):
+        module.resolve_model_snapshot("org/model", source="hub", allow_download=True, revision=revision)
 
 
 def test_huggingface_model_resolver_does_not_hide_authorized_download_failure(monkeypatch):
@@ -146,7 +190,7 @@ def test_huggingface_model_resolver_does_not_hide_authorized_download_failure(mo
     monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
 
     with pytest.raises(_CacheMiss, match="authorized resolution failed"):
-        module.resolve_model_snapshot("org/model", allow_download=True)
+        module.resolve_model_snapshot("org/model", source="hub", allow_download=True, revision="a" * 40)
 
 
 def test_non_fedavg_tensor_profile_omits_unsupported_disk_offload(tmp_path):

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -187,6 +187,7 @@ def test_huggingface_model_resolver_does_not_treat_existing_hub_id_as_local(monk
         }
     ]
     assert result["resolved_path"] == str(hub_snapshot.resolve())
+    assert result["repo_type"] == "model"
     assert result["source"] == "hub_cache"
 
 
@@ -218,6 +219,7 @@ def test_huggingface_model_resolver_reports_cache_miss_without_failing(monkeypat
         "download_authorized": False,
         "identifier": "org/model",
         "reason": "not_cached",
+        "repo_type": "model",
         "resolved_path": None,
         "revision": None,
         "source": "hub_cache",
@@ -261,6 +263,7 @@ def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypa
         "download_authorized": True,
         "identifier": "org/model",
         "resolved_path": str(snapshot_dir.resolve()),
+        "repo_type": "model",
         "revision": revision,
         "source": "hub_download_or_cache",
         "status": "available",
@@ -281,7 +284,7 @@ def test_huggingface_model_resolver_resolves_revision_for_authorized_download(mo
         calls.append(kwargs)
         return str(snapshot_dir)
 
-    monkeypatch.setattr(module, "_resolve_hub_revision", lambda identifier: revision)
+    monkeypatch.setattr(module, "_resolve_hub_revision", lambda identifier, repo_type: revision)
     monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
 
     result = module.resolve_model_snapshot("org/model", source="hub", allow_download=True)
@@ -311,7 +314,96 @@ def test_huggingface_model_resolver_uses_public_api_for_revision_lookup(monkeypa
     hub_module.HfApi = _HfApi
     monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
 
-    assert module._resolve_hub_revision("org/model") == revision
+    assert module._resolve_hub_revision("org/model", "model") == revision
+
+
+def test_huggingface_model_resolver_uses_dataset_repo_type_for_cache_only_lookup(monkeypatch, tmp_path, capsys):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    dataset_snapshot = tmp_path / "datasets--org--data" / "snapshots" / ("d" * 40)
+    dataset_snapshot.mkdir(parents=True)
+    calls = []
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(dataset_snapshot)
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    assert module.main(["--source", "hub", "--repo-type", "dataset", "org/data"]) == 0
+    result = json.loads(capsys.readouterr().out)
+
+    assert calls == [
+        {
+            "cache_dir": None,
+            "local_files_only": True,
+            "repo_id": "org/data",
+            "repo_type": "dataset",
+            "revision": None,
+        }
+    ]
+    assert result["repo_type"] == "dataset"
+    assert result["resolved_path"] == str(dataset_snapshot.resolve())
+
+
+def test_huggingface_model_resolver_uses_dataset_api_for_revision_lookup(monkeypatch):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    revision = "e" * 40
+    hub_module = types.ModuleType("huggingface_hub")
+
+    class _HfApi:
+        def dataset_info(self, *, repo_id):
+            assert repo_id == "org/data"
+            return types.SimpleNamespace(sha=revision)
+
+    hub_module.HfApi = _HfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
+
+    assert module._resolve_hub_revision("org/data", "dataset") == revision
+
+
+def test_huggingface_model_resolver_downloads_pinned_dataset_only_when_authorized(monkeypatch, tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    revision = "f" * 40
+    dataset_snapshot = tmp_path / "datasets--org--data" / "snapshots" / revision
+    dataset_snapshot.mkdir(parents=True)
+    calls = []
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(dataset_snapshot)
+
+    def resolve_revision(identifier, repo_type):
+        assert (identifier, repo_type) == ("org/data", "dataset")
+        return revision
+
+    monkeypatch.setattr(module, "_resolve_hub_revision", resolve_revision)
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    result = module.resolve_model_snapshot(
+        "org/data",
+        source="hub",
+        repo_type="dataset",
+        allow_download=True,
+    )
+
+    assert calls == [
+        {
+            "cache_dir": None,
+            "local_files_only": False,
+            "repo_id": "org/data",
+            "repo_type": "dataset",
+            "revision": revision,
+        }
+    ]
+    assert result["download_authorized"] is True
+    assert result["repo_type"] == "dataset"
+    assert result["revision"] == revision
 
 
 @pytest.mark.parametrize("revision", ["main", "abc123", "g" * 40])
@@ -926,7 +1018,7 @@ def test_huggingface_job_template_uses_one_simulator_topology_owner(tmp_path):
     assert named_env.num_clients == 2
     assert named_env.num_threads == 2
 
-    with pytest.raises(ValueError, match="named topology must match the requested client count"):
+    with pytest.raises(ValueError, match="Inconsistent number of clients"):
         module.build_sim_env(3, tmp_path / "mismatch", per_site_config=per_site_config)
 
 

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -36,6 +36,7 @@ SKILLS_ROOT = REPO_ROOT / "skills"
 PT_TEMPLATES = SKILLS_ROOT / "nvflare-convert-pytorch" / "assets"
 LIGHTNING_TEMPLATES = SKILLS_ROOT / "nvflare-convert-lightning" / "assets"
 HF_TEMPLATES = SKILLS_ROOT / "nvflare-convert-huggingface" / "assets"
+HF_SCRIPTS = SKILLS_ROOT / "nvflare-convert-huggingface" / "scripts"
 SHARED_TEMPLATES = SKILLS_ROOT / "nvflare-shared" / "assets"
 
 
@@ -49,6 +50,103 @@ def _load_module(path: Path):
 class _FloatOverflow:
     def __float__(self):
         raise OverflowError("step count too large")
+
+
+def test_huggingface_model_resolver_returns_existing_local_path(tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    result = module.resolve_model_snapshot(str(model_dir))
+
+    assert result == {
+        "download_authorized": False,
+        "identifier": str(model_dir),
+        "resolved_path": str(model_dir.resolve()),
+        "source": "local",
+        "status": "available",
+    }
+
+
+def test_huggingface_model_resolver_reports_cache_miss_without_failing(monkeypatch, capsys):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    calls = []
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        raise _CacheMiss("not cached")
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    assert module.main(["org/model"]) == 0
+    result = json.loads(capsys.readouterr().out)
+
+    assert calls == [{"local_files_only": True, "repo_id": "org/model"}]
+    assert result == {
+        "download_authorized": False,
+        "identifier": "org/model",
+        "reason": "not_cached",
+        "resolved_path": None,
+        "source": "hub_cache",
+        "status": "missing",
+    }
+
+
+def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypatch, tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    snapshot_dir = tmp_path / "models--org--model" / "snapshots" / "abc123"
+    snapshot_dir.mkdir(parents=True)
+    calls = []
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(snapshot_dir)
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    result = module.resolve_model_snapshot(
+        "org/model",
+        allow_download=True,
+        revision="abc123",
+        cache_dir=str(tmp_path),
+    )
+
+    assert calls == [
+        {
+            "cache_dir": str(tmp_path),
+            "local_files_only": False,
+            "repo_id": "org/model",
+            "revision": "abc123",
+        }
+    ]
+    assert result == {
+        "download_authorized": True,
+        "identifier": "org/model",
+        "resolved_path": str(snapshot_dir.resolve()),
+        "source": "hub_download_or_cache",
+        "status": "available",
+    }
+
+
+def test_huggingface_model_resolver_does_not_hide_authorized_download_failure(monkeypatch):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**_kwargs):
+        raise _CacheMiss("authorized resolution failed")
+
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    with pytest.raises(_CacheMiss, match="authorized resolution failed"):
+        module.resolve_model_snapshot("org/model", allow_download=True)
 
 
 def test_non_fedavg_tensor_profile_omits_unsupported_disk_offload(tmp_path):

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -249,6 +249,32 @@ def test_non_fedavg_tensor_profile_omits_unsupported_disk_offload(tmp_path):
     assert recipe.server_expected_format == ExchangeFormat.PYTORCH
 
 
+def test_cyclic_parameterized_model_config_exports_normalized_path(tmp_path):
+    pytest.importorskip("torch")
+    from nvflare.app_opt.pt.recipes.cyclic import CyclicRecipe
+
+    train_script = tmp_path / "client.py"
+    train_script.write_text("pass\n", encoding="utf-8")
+    recipe = CyclicRecipe(
+        name="skill-cyclic-model-config-test",
+        model={"class_path": "torch.nn.Linear", "args": {"in_features": 2, "out_features": 1}},
+        train_script=str(train_script),
+        min_clients=2,
+    )
+
+    export_root = tmp_path / "export"
+    recipe.export(str(export_root))
+    server_config = json.loads(
+        (export_root / recipe.name / "app" / "config" / "config_fed_server.json").read_text(encoding="utf-8")
+    )
+    persistor = next(component for component in server_config["components"] if component["id"] == "persistor")
+
+    assert persistor["args"]["model"] == {
+        "path": "torch.nn.Linear",
+        "args": {"in_features": 2, "out_features": 1},
+    }
+
+
 def test_pytorch_eval_template_computes_metric_against_toy_model():
     torch = pytest.importorskip("torch")
     module = _load_module(PT_TEMPLATES / "client_with_eval.py")

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -1018,6 +1018,45 @@ def test_huggingface_job_template_uses_public_recipe_execution_without_internal_
     assert "persistor" not in source.lower()
 
 
+def test_lightning_local_persistent_state_filters_both_directions_across_rounds():
+    torch = pytest.importorskip("torch")
+
+    from nvflare.apis.dxo import DXO, DataKind, from_shareable
+    from nvflare.apis.fl_context import FLContext
+    from nvflare.app_common.filters import ExcludeVars
+
+    class _Model(torch.nn.Module):
+        def __init__(self, shared_value, local_value):
+            super().__init__()
+            self.shared = torch.nn.Parameter(torch.tensor([shared_value]))
+            self.register_buffer("site_local", torch.tensor([local_value]))
+
+    def filter_payload(state):
+        shareable = DXO(data_kind=DataKind.WEIGHTS, data=dict(state)).to_shareable()
+        filtered = ExcludeVars(["site_local"]).process(shareable, FLContext())
+        return from_shareable(filtered).data
+
+    server = _Model(shared_value=1.0, local_value=-1.0)
+    client = _Model(shared_value=0.0, local_value=41.0)
+
+    for expected_shared in (1.0, 2.0):
+        server_to_client = filter_payload(server.state_dict())
+        assert "site_local" not in server_to_client
+
+        incompatible = client.load_state_dict(server_to_client, strict=False)
+        assert incompatible.missing_keys == ["site_local"]
+        assert client.site_local.item() == pytest.approx(41.0)
+
+        with torch.no_grad():
+            client.shared.add_(1.0)
+        client_to_server = filter_payload(client.state_dict())
+        assert "site_local" not in client_to_server
+
+        server.load_state_dict(client_to_server, strict=False)
+        assert server.shared.item() == pytest.approx(expected_shared + 1.0)
+        assert client.site_local.item() == pytest.approx(41.0)
+
+
 def test_custom_aggregator_template_step_weighted_average():
     import numpy as np
 

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -267,7 +267,54 @@ def test_huggingface_model_resolver_downloads_once_only_when_authorized(monkeypa
     }
 
 
-@pytest.mark.parametrize("revision", [None, "main", "abc123", "g" * 40])
+def test_huggingface_model_resolver_resolves_revision_for_authorized_download(monkeypatch, tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    revision = "b" * 40
+    snapshot_dir = tmp_path / "models--org--model" / "snapshots" / revision
+    snapshot_dir.mkdir(parents=True)
+    calls = []
+
+    class _CacheMiss(Exception):
+        pass
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(snapshot_dir)
+
+    monkeypatch.setattr(module, "_resolve_hub_revision", lambda identifier: revision)
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    result = module.resolve_model_snapshot("org/model", source="hub", allow_download=True)
+
+    assert calls == [
+        {
+            "cache_dir": None,
+            "local_files_only": False,
+            "repo_id": "org/model",
+            "revision": revision,
+        }
+    ]
+    assert result["revision"] == revision
+    assert result["resolved_path"] == str(snapshot_dir.resolve())
+
+
+def test_huggingface_model_resolver_uses_public_api_for_revision_lookup(monkeypatch):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    revision = "c" * 40
+    hub_module = types.ModuleType("huggingface_hub")
+
+    class _HfApi:
+        def model_info(self, *, repo_id):
+            assert repo_id == "org/model"
+            return types.SimpleNamespace(sha=revision)
+
+    hub_module.HfApi = _HfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
+
+    assert module._resolve_hub_revision("org/model") == revision
+
+
+@pytest.mark.parametrize("revision", ["main", "abc123", "g" * 40])
 def test_huggingface_model_resolver_requires_immutable_revision_for_download(monkeypatch, revision):
     module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
 

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -88,6 +88,38 @@ def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hu
     }
 
 
+def test_huggingface_model_resolver_does_not_treat_existing_hub_id_as_local(monkeypatch, tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    local_collision = tmp_path / "org" / "model"
+    local_collision.mkdir(parents=True)
+    hub_snapshot = tmp_path / "hub-snapshot"
+    hub_snapshot.mkdir()
+    calls = []
+
+    def snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return str(hub_snapshot)
+
+    class _CacheMiss(Exception):
+        pass
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(module, "_load_huggingface_hub", lambda: (snapshot_download, _CacheMiss))
+
+    result = module.resolve_model_snapshot("org/model", source="hub")
+
+    assert calls == [
+        {
+            "cache_dir": None,
+            "local_files_only": True,
+            "repo_id": "org/model",
+            "revision": None,
+        }
+    ]
+    assert result["resolved_path"] == str(hub_snapshot.resolve())
+    assert result["source"] == "hub_cache"
+
+
 def test_huggingface_model_resolver_reports_cache_miss_without_failing(monkeypatch, capsys):
     module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
     calls = []

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -68,7 +68,7 @@ def test_huggingface_model_resolver_returns_existing_local_path(tmp_path):
     }
 
 
-def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hub(monkeypatch):
+def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hub(monkeypatch, tmp_path):
     module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
 
     def unexpected_hub_load():
@@ -76,7 +76,7 @@ def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hu
 
     monkeypatch.setattr(module, "_load_huggingface_hub", unexpected_hub_load)
 
-    result = module.resolve_model_snapshot("models/checkpoint", source="local")
+    result = module.resolve_model_snapshot("models/checkpoint", source="local", source_root=str(tmp_path))
 
     assert result == {
         "download_authorized": False,
@@ -86,6 +86,42 @@ def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hu
         "source": "local",
         "status": "missing",
     }
+
+
+def test_huggingface_model_resolver_resolves_relative_local_path_from_source_root(monkeypatch, tmp_path, capsys):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    source_root = tmp_path / "source"
+    model_dir = source_root / "models" / "checkpoint"
+    model_dir.mkdir(parents=True)
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
+
+    assert (
+        module.main(
+            [
+                "--source",
+                "local",
+                "--source-root",
+                str(source_root),
+                "models/checkpoint",
+            ]
+        )
+        == 0
+    )
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["resolved_path"] == str(model_dir.resolve())
+    assert result["source"] == "local"
+
+
+def test_huggingface_model_resolver_rejects_relative_local_path_without_absolute_source_root(tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+
+    with pytest.raises(ValueError, match="relative local identifiers require an absolute source_root"):
+        module.resolve_model_snapshot("models/checkpoint", source="local")
+    with pytest.raises(ValueError, match="source_root must be an absolute path"):
+        module.resolve_model_snapshot("models/checkpoint", source="local", source_root="source")
 
 
 def test_huggingface_model_resolver_does_not_treat_existing_hub_id_as_local(monkeypatch, tmp_path):
@@ -792,6 +828,24 @@ def test_huggingface_job_template_exports_per_site_files_from_another_working_di
         executor_args = client_config["executors"][0]["executor"]["args"]
         assert executor_args["task_script_path"] == "client.py"
         assert executor_args["task_script_args"] == expected["train_args"]
+
+
+def test_huggingface_job_template_uses_one_simulator_topology_owner(tmp_path):
+    module = _load_module(HF_TEMPLATES / "job.py")
+    per_site_config = {"site-a": {"train_args": "--data_root /data/a"}, "site-b": {"train_args": "--data_root /data/b"}}
+
+    unified_env = module.build_sim_env(2, tmp_path / "unified")
+    assert unified_env.clients is None
+    assert unified_env.num_clients == 2
+    assert unified_env.num_threads == 2
+
+    named_env = module.build_sim_env(2, tmp_path / "named", per_site_config=per_site_config)
+    assert named_env.clients == ["site-a", "site-b"]
+    assert named_env.num_clients == 2
+    assert named_env.num_threads == 2
+
+    with pytest.raises(ValueError, match="named topology must match the requested client count"):
+        module.build_sim_env(3, tmp_path / "mismatch", per_site_config=per_site_config)
 
 
 def test_huggingface_job_template_rejects_deprecated_per_site_constructor_option():

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -68,6 +68,30 @@ def test_huggingface_model_resolver_returns_existing_local_path(tmp_path):
     }
 
 
+def test_huggingface_model_resolver_loads_exception_from_legacy_public_utils(monkeypatch):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    hub_module = types.ModuleType("huggingface_hub")
+    hub_module.__path__ = []
+    utils_module = types.ModuleType("huggingface_hub.utils")
+
+    class _LegacyLocalEntryNotFoundError(Exception):
+        pass
+
+    def snapshot_download(**_kwargs):
+        return "/cached/snapshot"
+
+    hub_module.snapshot_download = snapshot_download
+    utils_module.LocalEntryNotFoundError = _LegacyLocalEntryNotFoundError
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils_module)
+    monkeypatch.delitem(sys.modules, "huggingface_hub.errors", raising=False)
+
+    loaded_download, loaded_error = module._load_huggingface_hub()
+
+    assert loaded_download is snapshot_download
+    assert loaded_error is _LegacyLocalEntryNotFoundError
+
+
 def test_huggingface_model_resolver_does_not_treat_missing_bare_local_path_as_hub(monkeypatch, tmp_path):
     module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
 
@@ -122,6 +146,16 @@ def test_huggingface_model_resolver_rejects_relative_local_path_without_absolute
         module.resolve_model_snapshot("models/checkpoint", source="local")
     with pytest.raises(ValueError, match="source_root must be an absolute path"):
         module.resolve_model_snapshot("models/checkpoint", source="local", source_root="source")
+
+
+def test_huggingface_model_resolver_rejects_source_root_with_absolute_local_path(tmp_path):
+    module = _load_module(HF_SCRIPTS / "resolve_model_snapshot.py")
+    source_root = tmp_path / "source"
+    model_dir = source_root / "models" / "checkpoint"
+    model_dir.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="source_root can only be used with a relative local identifier"):
+        module.resolve_model_snapshot(str(model_dir), source="local", source_root=str(source_root))
 
 
 def test_huggingface_model_resolver_does_not_treat_existing_hub_id_as_local(monkeypatch, tmp_path):
@@ -303,8 +337,9 @@ def test_cyclic_parameterized_model_config_exports_normalized_path(tmp_path):
     server_config = json.loads(
         (export_root / recipe.name / "app" / "config" / "config_fed_server.json").read_text(encoding="utf-8")
     )
-    persistor = next(component for component in server_config["components"] if component["id"] == "persistor")
+    persistor = next((component for component in server_config["components"] if component["id"] == "persistor"), None)
 
+    assert persistor is not None, f"persistor missing from server components: {server_config['components']!r}"
     assert persistor["args"]["model"] == {
         "path": "torch.nn.Linear",
         "args": {"in_features": 2, "out_features": 1},

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -731,9 +731,9 @@ def test_all_conversion_skills_preserve_required_model_constructor_args():
     assert "recipe construction alone does not prove serialization" in validation_text
 
     converter_expectations = {
-        "nvflare-convert-pytorch": "a direct `torch.nn.Module` is allowed only when unchanged zero-argument defaults",
-        "nvflare-convert-lightning": "a direct `LightningModule` is allowed only when unchanged zero-argument defaults",
-        "nvflare-convert-huggingface": "Use explicit `class_path`/`args` for required or overridden constructor values",
+        "nvflare-convert-pytorch": "selected recipe's documented `class_path` or `path` key plus complete `args`",
+        "nvflare-convert-lightning": "recipe-documented `class_path` or `path` key plus complete `args`",
+        "nvflare-convert-huggingface": "recipe's documented `class_path` or `path` key plus complete `args`",
     }
     for converter, expectation in converter_expectations.items():
         skill_text = " ".join(repo_root.joinpath(f"skills/{converter}/SKILL.md").read_text(encoding="utf-8").split())

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1168,10 +1168,14 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "the patched callback owns delivery" in normalized_lightning
     assert "`False` makes them optional rather than suppressing metrics" in normalized_lightning
     assert "Do not copy validation metrics into `model.__fl_meta__[MetaKey.INITIAL_METRICS]`" in normalized_lightning
-    assert "recomputing it before the round loop does not keep it local" in normalized_lightning
+    assert "`exclude_vars` argument is only an aggregation rule" in normalized_lightning
+    assert 'recipe.add_server_output_filter(ExcludeVars([local_key]), tasks=["train"])' in normalized_lightning
+    assert 'recipe.add_client_output_filter(ExcludeVars([local_key]), tasks=["train"])' in normalized_lightning
     assert "`flare.patch(trainer, load_state_dict_strict=False)`" in normalized_lightning
-    assert "verify that no other state keys are missing or mismatched" in normalized_lightning
-    assert "ask or fail closed instead of silently exchanging the value" in normalized_lightning
+    assert "Non-strict loading does not suppress outbound state by itself" in normalized_lightning
+    assert "including the initial and later server-to-client payloads" in normalized_lightning
+    assert "not overwritten in the first or later rounds" in normalized_lightning
+    assert "ask or fail closed" in normalized_lightning
     phase_markers = [
         "Inspect before editing",
         "Apply the dependency-install ordering rule",

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -476,6 +476,10 @@ def test_lightning_conversion_limits_reference_loading_and_full_run_validation()
     assert len(site_data_text) < len(workflow_text)
 
     assert "select and record exactly one final validation target" in normalized_skill
+    assert "do not import `Recipe` from `nvflare.recipe`" in normalized_skill
+    assert "inspect or call `nvflare.recipe.run`" in normalized_skill
+    assert "or probe `export`, `run`, or lifecycle APIs" in normalized_skill
+    assert "Call `recipe.execute(SimEnv(...))`" in normalized_skill
     assert "do not export or run the exported simulator afterward" in normalized_skill
     assert "do not first run `python job.py`" in normalized_skill
     assert "rerun that same target" in normalized_skill
@@ -495,6 +499,7 @@ def test_lightning_conversion_limits_reference_loading_and_full_run_validation()
         "no-duplicate-full-validation",
         "no-compound-cleanup-and-execution",
         "no-unused-download-dependency-probe",
+        "no-recipe-lifecycle-probes",
     } <= prohibited_ids
 
 

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -463,12 +463,13 @@ def test_lightning_conversion_limits_reference_loading_and_full_run_validation()
         "Apply the dependency-install ordering rule",
         "Reuse the PyTorch recipe family",
         "Convert the training entry point",
-        "Only after generated files exist",
+        "Immediately after generated files exist",
         "Report the recipe",
     ]
     phase_positions = [skill_text.index(marker) for marker in phase_markers]
     assert phase_positions == sorted(phase_positions)
     assert "Complete each workflow phase before loading the next phase's reference" in normalized_skill
+    assert "before any preflight, smoke test, cleanup, validation, or execution command" in normalized_skill
     assert "Do not enumerate reference directories or preload validation" in normalized_skill
     assert "do not load the broad `conversion-workflow.md` for these standard concerns" in normalized_common
     assert "Do not reconstruct that focused contract from this broad workflow reference" in normalized_workflow
@@ -720,14 +721,26 @@ def test_shared_conversion_uses_one_simulator_topology_owner():
         references.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
     )
     workflow_text = " ".join(references.joinpath("conversion-workflow.md").read_text(encoding="utf-8").split())
+    hf_conversion_text = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-huggingface/references/huggingface-conversion.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
 
     assert "Use exactly one owner for the simulated client topology" in common_text
     assert "Do not call `set_per_site_config()` merely to assign partition indices" in common_text
-    assert "`SimEnv(clients=list(config), ...)`, never `SimEnv(num_clients=...)`" in common_text
-    assert "not a condition to recover from by setting `num_clients=None`" in common_text
-    assert "generate site partitions from `flare.get_site_name()` after `flare.init()`" in construction_text
-    assert "`SimEnv(clients=list(per_site_config), num_threads=len(per_site_config), ...)`" in construction_text
-    assert "This unified-app form is valid only while the recipe has no explicit named client targets" in workflow_text
+    assert "`clients` remains the topology owner" in common_text
+    assert "`SimEnv` rejects an inconsistent count" in common_text
+    assert "do not recover from a mismatch by setting `num_clients=None`" in common_text
+    assert "derive the site index from `flare.get_site_name()` after `flare.init()`" in construction_text
+    assert "single-topology-owner rule in `conversion-common.md`" in construction_text
+    assert "canonical single-topology-owner rule in the always-loaded common conversion reference" in workflow_text
+    assert (
+        "single-topology-owner rule from `../../nvflare-shared/references/conversion-common.md`" in hf_conversion_text
+    )
+    assert "clients=list(" not in construction_text
+    assert "clients=list(" not in workflow_text
+    assert "clients=list(" not in hf_conversion_text
 
     for framework in ("pytorch", "lightning", "huggingface"):
         eval_data = json.loads(
@@ -845,6 +858,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
         (repo_root / "skills" / "nvflare-convert-huggingface" / "evals" / "evals.json").read_text(encoding="utf-8")
     )
     basic_eval = _eval_by_id(eval_data, "huggingface-convert-basic")["nvflare"]
+    offline_eval = _eval_by_id(eval_data, "huggingface-offline-model-cache-miss")
     mandatory_ids = {item["id"] for item in basic_eval["mandatory_behavior"]}
     prohibited_ids = {item["id"] for item in basic_eval["prohibited_behavior"]}
     normalized_hf_validation = " ".join(hf_validation.split())
@@ -853,16 +867,24 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "make the inventory command exit zero" in " ".join(dependency_text.split())
     assert "optional capability or host-diagnostic utility as evidence" in " ".join(validation_text.split())
     assert "Do not append platform-specific utilities" in " ".join(validation_text.split())
-    assert "rerun the Hub resolver once with the complete canonical invocation" in normalized_hf_validation
+    assert "rerun its resolver once with the matching canonical invocation" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
     assert "`--source local`" in hf_validation
     assert "`--source hub`" in hf_validation
     assert "<skill-dir>/scripts/resolve_model_snapshot.py --source local --source-root" in hf_validation
     assert "<skill-dir>/scripts/resolve_model_snapshot.py --source hub <org/model>" in hf_validation
+    assert "--source hub --repo-type dataset <org/dataset>" in hf_validation
     assert "--source hub --allow-download <org/model>" in hf_validation
+    assert "--source hub --repo-type dataset --allow-download <org/dataset>" in hf_validation
+    assert "specific public Hub artifact" in normalized_hf_validation
+    assert "pass `resolved_path` only to a source-compatible local dataset loader" in normalized_hf_validation
+    assert "ask or fail closed rather than inventing a loader" in normalized_hf_validation
     assert "do not invent a `--model` option" in normalized_hf_validation
     assert "full immutable 40-character commit SHA" in normalized_hf_validation
     assert "`HfApi().model_info(...).sha`" in normalized_hf_validation
+    assert "`HfApi().dataset_info(...).sha`" in normalized_hf_validation
+    assert "that URL alone is not evidence that a network request was attempted" in normalized_hf_validation
+    assert any("mentioning huggingface.co can mean a local cache miss" in item for item in offline_eval["assertions"])
     assert "emits a structured `missing` result" in normalized_hf_validation
     assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
     assert "snapshot_download" not in hf_job_asset
@@ -893,11 +915,15 @@ def test_orientation_routes_only_unresolved_explicit_conversions():
         (repo_root / "skills" / "nvflare-convert-huggingface" / "evals" / "evals.json").read_text(encoding="utf-8")
     )
     generic_conversion = _eval_by_id(hf_eval_data, "huggingface-convert-basic")
+    pytorch_frontmatter = repo_root.joinpath("skills/nvflare-convert-pytorch/SKILL.md").read_text(encoding="utf-8")
+    lightning_frontmatter = repo_root.joinpath("skills/nvflare-convert-lightning/SKILL.md").read_text(encoding="utf-8")
 
     assert "Do not load orientation to perform the preliminary inspection" in normalized_orient
     assert "run `nvflare agent inspect source <path> --format json` first" in normalized_orient
     assert "route directly to the one detected converter" in normalized_orient
     assert "ownership conflict or unresolved Trainer factory" in normalized_orient
+    assert "preliminary source inspection identifies one plain-PyTorch owner" in pytorch_frontmatter
+    assert "preliminary source inspection identifies one Lightning owner" in lightning_frontmatter
     assert "Hugging Face" not in generic_conversion["prompt"]
     assert generic_conversion["nvflare"]["expected_skill"] == "nvflare-convert-huggingface"
     prohibited_ids = {item["id"] for item in generic_conversion["nvflare"]["prohibited_behavior"]}

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1034,6 +1034,42 @@ def test_fedstats_reuses_named_sites_for_recipe_and_simulation():
         assert "SimEnv(clients=sites" in example_text
 
 
+def test_pytorch_family_validation_avoids_recovered_probe_failures():
+    repo_root = Path(__file__).resolve().parents[4]
+    shared_root = repo_root / "skills" / "nvflare-shared" / "references"
+    validation_text = " ".join(shared_root.joinpath("validation-evidence.md").read_text(encoding="utf-8").split())
+    construction_text = " ".join(
+        shared_root.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
+    )
+
+    assert "when the selected final target is an exported/deployable artifact" in validation_text
+    assert "do not create a separate throwaway export" in validation_text
+    assert "when the selected final target is a local `python job.py` simulation, do not export during preflight" in (
+        validation_text
+    )
+    assert "Build validation calls from inspected callable signatures and type annotations" in validation_text
+    assert "change only the failing assumption" in validation_text
+    assert "preserve prior guards, fallbacks, and already-correct arguments" in validation_text
+    assert "Never replace an optional-field guard with a hard-coded conventional name" in validation_text
+
+    assert "do not import or introspect a `Run` class" in construction_text
+    assert "probe its module location, signature, or docstring" in construction_text
+    assert "selected maintained asset or the public recipe documentation" in construction_text
+
+    pytorch_skill = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-pytorch/SKILL.md").read_text(encoding="utf-8").split()
+    )
+    lightning_skill = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-lightning/SKILL.md").read_text(encoding="utf-8").split()
+    )
+    hf_skill = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-huggingface/SKILL.md").read_text(encoding="utf-8").split()
+    )
+    assert "export and package inspection only for the selected exported-artifact path" in pytorch_skill
+    assert "Export inspection belongs only to the exported path" in lightning_skill
+    assert "Inspect export/package evidence only for an exported final target" in hf_skill
+
+
 def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys():
     repo_root = Path(__file__).resolve().parents[4]
     skill_root = repo_root / "skills" / "nvflare-convert-huggingface"

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -854,6 +854,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     hf_skill = hf_root.joinpath("SKILL.md").read_text(encoding="utf-8")
     hf_validation = hf_root.joinpath("references/huggingface-validation.md").read_text(encoding="utf-8")
     hf_job_asset = hf_root.joinpath("assets/job.py").read_text(encoding="utf-8")
+    hf_snapshot_resolver = hf_root.joinpath("scripts/resolve_model_snapshot.py").read_text(encoding="utf-8")
     eval_data = json.loads(
         (repo_root / "skills" / "nvflare-convert-huggingface" / "evals" / "evals.json").read_text(encoding="utf-8")
     )
@@ -888,6 +889,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "emits a structured `missing` result" in normalized_hf_validation
     assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
     assert "snapshot_download" not in hf_job_asset
+    assert "revision=revision" in hf_snapshot_resolver
     assert "classify checkpoint-loaded versus missing or newly initialized parameters" in normalized_hf_validation
     assert "proves value determinism only for parameters actually loaded from it" in normalized_hf_validation
     assert "do not require their independently initialized values to match" in normalized_hf_validation

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -859,9 +859,10 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "`--source hub`" in hf_validation
     assert "<skill-dir>/scripts/resolve_model_snapshot.py --source local --source-root" in hf_validation
     assert "<skill-dir>/scripts/resolve_model_snapshot.py --source hub <org/model>" in hf_validation
-    assert "--source hub --allow-download --revision <commit-sha> <org/model>" in hf_validation
+    assert "--source hub --allow-download <org/model>" in hf_validation
     assert "do not invent a `--model` option" in normalized_hf_validation
     assert "full immutable 40-character commit SHA" in normalized_hf_validation
+    assert "`HfApi().model_info(...).sha`" in normalized_hf_validation
     assert "emits a structured `missing` result" in normalized_hf_validation
     assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
     assert "snapshot_download" not in hf_job_asset
@@ -1042,6 +1043,16 @@ def test_pytorch_family_validation_avoids_recovered_probe_failures():
     construction_text = " ".join(
         shared_root.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
     )
+    pytorch_conversion = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-pytorch/references/pytorch-client-api-conversion.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+    hf_conversion = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-huggingface/references/huggingface-conversion.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
 
     assert "when the selected final target is an exported/deployable artifact" in validation_text
     assert "do not create a separate throwaway export" in validation_text
@@ -1058,6 +1069,13 @@ def test_pytorch_family_validation_avoids_recovered_probe_failures():
     assert "must not declare, parse, or branch on those arguments" in common_text
     assert "does not use `parse_known_args()` to accommodate system arguments" in common_text
     assert "Do not create an export only for this check" in common_text
+
+    assert "run `python job.py` and inspect its materialized simulation workspace" in pytorch_conversion
+    assert "only when the user requests an exported/deployable artifact" in pytorch_conversion
+    assert "Do not run both targets after one succeeds" in pytorch_conversion
+    assert "For a local `python job.py` target, do not export" in hf_conversion
+    assert "inspect the materialized simulation workspace" in hf_conversion
+    assert "For an exported-artifact target, exported app layout is owned by" in hf_conversion
 
     assert "do not import or introspect a `Run` class" in construction_text
     assert "probe its module location, signature, or docstring" in construction_text
@@ -1150,6 +1168,10 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "the patched callback owns delivery" in normalized_lightning
     assert "`False` makes them optional rather than suppressing metrics" in normalized_lightning
     assert "Do not copy validation metrics into `model.__fl_meta__[MetaKey.INITIAL_METRICS]`" in normalized_lightning
+    assert "recomputing it before the round loop does not keep it local" in normalized_lightning
+    assert "`flare.patch(trainer, load_state_dict_strict=False)`" in normalized_lightning
+    assert "verify that no other state keys are missing or mismatched" in normalized_lightning
+    assert "ask or fail closed instead of silently exchanging the value" in normalized_lightning
     phase_markers = [
         "Inspect before editing",
         "Apply the dependency-install ordering rule",
@@ -1180,7 +1202,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "client import is not enough when an export separates server and client apps" in normalized_conversion
     # Exported app layout is authored once in conversion-workflow.md; the HF reference
     # points at it and states only which files the job asset must package.
-    assert "Exported app layout is owned by" in normalized_conversion
+    assert "For an exported-artifact target, exported app layout is owned by" in normalized_conversion
     assert "inspect the exported job root and enumerate the app directories" in normalized_conversion
     assert "`app/custom` for a unified export" in normalized_conversion
     assert "`app_server/custom` and each `app_<site>/custom`" in normalized_conversion
@@ -1287,6 +1309,11 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "Run intentional rejection checks" in normalized_shared_validation
     assert "through an assertion wrapper" in normalized_shared_validation
     assert "expected child failure as a failed top-level validation command" in normalized_shared_validation
+    assert 'Do not append `; echo "EXIT_CODE=$?"`' in normalized_shared_validation
+    assert '`rc=$?; echo "EXIT_CODE=$rc"; exit "$rc"`' in normalized_shared_validation
+    assert "Keep custom checks atomic" in normalized_shared_validation
+    assert "do not combine partition, model-compatibility, metric, and artifact checks" in normalized_shared_validation
+    assert "After the selected final run succeeds" in normalized_shared_validation
     assert "shared assertion-wrapper rule" in normalized_validation
     assert "typo and abbreviation rejection cases" in normalized_validation
     assert "explicit non-client entry parameter" in normalized_validation

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1088,6 +1088,11 @@ def test_pytorch_family_validation_avoids_recovered_probe_failures():
         validation_text
     )
     assert "Build validation calls from inspected callable signatures and type annotations" in validation_text
+    assert "When a helper parameter is annotated as `Path`, instantiate and pass `Path(...)`" in validation_text
+    assert "normalize generated columns to the source schema before using `DataFrame.equals()`" in validation_text
+    assert "a dtype-only difference is not a coverage failure" in validation_text
+    assert "copy the complete local import closure" in validation_text
+    assert "do not copy only selected entry-point scripts" in validation_text
     assert "change only the failing assumption" in validation_text
     assert "preserve prior guards, fallbacks, and already-correct arguments" in validation_text
     assert "Never replace an optional-field guard with a hard-coded conventional name" in validation_text

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -752,6 +752,16 @@ def test_all_conversion_skills_preserve_required_model_constructor_args():
         assert "exported server config retains" in mandatory[behavior_id]
 
 
+def test_huggingface_hello_world_prompt_authorizes_required_public_artifact_downloads():
+    repo_root = Path(__file__).resolve().parents[4]
+    readme = repo_root / "examples" / "hello-world" / "agent-skills" / "huggingface-conversion" / "README.md"
+    normalized = " ".join(readme.read_text(encoding="utf-8").split())
+
+    assert "You may download any required public model, tokenizer, and configuration artifacts" in normalized
+    assert "if they are not already cached" in normalized
+    assert "Proceed without asking for additional confirmation" in normalized
+
+
 def test_skills_readme_frontmatter_example_includes_required_author():
     readme = (Path(__file__).resolve().parents[4] / "skills" / "README.md").read_text(encoding="utf-8")
     normalized = " ".join(readme.split())

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -712,6 +712,34 @@ def test_shared_conversion_policies_have_single_canonical_owners():
     assert "## Source Trust Boundary" not in workflow_text
 
 
+def test_shared_conversion_uses_one_simulator_topology_owner():
+    repo_root = Path(__file__).resolve().parents[4]
+    references = repo_root / "skills" / "nvflare-shared" / "references"
+    common_text = " ".join(references.joinpath("conversion-common.md").read_text(encoding="utf-8").split())
+    construction_text = " ".join(
+        references.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
+    )
+    workflow_text = " ".join(references.joinpath("conversion-workflow.md").read_text(encoding="utf-8").split())
+
+    assert "Use exactly one owner for the simulated client topology" in common_text
+    assert "Do not call `set_per_site_config()` merely to assign partition indices" in common_text
+    assert "`SimEnv(clients=list(config), ...)`, never `SimEnv(num_clients=...)`" in common_text
+    assert "not a condition to recover from by setting `num_clients=None`" in common_text
+    assert "generate site partitions from `flare.get_site_name()` after `flare.init()`" in construction_text
+    assert "`SimEnv(clients=list(per_site_config), num_threads=len(per_site_config), ...)`" in construction_text
+    assert "This unified-app form is valid only while the recipe has no explicit named client targets" in workflow_text
+
+    for framework in ("pytorch", "lightning", "huggingface"):
+        eval_data = json.loads(
+            repo_root.joinpath(f"skills/nvflare-convert-{framework}/evals/evals.json").read_text(encoding="utf-8")
+        )
+        basic_eval = _eval_by_id(eval_data, f"{framework}-convert-basic")["nvflare"]
+        mandatory_ids = {item["id"] for item in basic_eval["mandatory_behavior"]}
+        prohibited_ids = {item["id"] for item in basic_eval["prohibited_behavior"]}
+        assert "single-simulator-topology-owner" in mandatory_ids
+        assert "no-mixed-named-and-generated-client-topology" in prohibited_ids
+
+
 def test_all_conversion_skills_preserve_required_model_constructor_args():
     repo_root = Path(__file__).resolve().parents[4]
     references = repo_root / "skills" / "nvflare-shared" / "references"
@@ -821,10 +849,14 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "make the inventory command exit zero" in " ".join(dependency_text.split())
     assert "optional capability or host-diagnostic utility as evidence" in " ".join(validation_text.split())
     assert "Do not append platform-specific utilities" in " ".join(validation_text.split())
-    assert "rerun the Hub resolver once with `--allow-download --revision <commit-sha>`" in normalized_hf_validation
+    assert "rerun the Hub resolver once with the complete canonical invocation" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
     assert "`--source local`" in hf_validation
     assert "`--source hub`" in hf_validation
+    assert "<skill-dir>/scripts/resolve_model_snapshot.py --source local --source-root" in hf_validation
+    assert "<skill-dir>/scripts/resolve_model_snapshot.py --source hub <org/model>" in hf_validation
+    assert "--source hub --allow-download --revision <commit-sha> <org/model>" in hf_validation
+    assert "do not invent a `--model` option" in normalized_hf_validation
     assert "full immutable 40-character commit SHA" in normalized_hf_validation
     assert "emits a structured `missing` result" in normalized_hf_validation
     assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
@@ -840,6 +872,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert {
         "no-raising-cache-only-model-probe",
         "no-ambiguous-model-source",
+        "no-invented-resolver-model-option",
         "no-unpinned-hub-download",
         "no-unguarded-platform-specific-diagnostic",
         "no-unconditional-equality-for-newly-initialized-parameters",
@@ -856,8 +889,9 @@ def test_orientation_routes_only_unresolved_explicit_conversions():
     )
     generic_conversion = _eval_by_id(hf_eval_data, "huggingface-convert-basic")
 
-    assert "Do not use orientation merely because an explicit conversion omits its framework" in normalized_orient
-    assert "preliminary inspection identifies one training owner" in normalized_orient
+    assert "Do not load orientation to perform the preliminary inspection" in normalized_orient
+    assert "run `nvflare agent inspect source <path> --format json` first" in normalized_orient
+    assert "route directly to the one detected converter" in normalized_orient
     assert "ownership conflict or unresolved Trainer factory" in normalized_orient
     assert "Hugging Face" not in generic_conversion["prompt"]
     assert generic_conversion["nvflare"]["expected_skill"] == "nvflare-convert-huggingface"

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -476,9 +476,9 @@ def test_lightning_conversion_limits_reference_loading_and_full_run_validation()
     assert len(site_data_text) < len(workflow_text)
 
     assert "select and record exactly one final validation target" in normalized_skill
-    assert "do not import `Recipe` from `nvflare.recipe`" in normalized_skill
-    assert "inspect or call `nvflare.recipe.run`" in normalized_skill
-    assert "or probe `export`, `run`, or lifecycle APIs" in normalized_skill
+    assert "do not run exploratory NVFLARE imports" in normalized_skill
+    assert "`inspect`, `hasattr`, constant discovery" in normalized_skill
+    assert "report a skill gap or fail closed instead of guessing" in normalized_skill
     assert "Call `recipe.execute(SimEnv(...))`" in normalized_skill
     assert "do not export or run the exported simulator afterward" in normalized_skill
     assert "do not first run `python job.py`" in normalized_skill

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1276,6 +1276,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "must import the Recipe API before parsing its own options" in normalized_common
     assert "`argparse.ArgumentParser(allow_abbrev=False)`" in normalized_common
     assert "does not use `parse_known_args()`" in normalized_common
+    assert "Unknown and abbreviated local options must fail" in normalized_common
     assert "`ArgumentParser(allow_abbrev=False)`" in normalized_skill
     assert "strict `parse_args()`; do not use `parse_known_args()`" in normalized_skill
     assert "`recipe show` validates only the selected recipe's module, class" in normalized_recipe

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -780,14 +780,18 @@ def test_all_conversion_skills_preserve_required_model_constructor_args():
         assert "exported server config retains" in mandatory[behavior_id]
 
 
-def test_huggingface_hello_world_prompt_authorizes_required_public_artifact_downloads():
+def test_conversion_hello_world_prompts_authorize_required_public_model_artifacts():
     repo_root = Path(__file__).resolve().parents[4]
-    readme = repo_root / "examples" / "hello-world" / "agent-skills" / "huggingface-conversion" / "README.md"
-    normalized = " ".join(readme.read_text(encoding="utf-8").split())
+    examples_root = repo_root / "examples" / "hello-world" / "agent-skills"
 
-    assert "You may download any required public model, tokenizer, and configuration artifacts" in normalized
-    assert "if they are not already cached" in normalized
-    assert "Proceed without asking for additional confirmation" in normalized
+    for example_name in ("pytorch-conversion", "lightning-conversion", "huggingface-conversion"):
+        readme = examples_root / example_name / "README.md"
+        normalized = " ".join(readme.read_text(encoding="utf-8").split())
+
+        assert "You may download any required public model artifacts" in normalized
+        assert "including tokenizer and configuration files" in normalized
+        assert "if they are not already cached" in normalized
+        assert "Proceed without asking for additional confirmation" in normalized
 
 
 def test_skills_readme_frontmatter_example_includes_required_author():

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -712,6 +712,46 @@ def test_shared_conversion_policies_have_single_canonical_owners():
     assert "## Source Trust Boundary" not in workflow_text
 
 
+def test_all_conversion_skills_preserve_required_model_constructor_args():
+    repo_root = Path(__file__).resolve().parents[4]
+    references = repo_root / "skills" / "nvflare-shared" / "references"
+    common_text = " ".join(references.joinpath("conversion-common.md").read_text(encoding="utf-8").split())
+    workflow_text = " ".join(references.joinpath("conversion-workflow.md").read_text(encoding="utf-8").split())
+    validation_text = " ".join(references.joinpath("validation-evidence.md").read_text(encoding="utf-8").split())
+
+    assert "## Model Constructor Serialization" in references.joinpath("conversion-common.md").read_text(
+        encoding="utf-8"
+    )
+    assert "including a required parameter or an overridden default" in common_text
+    assert "Never use a live model instance to carry those values" in common_text
+    assert "zero-argument construction with unchanged defaults" in common_text
+    assert "retains the audited class path and every constructor argument" in common_text
+    assert "Never use a live instance to carry required or overridden constructor values" in workflow_text
+    assert "model=MyModel(num_classes=10)" not in workflow_text
+    assert "recipe construction alone does not prove serialization" in validation_text
+
+    converter_expectations = {
+        "nvflare-convert-pytorch": "a direct `torch.nn.Module` is allowed only when unchanged zero-argument defaults",
+        "nvflare-convert-lightning": "a direct `LightningModule` is allowed only when unchanged zero-argument defaults",
+        "nvflare-convert-huggingface": "Use explicit `class_path`/`args` for required or overridden constructor values",
+    }
+    for converter, expectation in converter_expectations.items():
+        skill_text = " ".join(repo_root.joinpath(f"skills/{converter}/SKILL.md").read_text(encoding="utf-8").split())
+        assert expectation in skill_text
+
+    eval_expectations = {
+        "nvflare-convert-pytorch": ("pytorch-convert-basic", "explicit-model-config-with-args"),
+        "nvflare-convert-lightning": ("lightning-convert-basic", "explicit-model-config-with-args"),
+        "nvflare-convert-huggingface": ("huggingface-convert-basic", "explicit-server-model-config"),
+    }
+    for converter, (eval_id, behavior_id) in eval_expectations.items():
+        eval_data = json.loads(repo_root.joinpath(f"skills/{converter}/evals/evals.json").read_text(encoding="utf-8"))
+        mandatory = {
+            item["id"]: item["description"] for item in _eval_by_id(eval_data, eval_id)["nvflare"]["mandatory_behavior"]
+        }
+        assert "exported server config retains" in mandatory[behavior_id]
+
+
 def test_skills_readme_frontmatter_example_includes_required_author():
     readme = (Path(__file__).resolve().parents[4] / "skills" / "README.md").read_text(encoding="utf-8")
     normalized = " ".join(readme.split())
@@ -771,8 +811,11 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "make the inventory command exit zero" in " ".join(dependency_text.split())
     assert "optional capability or host-diagnostic utility as evidence" in " ".join(validation_text.split())
     assert "Do not append platform-specific utilities" in " ".join(validation_text.split())
-    assert "rerun the resolver once with `--allow-download`" in normalized_hf_validation
+    assert "rerun the Hub resolver once with `--allow-download --revision <commit-sha>`" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
+    assert "`--source local`" in hf_validation
+    assert "`--source hub`" in hf_validation
+    assert "full immutable 40-character commit SHA" in normalized_hf_validation
     assert "emits a structured `missing` result" in normalized_hf_validation
     assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
     assert "snapshot_download" not in hf_job_asset
@@ -786,6 +829,8 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert {"cache-aware-authorized-model-resolution", "numeric-primary-metric-reporting"} <= mandatory_ids
     assert {
         "no-raising-cache-only-model-probe",
+        "no-ambiguous-model-source",
+        "no-unpinned-hub-download",
         "no-unguarded-platform-specific-diagnostic",
         "no-unconditional-equality-for-newly-initialized-parameters",
         "no-orient-for-single-owner-conversion",

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -758,6 +758,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     hf_root = repo_root / "skills" / "nvflare-convert-huggingface"
     hf_skill = hf_root.joinpath("SKILL.md").read_text(encoding="utf-8")
     hf_validation = hf_root.joinpath("references/huggingface-validation.md").read_text(encoding="utf-8")
+    hf_job_asset = hf_root.joinpath("assets/job.py").read_text(encoding="utf-8")
     eval_data = json.loads(
         (repo_root / "skills" / "nvflare-convert-huggingface" / "evals" / "evals.json").read_text(encoding="utf-8")
     )
@@ -770,8 +771,11 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "make the inventory command exit zero" in " ".join(dependency_text.split())
     assert "optional capability or host-diagnostic utility as evidence" in " ".join(validation_text.split())
     assert "Do not append platform-specific utilities" in " ".join(validation_text.split())
-    assert "invoke the selected library's normal cache-aware load or download once" in " ".join(hf_validation.split())
-    assert "`snapshot_download(..., local_files_only=True)`" in hf_validation
+    assert "rerun the resolver once with `--allow-download`" in normalized_hf_validation
+    assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
+    assert "emits a structured `missing` result" in normalized_hf_validation
+    assert "copy resolver logic into generated `job.py`" in normalized_hf_validation
+    assert "snapshot_download" not in hf_job_asset
     assert "classify checkpoint-loaded versus missing or newly initialized parameters" in normalized_hf_validation
     assert "proves value determinism only for parameters actually loaded from it" in normalized_hf_validation
     assert "do not require their independently initialized values to match" in normalized_hf_validation
@@ -784,7 +788,26 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
         "no-raising-cache-only-model-probe",
         "no-unguarded-platform-specific-diagnostic",
         "no-unconditional-equality-for-newly-initialized-parameters",
+        "no-orient-for-single-owner-conversion",
     } <= prohibited_ids
+
+
+def test_orientation_routes_only_unresolved_explicit_conversions():
+    repo_root = Path(__file__).resolve().parents[4]
+    orient_text = repo_root.joinpath("skills/nvflare-orient/SKILL.md").read_text(encoding="utf-8")
+    normalized_orient = " ".join(orient_text.split())
+    hf_eval_data = json.loads(
+        (repo_root / "skills" / "nvflare-convert-huggingface" / "evals" / "evals.json").read_text(encoding="utf-8")
+    )
+    generic_conversion = _eval_by_id(hf_eval_data, "huggingface-convert-basic")
+
+    assert "Do not use orientation merely because an explicit conversion omits its framework" in normalized_orient
+    assert "preliminary inspection identifies one training owner" in normalized_orient
+    assert "ownership conflict or unresolved Trainer factory" in normalized_orient
+    assert "Hugging Face" not in generic_conversion["prompt"]
+    assert generic_conversion["nvflare"]["expected_skill"] == "nvflare-convert-huggingface"
+    prohibited_ids = {item["id"] for item in generic_conversion["nvflare"]["prohibited_behavior"]}
+    assert "no-orient-for-single-owner-conversion" in prohibited_ids
 
 
 def test_huggingface_train_only_model_selection_contract_is_explicit():

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1037,6 +1037,7 @@ def test_fedstats_reuses_named_sites_for_recipe_and_simulation():
 def test_pytorch_family_validation_avoids_recovered_probe_failures():
     repo_root = Path(__file__).resolve().parents[4]
     shared_root = repo_root / "skills" / "nvflare-shared" / "references"
+    common_text = " ".join(shared_root.joinpath("conversion-common.md").read_text(encoding="utf-8").split())
     validation_text = " ".join(shared_root.joinpath("validation-evidence.md").read_text(encoding="utf-8").split())
     construction_text = " ".join(
         shared_root.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
@@ -1051,6 +1052,12 @@ def test_pytorch_family_validation_avoids_recovered_probe_failures():
     assert "change only the failing assumption" in validation_text
     assert "preserve prior guards, fallbacks, and already-correct arguments" in validation_text
     assert "Never replace an optional-field guard with a hard-coded conventional name" in validation_text
+
+    assert "Recipe API materializes the job configuration needed by `SimEnv` behind the scenes" in common_text
+    assert "Only when the user requests an exported/deployable job folder" in common_text
+    assert "must not declare, parse, or branch on those arguments" in common_text
+    assert "does not use `parse_known_args()` to accommodate system arguments" in common_text
+    assert "Do not create an export only for this check" in common_text
 
     assert "do not import or introspect a `Run` class" in construction_text
     assert "probe its module location, signature, or docstring" in construction_text
@@ -1069,6 +1076,16 @@ def test_pytorch_family_validation_avoids_recovered_probe_failures():
     assert "Export inspection belongs only to the exported path" in lightning_skill
     assert "Inspect export/package evidence only for an exported final target" in hf_skill
 
+    for framework in ("pytorch", "lightning", "huggingface"):
+        eval_data = json.loads(
+            repo_root.joinpath(f"skills/nvflare-convert-{framework}/evals/evals.json").read_text(encoding="utf-8")
+        )
+        basic_eval = _eval_by_id(eval_data, f"{framework}-convert-basic")["nvflare"]
+        mandatory_ids = {item["id"] for item in basic_eval["mandatory_behavior"]}
+        prohibited_ids = {item["id"] for item in basic_eval["prohibited_behavior"]}
+        assert "single-final-validation-path" in mandatory_ids
+        assert {"no-unrequested-explicit-export", "no-generated-export-system-arguments"} <= prohibited_ids
+
 
 def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys():
     repo_root = Path(__file__).resolve().parents[4]
@@ -1078,6 +1095,9 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     validation_text = skill_root.joinpath("references/huggingface-validation.md").read_text(encoding="utf-8")
     state_text = skill_root.joinpath("references/huggingface-state-and-distributed.md").read_text(encoding="utf-8")
     shared_validation = repo_root.joinpath("skills/nvflare-shared/references/validation-evidence.md").read_text(
+        encoding="utf-8"
+    )
+    shared_common = repo_root.joinpath("skills/nvflare-shared/references/conversion-common.md").read_text(
         encoding="utf-8"
     )
     shared_workflow = repo_root.joinpath("skills/nvflare-shared/references/conversion-workflow.md").read_text(
@@ -1105,6 +1125,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     normalized_validation = " ".join(validation_text.split())
     normalized_state = " ".join(state_text.split())
     normalized_shared_validation = " ".join(shared_validation.split())
+    normalized_common = " ".join(shared_common.split())
     normalized_shared = " ".join(shared_workflow.split())
     normalized_pytorch = " ".join(pytorch_conversion.split())
     normalized_lightning = " ".join(lightning_conversion.split())
@@ -1245,17 +1266,16 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "make at most one expensive real-model retry" in normalized_validation
     assert "do not write one-off AST, class-loader, persistor, Recipe-source" in normalized_validation
     assert "`python job.py --export --export-dir <runtime-dir>/job_config`" in normalized_shared_validation
-    assert "Do not accept a generated job-local export alias such as `--export_only`" in normalized_shared_validation
+    assert "Do not accept generated job-local `--export` or `--export-dir` arguments" in normalized_shared_validation
     assert "report it as a generated-code violation" in normalized_shared_validation
     assert "not automatically as a POSIX shell command" in normalized_recipe
     assert "default in-process Client API executor" in normalized_recipe
     assert "Do not import or call internal command-splitting helpers" in normalized_recipe
     assert "Do not import internal class loader helpers" in normalized_recipe
-    assert "invent alternate export flags such as `--export_only`" in normalized_shared
-    assert "import the NVFLARE recipe API before local argument parsing" in normalized_shared
-    assert "`argparse.ArgumentParser(allow_abbrev=False)`" in normalized_shared
-    assert "`parse_known_args()` is not needed" in normalized_shared
-    assert "unknown and abbreviated options fail" in normalized_shared
+    assert "must not declare, parse, or branch on those arguments" in normalized_common
+    assert "must import the Recipe API before parsing its own options" in normalized_common
+    assert "`argparse.ArgumentParser(allow_abbrev=False)`" in normalized_common
+    assert "does not use `parse_known_args()`" in normalized_common
     assert "`ArgumentParser(allow_abbrev=False)`" in normalized_skill
     assert "strict `parse_args()`; do not use `parse_known_args()`" in normalized_skill
     assert "`recipe show` validates only the selected recipe's module, class" in normalized_recipe


### PR DESCRIPTION
## Summary

- harden Hugging Face model and dataset artifact resolution for offline caches and explicitly authorized downloads
- make PyTorch, Lightning, and Hugging Face conversion routing, model construction, topology ownership, export behavior, and validation consistent
- prevent generated jobs from redefining NVFLARE-reserved export arguments or losing audited model/site configuration during recovery
- tighten Lightning validation sequencing and persistent site-local state guidance
- add behavioral regression coverage for the conversion contracts

## Details

### Artifact resolution

- Add a maintained resolver for local artifacts and Hugging Face model or dataset repositories.
- Require callers to distinguish local paths from Hub IDs and resolve relative local paths against an explicit absolute source root.
- Report expected cache misses as structured exit-zero results.
- For authorized Hub downloads, resolve and validate a full commit SHA before calling `snapshot_download()`.
- Support older compatible `huggingface_hub` releases through the public `huggingface_hub.utils.LocalEntryNotFoundError` export.
- Keep documentation and evaluations aligned: a cache-only exception mentioning `huggingface.co` does not by itself prove network access.

### Conversion behavior

- Route directly to a single PyTorch-family converter when the user names the framework or preliminary inspection identifies one owner; retain `nvflare-orient` for unresolved or conflicting ownership.
- Preserve required and overridden constructor values through explicit `class_path`/`path` plus complete `args`; allow direct instances only when unchanged zero-argument defaults reconstruct the model.
- Centralize the single simulator-topology-owner contract in `conversion-common.md` and rely on `SimEnv` for named-client/count consistency and default thread handling.
- Make explicit export opt-in. Local `python job.py` validation uses the workspace materialized by Recipe/`SimEnv`; generated parsers must not declare or interpret reserved `--export` or `--export-dir` arguments.
- Select one final validation target and preserve inspected argument types, guards, fallbacks, and correct values during retries.
- Prevent the three observed partition-probe recoveries by preserving annotated `Path` values, normalizing CSV-reloaded frame dtypes before equality checks, and retaining complete local import closures in isolated checks.
- Prevent local Lightning conversions from probing unsupported `Recipe`, `nvflare.recipe.run`, export, run, or lifecycle APIs after `recipe show`; use the concrete recipe with `recipe.execute(SimEnv(...))`.
- Require Lightning to load both validation references immediately after file generation and before any preflight, smoke test, cleanup, validation, or execution command.
- Clarify that persistent Lightning site-local state requires supported filters in both network directions; aggregation-only `exclude_vars` is insufficient.

## Validation

- `python3 -m pytest tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py tests/unit_test/tool/agent_skill_checks/seed_skills_test.py -q --deselect tests/unit_test/tool/agent_skill_checks/seed_skills_test.py::test_pytorch_recipe_capability_profiles_match_tensor_disk_offload_support` — 147 passed, 1 skipped, 1 deselected; the deselected XGBoost catalog test requires unavailable local `libomp`
- focused resolver, routing, simulator-topology, validation-recovery, and Lightning bidirectional-filter regression tests passed
- `python3 dev_tools/agent/skills/checks/cli.py --skills-root skills` — 0 findings
- Bandit B615 against the resolver — passed
- `./runtest.sh -s` — Black, isort, Flake8, and agent-skill lint passed
- pre-push agent-skill lint passed

## Review follow-up

- Addresses the unpinned `snapshot_download()` finding by passing the validated immutable revision through an explicit `revision=` keyword visible to static analysis.
- Addresses caller-working-directory ambiguity through the explicit source-root contract and fresh-working-directory coverage.
- Addresses the Lightning site-local-state finding with bidirectional filtering guidance and two-round regression coverage.
- Addresses the dataset-repository, offline-eval, routing-symmetry, validation-sequencing, topology-duplication, and `SimEnv` helper findings.
- Addresses the two-machine Lightning validation recoveries without changing Lightning workflow or dataset behavior.
