### PR TITLE
Avoid optional framework imports in recipe CLI metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include versioneer.py
 include nvflare/_version.py
 include nvflare/libs/*.so
 include nvflare/fuel/utils/*.json
+include nvflare/tool/recipe/recipe_catalog.json
 global-exclude *.py[co]
 global-exclude __pycache__
 recursive-include nvflare/lighter/templates *

--- a/nvflare/tool/recipe/generate_recipe_catalog.py
+++ b/nvflare/tool/recipe/generate_recipe_catalog.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+
+from nvflare.tool.recipe.recipe_cli import _RECIPE_CATALOG_PATH, _generate_recipe_catalog
+
+
+def _render_catalog() -> str:
+    return json.dumps(_generate_recipe_catalog(), indent=2) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate static NVFLARE recipe CLI metadata.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if the checked-in catalog differs from the recipe sources",
+    )
+    args = parser.parse_args()
+
+    rendered = _render_catalog()
+    if args.check:
+        existing = _RECIPE_CATALOG_PATH.read_text(encoding="utf-8") if _RECIPE_CATALOG_PATH.is_file() else ""
+        if existing != rendered:
+            parser.error(
+                "recipe catalog is stale; run "
+                "'python -m nvflare.tool.recipe.generate_recipe_catalog' and commit the result"
+            )
+        return
+
+    _RECIPE_CATALOG_PATH.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/nvflare/tool/recipe/recipe_catalog.json
+++ b/nvflare/tool/recipe/recipe_catalog.json
@@ -1,0 +1,4583 @@
+{
+  "schema_version": 1,
+  "recipes": [
+    {
+      "summary": {
+        "name": "cyclic",
+        "description": "Cyclic federated learning recipe for sequential model training across clients.",
+        "framework": "core",
+        "module": "nvflare.recipe.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "cyclic",
+        "description": "Cyclic federated learning recipe for sequential model training across clients.",
+        "framework": "core",
+        "module": "nvflare.recipe.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": false,
+            "default": 2
+          }
+        },
+        "framework_support": [
+          "pytorch",
+          "tensorflow",
+          "numpy",
+          "raw"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "cyclic",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_assignment_timeout",
+            "type": "int",
+            "required": false,
+            "default": 10,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "cyclic-pt",
+        "description": "PyTorch-specific cyclic federated learning recipe.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "cyclic-pt",
+        "description": "PyTorch-specific cyclic federated learning recipe.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": false,
+            "default": 2
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "cyclic",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "pytorch",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_assignment_timeout",
+            "type": "int",
+            "required": false,
+            "default": 10,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "cyclic-tf",
+        "description": "TensorFlow-specific cyclic federated learning recipe.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "cyclic-tf",
+        "description": "TensorFlow-specific cyclic federated learning recipe.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.cyclic",
+        "class": "CyclicRecipe",
+        "algorithm": "cyclic",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": false,
+            "default": 2
+          }
+        },
+        "framework_support": [
+          "tensorflow"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "cyclic",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "tensorflow",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_assignment_timeout",
+            "type": "int",
+            "required": false,
+            "default": 10,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install tensorflow"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fed-task",
+        "description": "A model-free recipe for running one federated task on participating clients.",
+        "framework": "core",
+        "module": "nvflare.recipe.fed_task",
+        "class": "FedTaskRecipe",
+        "algorithm": null,
+        "aggregation": null,
+        "state_exchange": null,
+        "privacy": []
+      },
+      "detail": {
+        "name": "fed-task",
+        "description": "A model-free recipe for running one federated task on participating clients.",
+        "framework": "core",
+        "module": "nvflare.recipe.fed_task",
+        "class": "FedTaskRecipe",
+        "algorithm": null,
+        "aggregation": null,
+        "state_exchange": null,
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": null,
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "framework_agnostic"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fed_task",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_name",
+            "type": "str",
+            "required": false,
+            "default": "task",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_clients",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_responses",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "timeout",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_data",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_meta",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "task_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "raw",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "raw",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg",
+        "description": "Unified FedAvg recipe for PyTorch, TensorFlow, and Scikit-learn.",
+        "framework": "core",
+        "module": "nvflare.recipe.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedavg",
+        "description": "Unified FedAvg recipe for PyTorch, TensorFlow, and Scikit-learn.",
+        "framework": "core",
+        "module": "nvflare.recipe.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch",
+          "tensorflow",
+          "sklearn",
+          "numpy",
+          "raw"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "pytorch",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_persistor",
+            "type": "Optional[ModelPersistor]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[Dict[str, Dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": 300.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Optional[Literal['min', 'max']]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "stop_cond",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "patience",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "save_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "exclude_vars",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregation_weights",
+            "type": "Optional[Dict[str, float]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg-he-pt",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) with Homomorphic Encryption.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedavg_he",
+        "class": "FedAvgRecipeWithHE",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [
+          "homomorphic_encryption"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption"
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch",
+          "pip install tenseal"
+        ]
+      },
+      "detail": {
+        "name": "fedavg-he-pt",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) with Homomorphic Encryption.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedavg_he",
+        "class": "FedAvgRecipeWithHE",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [
+          "homomorphic_encryption"
+        ],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption"
+        ],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedavg_he",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "encrypt_layers",
+            "type": "Optional[Union[List[str], str]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch",
+          "pip install tenseal"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg-numpy",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for NumPy-based models.",
+        "framework": "numpy",
+        "module": "nvflare.app_common.np.recipes.fedavg",
+        "class": "NumpyFedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "framework_support": [
+          "numpy",
+          "raw"
+        ]
+      },
+      "detail": {
+        "name": "fedavg-numpy",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for NumPy-based models.",
+        "framework": "numpy",
+        "module": "nvflare.app_common.np.recipes.fedavg",
+        "class": "NumpyFedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "numpy",
+          "raw"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_model",
+            "type": "Union[Any, Dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[Dict[str, Dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Optional[Literal['min', 'max']]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "stop_cond",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "patience",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "save_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "exclude_vars",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregation_weights",
+            "type": "Optional[Dict[str, float]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg-pt",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedavg-pt",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_persistor",
+            "type": "Optional[ModelPersistor]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_locator",
+            "type": "Optional[ModelLocator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": 300.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Optional[Literal['min', 'max']]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "stop_cond",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "patience",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "save_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "exclude_vars",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregation_weights",
+            "type": "Optional[dict[str, float]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg-sklearn",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.fedavg",
+        "class": "SklearnFedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedavg-sklearn",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.fedavg",
+        "class": "SklearnFedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "sklearn"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "sklearn_fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_params",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_path",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "DataKind",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Literal['min', 'max']",
+            "required": false,
+            "default": "max",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": 300.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[SKLEARN]",
+          "pip install scikit-learn"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedavg-tf",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedavg-tf",
+        "description": "A recipe for implementing Federated Averaging (FedAvg) for TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.fedavg",
+        "class": "FedAvgRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "tensorflow"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "framework",
+            "type": "FrameworkType",
+            "required": false,
+            "default": "tensorflow",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_persistor",
+            "type": "Optional[ModelPersistor]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": 300.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Literal['min', 'max']",
+            "required": false,
+            "default": "max",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "save_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install tensorflow"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedce-pt",
+        "description": "PyTorch federated training via client contribution estimation (FedCE).",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedce",
+        "class": "FedCERecipe",
+        "algorithm": "fedce",
+        "aggregation": "contribution_weighted_average",
+        "state_exchange": "weight_diff",
+        "privacy": [],
+        "heterogeneity_support": [
+          "non_iid",
+          "contribution_fairness"
+        ],
+        "notes": [
+          "Client scripts must return fedce_minus_val metadata; FedCE is not a passive FedAvg flag."
+        ]
+      },
+      "detail": {
+        "name": "fedce-pt",
+        "description": "PyTorch federated training via client contribution estimation (FedCE).",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedce",
+        "class": "FedCERecipe",
+        "algorithm": "fedce",
+        "aggregation": "contribution_weighted_average",
+        "state_exchange": "weight_diff",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "weight_diff",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "non_iid",
+          "contribution_fairness"
+        ],
+        "privacy_compatible": [],
+        "notes": [
+          "Client scripts must return fedce_minus_val metadata; FedCE is not a passive FedAvg flag."
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedce",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "fedce_mode",
+            "type": "str",
+            "required": false,
+            "default": "plus",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "trainable_param_names",
+            "type": "Optional[List[str]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "pytorch",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[Dict[str, Dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Optional[Literal['min', 'max']]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "stop_cond",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "patience",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedeval-pt",
+        "description": "A recipe for federated evaluation of a PyTorch model across multiple sites.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedeval",
+        "class": "FedEvalRecipe",
+        "algorithm": "fedeval",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedeval-pt",
+        "description": "A recipe for federated evaluation of a PyTorch model across multiple sites.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedeval",
+        "class": "FedEvalRecipe",
+        "algorithm": "fedeval",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "eval",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any]]",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "eval_ckpt",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "eval_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "eval_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "validation_timeout",
+            "type": "int",
+            "required": false,
+            "default": 6000,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[Dict[str, Dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedopt-pt",
+        "description": "A recipe for implementing Federated Optimization (FedOpt) in PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedopt",
+        "class": "FedOptRecipe",
+        "algorithm": "fedopt",
+        "aggregation": "server_optimizer",
+        "state_exchange": "weight_diff",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedopt-pt",
+        "description": "A recipe for implementing Federated Optimization (FedOpt) in PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedopt",
+        "class": "FedOptRecipe",
+        "algorithm": "fedopt",
+        "aggregation": "server_optimizer",
+        "state_exchange": "weight_diff",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "weight_diff",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedopt",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "device",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "source_model",
+            "type": "str",
+            "required": false,
+            "default": "model",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "optimizer_args",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "lr_scheduler_args",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedopt-tf",
+        "description": "A recipe for implementing Federated Optimization (FedOpt) in TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.fedopt",
+        "class": "FedOptRecipe",
+        "algorithm": "fedopt",
+        "aggregation": "server_optimizer",
+        "state_exchange": "weight_diff",
+        "privacy": []
+      },
+      "detail": {
+        "name": "fedopt-tf",
+        "description": "A recipe for implementing Federated Optimization (FedOpt) in TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.fedopt",
+        "class": "FedOptRecipe",
+        "algorithm": "fedopt",
+        "aggregation": "server_optimizer",
+        "state_exchange": "weight_diff",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "weight_diff",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "tensorflow"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedopt",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "optimizer_args",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "lr_scheduler_args",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install tensorflow"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedprox-pt",
+        "description": "A recipe for implementing FedProx with PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedprox",
+        "class": "FedProxRecipe",
+        "algorithm": "fedprox",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "heterogeneity_support": [
+          "non_iid"
+        ],
+        "notes": [
+          "Patched PyTorch Lightning clients apply FedProx automatically; raw PyTorch clients must consume FEDPROX_MU metadata and integrate PTFedProxLoss."
+        ]
+      },
+      "detail": {
+        "name": "fedprox-pt",
+        "description": "A recipe for implementing FedProx with PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.fedprox",
+        "class": "FedProxRecipe",
+        "algorithm": "fedprox",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "non_iid"
+        ],
+        "privacy_compatible": [],
+        "notes": [
+          "Patched PyTorch Lightning clients apply FedProx automatically; raw PyTorch clients must consume FEDPROX_MU metadata and integrate PTFedProxLoss."
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "fedprox",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator",
+            "type": "Optional[Aggregator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregator_data_kind",
+            "type": "Optional[DataKind]",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_persistor",
+            "type": "Optional[ModelPersistor]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_locator",
+            "type": "Optional[ModelLocator]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_once",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": 300.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "shutdown_timeout",
+            "type": "float",
+            "required": false,
+            "default": 0.0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "accuracy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Optional[Literal['min', 'max']]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "stop_cond",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "patience",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "best_model_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "save_filename",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "exclude_vars",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "aggregation_weights",
+            "type": "Optional[dict[str, float]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "fedprox_mu",
+            "type": "float",
+            "required": false,
+            "default": 0.01,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "fedstats",
+        "description": "A recipe for federated statistics computation.",
+        "framework": "core",
+        "module": "nvflare.recipe.fedstats",
+        "class": "FedStatsRecipe",
+        "algorithm": "fedstats",
+        "aggregation": null,
+        "state_exchange": null,
+        "privacy": [],
+        "framework_support": [
+          "framework_agnostic"
+        ],
+        "heterogeneity_support": [
+          "cross_site_statistics"
+        ]
+      },
+      "detail": {
+        "name": "fedstats",
+        "description": "A recipe for federated statistics computation.",
+        "framework": "core",
+        "module": "nvflare.recipe.fedstats",
+        "class": "FedStatsRecipe",
+        "algorithm": "fedstats",
+        "aggregation": null,
+        "state_exchange": null,
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": null,
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": true,
+          "sites": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "framework_agnostic"
+        ],
+        "heterogeneity_support": [
+          "cross_site_statistics"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "stats_output_path",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "sites",
+            "type": "List[str]",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "statistic_configs",
+            "type": "Dict[str, Any]",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "stats_generator",
+            "type": "Statistics",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_count",
+            "type": "int",
+            "required": false,
+            "default": 10,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_noise_level",
+            "type": "float",
+            "required": false,
+            "default": 0.1,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "max_noise_level",
+            "type": "float",
+            "required": false,
+            "default": 0.3,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "max_bins_percent",
+            "type": "float",
+            "required": false,
+            "default": 10,
+            "kind": "positional_or_keyword"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "kmeans-sklearn",
+        "description": "A recipe for Federated K-Means Clustering with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.kmeans",
+        "class": "KMeansFedAvgRecipe",
+        "algorithm": "kmeans",
+        "aggregation": "cluster_centers",
+        "state_exchange": "cluster_centers",
+        "privacy": []
+      },
+      "detail": {
+        "name": "kmeans-sklearn",
+        "description": "A recipe for Federated K-Means Clustering with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.kmeans",
+        "class": "KMeansFedAvgRecipe",
+        "algorithm": "kmeans",
+        "aggregation": "cluster_centers",
+        "state_exchange": "cluster_centers",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "cluster_centers",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "sklearn"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "kmeans_fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 5,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "n_clusters",
+            "type": "int",
+            "required": false,
+            "default": 3,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_path",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "metrics",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Literal['min', 'max']",
+            "required": false,
+            "default": "max",
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[SKLEARN]",
+          "pip install scikit-learn"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "lr",
+        "description": "A recipe for federated logistic regression.",
+        "framework": "numpy",
+        "module": "nvflare.app_common.np.recipes.lr.fedavg",
+        "class": "FedAvgLrRecipe",
+        "algorithm": "fedavg_logistic_regression",
+        "aggregation": "weighted_average",
+        "state_exchange": "model_weights",
+        "privacy": [],
+        "framework_support": [
+          "numpy",
+          "sklearn"
+        ]
+      },
+      "detail": {
+        "name": "lr",
+        "description": "A recipe for federated logistic regression.",
+        "framework": "numpy",
+        "module": "nvflare.app_common.np.recipes.lr.fedavg",
+        "class": "FedAvgLrRecipe",
+        "algorithm": "fedavg_logistic_regression",
+        "aggregation": "weighted_average",
+        "state_exchange": "model_weights",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "model_weights",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "numpy",
+          "sklearn"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "lr_fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "damping_factor",
+            "type": null,
+            "required": false,
+            "default": 0.8,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_features",
+            "type": null,
+            "required": false,
+            "default": 13,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": null,
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "scaffold-pt",
+        "description": "A recipe for implementing SCAFFOLD in PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.scaffold",
+        "class": "ScaffoldRecipe",
+        "algorithm": "scaffold",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "heterogeneity_support": [
+          "non_iid"
+        ]
+      },
+      "detail": {
+        "name": "scaffold-pt",
+        "description": "A recipe for implementing SCAFFOLD in PyTorch.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.scaffold",
+        "class": "ScaffoldRecipe",
+        "algorithm": "scaffold",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "non_iid"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "scaffold",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "scaffold-tf",
+        "description": "A recipe for implementing SCAFFOLD in TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.scaffold",
+        "class": "ScaffoldRecipe",
+        "algorithm": "scaffold",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "heterogeneity_support": [
+          "non_iid"
+        ]
+      },
+      "detail": {
+        "name": "scaffold-tf",
+        "description": "A recipe for implementing SCAFFOLD in TensorFlow.",
+        "framework": "tensorflow",
+        "module": "nvflare.app_opt.tf.recipes.scaffold",
+        "class": "ScaffoldRecipe",
+        "algorithm": "scaffold",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "tensorflow"
+        ],
+        "heterogeneity_support": [
+          "non_iid"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "scaffold",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, dict[str, Any], None]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_expected_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "TransferType",
+            "required": false,
+            "default": "FULL",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "server_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "client_memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 0,
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install tensorflow"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "svm-sklearn",
+        "description": "A recipe for Federated SVM with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.svm",
+        "class": "SVMFedAvgRecipe",
+        "algorithm": "svm",
+        "aggregation": "support_vectors",
+        "state_exchange": "support_vectors",
+        "privacy": []
+      },
+      "detail": {
+        "name": "svm-sklearn",
+        "description": "A recipe for Federated SVM with Scikit-learn.",
+        "framework": "sklearn",
+        "module": "nvflare.app_opt.sklearn.recipes.svm",
+        "class": "SVMFedAvgRecipe",
+        "algorithm": "svm",
+        "aggregation": "support_vectors",
+        "state_exchange": "support_vectors",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "support_vectors",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "sklearn"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": false,
+            "default": "svm_fedavg",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "kernel",
+            "type": "Literal['linear', 'poly', 'rbf', 'sigmoid']",
+            "required": false,
+            "default": "rbf",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "model_path",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "train_args",
+            "type": "str",
+            "required": false,
+            "default": "",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric",
+            "type": "str",
+            "required": false,
+            "default": "AUC",
+            "kind": "keyword_only"
+          },
+          {
+            "name": "key_metric_mode",
+            "type": "Literal['min', 'max']",
+            "required": false,
+            "default": "max",
+            "kind": "keyword_only"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[SKLEARN]",
+          "pip install scikit-learn"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "swarm-pt",
+        "description": "A simple recipe for Swarm Learning with PyTorch models.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.swarm",
+        "class": "SwarmLearningRecipe",
+        "algorithm": "swarm",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": []
+      },
+      "detail": {
+        "name": "swarm-pt",
+        "description": "A simple recipe for Swarm Learning with PyTorch models.",
+        "framework": "pytorch",
+        "module": "nvflare.app_opt.pt.recipes.swarm",
+        "class": "SwarmLearningRecipe",
+        "algorithm": "swarm",
+        "aggregation": null,
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "full_model",
+          "requires_training_script": true,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "pytorch"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "model",
+            "type": "Union[Any, Dict[str, Any]]",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "train_script",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "initial_ckpt",
+            "type": "Optional[str]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "train_args",
+            "type": "dict",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "do_cross_site_eval",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "cross_site_eval_timeout",
+            "type": "float",
+            "required": false,
+            "default": 300,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "launch_external_process",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "command",
+            "type": "str",
+            "required": false,
+            "default": "python3 -u",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "memory_gc_rounds",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "cuda_empty_cache",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "expected_data_kind",
+            "type": "str",
+            "required": false,
+            "default": "WEIGHTS",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "params_transfer_type",
+            "type": "str",
+            "required": false,
+            "default": "FULL",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "start_task_timeout",
+            "type": "float",
+            "required": false,
+            "default": 300,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "progress_timeout",
+            "type": "float",
+            "required": false,
+            "default": 3600,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "max_status_report_interval",
+            "type": "float",
+            "required": false,
+            "default": 300,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "round_timeout",
+            "type": "float",
+            "required": false,
+            "default": 3600,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "learn_task_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "max_concurrent_submissions",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "learn_task_abort_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "learn_task_ack_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "final_result_ack_timeout",
+            "type": "Optional[float]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "server_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "client_config_overrides",
+            "type": "Optional[Dict[str, Any]]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "aggregation_format",
+            "type": "ExchangeFormat",
+            "required": false,
+            "default": "numpy",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "enable_tensor_disk_offload",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install nvflare[PT]",
+          "pip install torch"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "xgb-bagging",
+        "description": "Tree-based federated XGBoost using bagging.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.bagging",
+        "class": "XGBBaggingRecipe",
+        "algorithm": "xgboost_bagging",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "heterogeneity_support": [
+          "horizontal"
+        ]
+      },
+      "detail": {
+        "name": "xgb-bagging",
+        "description": "Tree-based federated XGBoost using bagging.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.bagging",
+        "class": "XGBBaggingRecipe",
+        "algorithm": "xgboost_bagging",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "trees",
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "xgboost"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "training_mode",
+            "type": "str",
+            "required": false,
+            "default": "bagging",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_rounds",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_client_bagging",
+            "type": "Optional[int]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_local_parallel_tree",
+            "type": "int",
+            "required": false,
+            "default": 1,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "local_subsample",
+            "type": "float",
+            "required": false,
+            "default": 0.8,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "learning_rate",
+            "type": "float",
+            "required": false,
+            "default": 0.1,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "objective",
+            "type": "str",
+            "required": false,
+            "default": "binary:logistic",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "max_depth",
+            "type": "int",
+            "required": false,
+            "default": 8,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "eval_metric",
+            "type": "str",
+            "required": false,
+            "default": "auc",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "tree_method",
+            "type": "str",
+            "required": false,
+            "default": "hist",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "use_gpus",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "nthread",
+            "type": "int",
+            "required": false,
+            "default": 16,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "lr_mode",
+            "type": "str",
+            "required": false,
+            "default": "uniform",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "save_name",
+            "type": "str",
+            "required": false,
+            "default": "xgboost_model.json",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "data_loader_id",
+            "type": "str",
+            "required": false,
+            "default": "dataloader",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install xgboost"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "xgb-horizontal",
+        "description": "Histogram-based federated XGBoost for horizontal data partitioning.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.histogram",
+        "class": "XGBHorizontalRecipe",
+        "algorithm": "xgboost_horizontal",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption"
+        ]
+      },
+      "detail": {
+        "name": "xgb-horizontal",
+        "description": "Histogram-based federated XGBoost for horizontal data partitioning.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.histogram",
+        "class": "XGBHorizontalRecipe",
+        "algorithm": "xgboost_horizontal",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "trees",
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          },
+          "client_ranks": {
+            "required": false,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "xgboost"
+        ],
+        "heterogeneity_support": [
+          "horizontal"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption"
+        ],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "early_stopping_rounds",
+            "type": "int",
+            "required": false,
+            "default": 2,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "use_gpus",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "secure",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "client_ranks",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "xgb_params",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "data_loader_id",
+            "type": "str",
+            "required": false,
+            "default": "dataloader",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "metrics_writer_id",
+            "type": "str",
+            "required": false,
+            "default": "metrics_writer",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install xgboost"
+        ],
+        "template_references": []
+      }
+    },
+    {
+      "summary": {
+        "name": "xgb-vertical",
+        "description": "Federated XGBoost for vertical data partitioning.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.vertical",
+        "class": "XGBVerticalRecipe",
+        "algorithm": "xgboost_vertical",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "heterogeneity_support": [
+          "vertical"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption",
+          "private_set_intersection"
+        ]
+      },
+      "detail": {
+        "name": "xgb-vertical",
+        "description": "Federated XGBoost for vertical data partitioning.",
+        "framework": "xgboost",
+        "module": "nvflare.app_opt.xgboost.recipes.vertical",
+        "class": "XGBVerticalRecipe",
+        "algorithm": "xgboost_vertical",
+        "aggregation": "tree_ensemble",
+        "state_exchange": "trees",
+        "privacy": [],
+        "client_requirements": {
+          "state_exchange": "trees",
+          "requires_training_script": false,
+          "requires_per_site_config": false,
+          "requires_site_list": false,
+          "min_clients": {
+            "required": true,
+            "default": null
+          },
+          "label_owner": {
+            "required": true,
+            "default": null
+          },
+          "client_ranks": {
+            "required": false,
+            "default": null
+          }
+        },
+        "framework_support": [
+          "xgboost"
+        ],
+        "heterogeneity_support": [
+          "vertical"
+        ],
+        "privacy_compatible": [
+          "homomorphic_encryption",
+          "private_set_intersection"
+        ],
+        "notes": [],
+        "parameters": [
+          {
+            "name": "name",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "min_clients",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "num_rounds",
+            "type": "int",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "label_owner",
+            "type": "str",
+            "required": true,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "early_stopping_rounds",
+            "type": "int",
+            "required": false,
+            "default": 3,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "use_gpus",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "secure",
+            "type": "bool",
+            "required": false,
+            "default": false,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "client_ranks",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "xgb_params",
+            "type": "Optional[dict]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "data_loader_id",
+            "type": "str",
+            "required": false,
+            "default": "dataloader",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "metrics_writer_id",
+            "type": "str",
+            "required": false,
+            "default": "metrics_writer",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "in_process",
+            "type": "bool",
+            "required": false,
+            "default": true,
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "model_file_name",
+            "type": "str",
+            "required": false,
+            "default": "test.model.json",
+            "kind": "positional_or_keyword"
+          },
+          {
+            "name": "per_site_config",
+            "type": "Optional[dict[str, dict]]",
+            "required": false,
+            "default": null,
+            "kind": "positional_or_keyword"
+          }
+        ],
+        "optional_dependencies": [
+          "pip install xgboost"
+        ],
+        "template_references": []
+      }
+    }
+  ]
+}

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -34,6 +34,12 @@ _LIST_METADATA_KEYS = {"privacy"}
 _CATALOG_RECIPE_ATTRS_KEY = "_recipe_attrs"
 _RECIPE_CATALOG_PATH = Path(__file__).with_name("recipe_catalog.json")
 _RECIPE_CATALOG_SCHEMA_VERSION = 1
+_RECIPE_CORE_ATTR_ALIASES = {
+    "algorithm": ("recipe_algorithm", "algorithm"),
+    "aggregation": ("recipe_aggregation", "aggregation"),
+    "state_exchange": ("recipe_state_exchange", "state_exchange"),
+    "privacy": ("recipe_privacy", "privacy"),
+}
 _RECIPE_DETAIL_ATTR_ALIASES = {
     "framework_support": (
         "recipe_framework_support",
@@ -321,10 +327,12 @@ def _normalize_recipe_name(value: str) -> str:
 
 
 def _recipe_metadata_attr(metadata: dict, name: str, default=None):
+    metadata = metadata or {}
+    if name in metadata:
+        return metadata[name]
     for alias in _RECIPE_DETAIL_ATTR_ALIASES[name]:
-        value = (metadata or {}).get(alias)
-        if value is not None:
-            return value
+        if alias in metadata:
+            return metadata[alias]
     return default
 
 
@@ -561,18 +569,20 @@ def _static_class_attr(class_node: ast.ClassDef, *names):
     return None if unresolved else _STATIC_ATTR_MISSING
 
 
-def _static_recipe_attrs(module_name: str, class_name: str) -> dict:
+def _static_recipe_attrs(module_name: str, class_name: str, attr_aliases: dict = None) -> dict:
+    attr_aliases = _RECIPE_DETAIL_ATTR_ALIASES if attr_aliases is None else attr_aliases
     attrs = {}
-    for mro_module, mro_class in reversed(_static_class_mro(module_name, class_name)):
+    for mro_module, mro_class in _static_class_mro(module_name, class_name):
         _, _, class_node = _static_class_node(mro_module, mro_class)
         if class_node is None:
             continue
-        for aliases in _RECIPE_DETAIL_ATTR_ALIASES.values():
-            for name in aliases:
-                value = _static_class_attr(class_node, name)
-                if value is not _STATIC_ATTR_MISSING:
-                    attrs[name] = _json_safe_value(value)
-    return attrs
+        for name, aliases in attr_aliases.items():
+            if name in attrs:
+                continue
+            value = _static_class_attr(class_node, *aliases)
+            if value is not _STATIC_ATTR_MISSING:
+                attrs[name] = _json_safe_value(value)
+    return {name: attrs[name] for name in attr_aliases if name in attrs}
 
 
 def _infer_algorithm(cli_name: str, class_name: str, module_name: str) -> str:
@@ -641,19 +651,23 @@ def _infer_privacy(cli_name: str, class_name: str, module_name: str) -> list:
 
 
 def _static_recipe_metadata(cli_name: str, module_name: str, class_node: ast.ClassDef) -> dict:
-    algorithm = _static_class_attr(class_node, "recipe_algorithm", "algorithm")
-    if algorithm is _STATIC_ATTR_MISSING or not algorithm:
+    metadata = _static_recipe_attrs(module_name, class_node.name, _RECIPE_CORE_ATTR_ALIASES)
+    if "algorithm" in metadata:
+        algorithm = metadata["algorithm"]
+    else:
         algorithm = _infer_algorithm(cli_name, class_node.name, module_name)
-    aggregation = _static_class_attr(class_node, "recipe_aggregation", "aggregation")
-    if aggregation is _STATIC_ATTR_MISSING or not aggregation:
+    if "aggregation" in metadata:
+        aggregation = metadata["aggregation"]
+    else:
         aggregation = _infer_aggregation(algorithm)
-    state_exchange = _static_class_attr(class_node, "recipe_state_exchange", "state_exchange")
-    if state_exchange is _STATIC_ATTR_MISSING or not state_exchange:
+    if "state_exchange" in metadata:
+        state_exchange = metadata["state_exchange"]
+    else:
         state_exchange = _infer_state_exchange(algorithm)
-    privacy = _static_class_attr(class_node, "recipe_privacy", "privacy")
-    if privacy is _STATIC_ATTR_MISSING:
-        privacy = None
-    privacy = _as_string_list(privacy) or _infer_privacy(cli_name, class_node.name, module_name)
+    if "privacy" in metadata:
+        privacy = _as_string_list(metadata["privacy"])
+    else:
+        privacy = _infer_privacy(cli_name, class_node.name, module_name)
     return {
         "algorithm": _normalize_filter_value(algorithm) if algorithm else None,
         "aggregation": _normalize_filter_value(aggregation) if aggregation else None,

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -86,6 +86,12 @@ _CATALOG_DETAIL_STRING_LIST_FIELDS = (
     "optional_dependencies",
     "template_references",
 )
+_CATALOG_PARAMETER_REQUIRED_FIELDS = {
+    "name": str,
+    "type": (str, type(None)),
+    "required": bool,
+    "kind": str,
+}
 _CORE_FRAMEWORK_SUPPORT = {
     "cyclic": ["pytorch", "tensorflow", "numpy", "raw"],
     "fedavg": ["pytorch", "tensorflow", "sklearn", "numpy", "raw"],
@@ -999,6 +1005,10 @@ def _is_string_list(value) -> bool:
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 
+def _is_valid_catalog_parameter(parameter) -> bool:
+    return _has_required_field_types(parameter, _CATALOG_PARAMETER_REQUIRED_FIELDS) and "default" in parameter
+
+
 def _is_valid_catalog_entry(entry) -> bool:
     if not isinstance(entry, dict):
         return False
@@ -1012,7 +1022,7 @@ def _is_valid_catalog_entry(entry) -> bool:
         return False
     if any(not _is_string_list(detail[name]) for name in _CATALOG_DETAIL_STRING_LIST_FIELDS):
         return False
-    if any(not isinstance(parameter, dict) for parameter in detail["parameters"]):
+    if any(not _is_valid_catalog_parameter(parameter) for parameter in detail["parameters"]):
         return False
     return summary["name"] == detail["name"] and summary["framework"] == detail["framework"]
 

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -56,6 +56,36 @@ _RECIPE_DETAIL_ATTR_NAMES = (
     "recipe_template_references",
     "template_references",
 )
+_CATALOG_SUMMARY_REQUIRED_FIELDS = {
+    "name": str,
+    "description": str,
+    "framework": str,
+    "module": str,
+    "class": str,
+    "algorithm": (str, type(None)),
+    "aggregation": (str, type(None)),
+    "state_exchange": (str, type(None)),
+    "privacy": list,
+}
+_CATALOG_DETAIL_REQUIRED_FIELDS = {
+    **_CATALOG_SUMMARY_REQUIRED_FIELDS,
+    "client_requirements": dict,
+    "framework_support": list,
+    "heterogeneity_support": list,
+    "privacy_compatible": list,
+    "notes": list,
+    "parameters": list,
+    "optional_dependencies": list,
+    "template_references": list,
+}
+_CATALOG_DETAIL_STRING_LIST_FIELDS = (
+    "framework_support",
+    "heterogeneity_support",
+    "privacy_compatible",
+    "notes",
+    "optional_dependencies",
+    "template_references",
+)
 _CORE_FRAMEWORK_SUPPORT = {
     "cyclic": ["pytorch", "tensorflow", "numpy", "raw"],
     "fedavg": ["pytorch", "tensorflow", "sklearn", "numpy", "raw"],
@@ -302,7 +332,9 @@ def _as_string_list(value) -> list:
         return []
     if isinstance(value, str):
         return [_normalize_filter_value(value)] if value.strip() else []
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, set):
+        return sorted(_normalize_filter_value(v) for v in value if str(v).strip())
+    if isinstance(value, (list, tuple)):
         return [_normalize_filter_value(v) for v in value if str(v).strip()]
     return [_normalize_filter_value(value)]
 
@@ -312,7 +344,9 @@ def _as_preserved_string_list(value) -> list:
         return []
     if isinstance(value, str):
         return [value] if value.strip() else []
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, set):
+        return sorted(str(v) for v in value if str(v).strip())
+    if isinstance(value, (list, tuple)):
         return [str(v) for v in value if str(v).strip()]
     return [str(value)]
 
@@ -405,7 +439,7 @@ def _static_recipe_attrs(class_node: ast.ClassDef) -> dict:
     for name in _RECIPE_DETAIL_ATTR_NAMES:
         value = _static_class_attr(class_node, name)
         if value is not None:
-            attrs[name] = value
+            attrs[name] = _json_safe_value(value)
     return attrs
 
 
@@ -622,7 +656,10 @@ def _json_safe_value(value):
         return value.value
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, set):
+        values = [_json_safe_value(v) for v in value]
+        return sorted(values, key=lambda v: json.dumps(v, sort_keys=True))
+    if isinstance(value, (list, tuple)):
         return [_json_safe_value(v) for v in value]
     if isinstance(value, dict):
         return {str(k): _json_safe_value(v) for k, v in value.items()}
@@ -952,6 +989,34 @@ def _generate_recipe_catalog() -> dict:
     }
 
 
+def _has_required_field_types(value: dict, required_fields: dict) -> bool:
+    return isinstance(value, dict) and all(
+        name in value and isinstance(value[name], expected_type) for name, expected_type in required_fields.items()
+    )
+
+
+def _is_string_list(value) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _is_valid_catalog_entry(entry) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    summary = entry.get("summary")
+    detail = entry.get("detail")
+    if not _has_required_field_types(summary, _CATALOG_SUMMARY_REQUIRED_FIELDS) or not _has_required_field_types(
+        detail, _CATALOG_DETAIL_REQUIRED_FIELDS
+    ):
+        return False
+    if not _is_string_list(summary["privacy"]) or not _is_string_list(detail["privacy"]):
+        return False
+    if any(not _is_string_list(detail[name]) for name in _CATALOG_DETAIL_STRING_LIST_FIELDS):
+        return False
+    if any(not isinstance(parameter, dict) for parameter in detail["parameters"]):
+        return False
+    return summary["name"] == detail["name"] and summary["framework"] == detail["framework"]
+
+
 def _read_recipe_catalog() -> list:
     try:
         payload = json.loads(_RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
@@ -963,12 +1028,7 @@ def _read_recipe_catalog() -> list:
     if (
         payload.get("schema_version") != _RECIPE_CATALOG_SCHEMA_VERSION
         or not isinstance(recipes, list)
-        or any(
-            not isinstance(entry, dict)
-            or not isinstance(entry.get("summary"), dict)
-            or not isinstance(entry.get("detail"), dict)
-            for entry in recipes
-        )
+        or any(not _is_valid_catalog_entry(entry) for entry in recipes)
     ):
         raise RuntimeError(f"invalid generated recipe catalog at {_RECIPE_CATALOG_PATH}")
     return recipes

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -33,8 +33,29 @@ _JSON_OUTPUT_MODES = ["json"]
 _NO_RETRY_TOKEN_SCHEMA = {"supported": False}
 _LIST_METADATA_KEYS = {"privacy"}
 _CATALOG_RECIPE_CLASS_KEY = "_recipe_cls"
+_CATALOG_RECIPE_ATTRS_KEY = "_recipe_attrs"
 _RECIPE_CATALOG_PATH = Path(__file__).with_name("recipe_catalog.json")
 _RECIPE_CATALOG_SCHEMA_VERSION = 1
+_RECIPE_DETAIL_ATTR_NAMES = (
+    "recipe_framework_support",
+    "framework_support",
+    "recipe_frameworks",
+    "frameworks",
+    "recipe_supported_frameworks",
+    "supported_frameworks",
+    "recipe_optional_dependencies",
+    "optional_dependencies",
+    "recipe_heterogeneity_support",
+    "heterogeneity_support",
+    "recipe_supported_heterogeneity",
+    "supported_heterogeneity",
+    "recipe_privacy_compatible",
+    "privacy_compatible",
+    "recipe_notes",
+    "notes",
+    "recipe_template_references",
+    "template_references",
+)
 _CORE_FRAMEWORK_SUPPORT = {
     "cyclic": ["pytorch", "tensorflow", "numpy", "raw"],
     "fedavg": ["pytorch", "tensorflow", "sklearn", "numpy", "raw"],
@@ -264,6 +285,12 @@ def _normalize_recipe_name(value: str) -> str:
 
 
 def _recipe_attr(recipe_cls, name: str, default=None):
+    if isinstance(recipe_cls, dict):
+        value = recipe_cls.get(f"recipe_{name}")
+        if value is None:
+            value = recipe_cls.get(name)
+        return default if value is None else value
+
     value = getattr(recipe_cls, f"recipe_{name}", None)
     if value is None:
         value = getattr(recipe_cls, name, None)
@@ -325,6 +352,7 @@ def _static_recipe_class(module_name: str):
     except (OSError, SyntaxError, UnicodeDecodeError):
         return None
 
+    imports = _static_imports(tree)
     class_nodes = [node for node in tree.body if isinstance(node, ast.ClassDef) and node.name != "Recipe"]
     candidate_names = set()
     while True:
@@ -332,7 +360,9 @@ def _static_recipe_class(module_name: str):
             node.name
             for node in class_nodes
             if any(
-                _ast_base_name(base).endswith("Recipe") or _ast_base_name(base) in candidate_names
+                _ast_base_name(base).endswith("Recipe")
+                or (imports.get(_ast_base_name(base), (None, ""))[1]).endswith("Recipe")
+                or _ast_base_name(base) in candidate_names
                 for base in node.bases
             )
         }
@@ -368,6 +398,15 @@ def _static_class_attr(class_node: ast.ClassDef, *names):
         except (ValueError, TypeError):
             return None
     return None
+
+
+def _static_recipe_attrs(class_node: ast.ClassDef) -> dict:
+    attrs = {}
+    for name in _RECIPE_DETAIL_ATTR_NAMES:
+        value = _static_class_attr(class_node, name)
+        if value is not None:
+            attrs[name] = value
+    return attrs
 
 
 def _infer_algorithm(cli_name: str, class_name: str, module_name: str) -> str:
@@ -711,6 +750,7 @@ def _client_requirements(entry: dict, parameters: list) -> dict:
 
 def _recipe_detail(entry: dict) -> dict:
     recipe_cls = entry.get(_CATALOG_RECIPE_CLASS_KEY)
+    recipe_metadata = recipe_cls or entry.get(_CATALOG_RECIPE_ATTRS_KEY)
     parameters = _entry_parameters(entry, recipe_cls)
     detail = {
         "name": entry.get("name"),
@@ -723,14 +763,14 @@ def _recipe_detail(entry: dict) -> dict:
         "state_exchange": entry.get("state_exchange"),
         "privacy": entry.get("privacy"),
         "client_requirements": _client_requirements(entry, parameters),
-        "framework_support": _framework_support(entry, recipe_cls),
-        "heterogeneity_support": _heterogeneity_support(entry, recipe_cls),
-        "privacy_compatible": _privacy_compatible(entry, parameters, recipe_cls),
-        "notes": _as_preserved_string_list(entry.get("notes") or _recipe_attr(recipe_cls, "notes")),
+        "framework_support": _framework_support(entry, recipe_metadata),
+        "heterogeneity_support": _heterogeneity_support(entry, recipe_metadata),
+        "privacy_compatible": _privacy_compatible(entry, parameters, recipe_metadata),
+        "notes": _as_preserved_string_list(entry.get("notes") or _recipe_attr(recipe_metadata, "notes")),
         "parameters": parameters,
-        "optional_dependencies": _optional_dependencies(entry, recipe_cls),
+        "optional_dependencies": _optional_dependencies(entry, recipe_metadata),
         "template_references": _as_preserved_string_list(
-            entry.get("template_references") or _recipe_attr(recipe_cls, "template_references")
+            entry.get("template_references") or _recipe_attr(recipe_metadata, "template_references")
         ),
     }
     return detail
@@ -891,6 +931,9 @@ def _discover_recipe_catalog() -> list:
                 "class": recipe_class.name,
             }
             entry.update(_static_recipe_metadata(cli_name, module_name, recipe_class))
+            recipe_attrs = _static_recipe_attrs(recipe_class)
+            if recipe_attrs:
+                entry[_CATALOG_RECIPE_ATTRS_KEY] = recipe_attrs
             results.append(entry)
     return _apply_documented_recipe_specs(results)
 
@@ -899,18 +942,36 @@ def _generate_recipe_catalog() -> dict:
     discovered = _discover_recipe_catalog()
     return {
         "schema_version": _RECIPE_CATALOG_SCHEMA_VERSION,
-        "recipes": [{"summary": entry, "detail": _recipe_detail(entry)} for entry in discovered],
+        "recipes": [
+            {
+                "summary": {key: value for key, value in entry.items() if not key.startswith("_")},
+                "detail": _recipe_detail(entry),
+            }
+            for entry in discovered
+        ],
     }
 
 
 def _read_recipe_catalog() -> list:
     try:
         payload = json.loads(_RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
         raise RuntimeError(f"unable to read generated recipe catalog at {_RECIPE_CATALOG_PATH}: {e}") from e
-    if payload.get("schema_version") != _RECIPE_CATALOG_SCHEMA_VERSION or not isinstance(payload.get("recipes"), list):
+    if not isinstance(payload, dict):
         raise RuntimeError(f"invalid generated recipe catalog at {_RECIPE_CATALOG_PATH}")
-    return payload["recipes"]
+    recipes = payload.get("recipes")
+    if (
+        payload.get("schema_version") != _RECIPE_CATALOG_SCHEMA_VERSION
+        or not isinstance(recipes, list)
+        or any(
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("summary"), dict)
+            or not isinstance(entry.get("detail"), dict)
+            for entry in recipes
+        )
+    ):
+        raise RuntimeError(f"invalid generated recipe catalog at {_RECIPE_CATALOG_PATH}")
+    return recipes
 
 
 def _load_catalog(framework: str = None, include_recipe_detail: bool = False) -> list:
@@ -922,6 +983,29 @@ def _load_catalog(framework: str = None, include_recipe_detail: bool = False) ->
     entry_type = "detail" if include_recipe_detail else "summary"
     recipes = [entry[entry_type] for entry in _read_recipe_catalog()]
     return [entry for entry in recipes if not framework or entry.get("framework") == framework]
+
+
+def _load_catalog_for_cli(framework: str = None, include_recipe_detail: bool = False) -> list:
+    from nvflare.tool.cli_output import output_error_message
+
+    try:
+        kwargs = {}
+        if framework is not None:
+            kwargs["framework"] = framework
+        if include_recipe_detail:
+            kwargs["include_recipe_detail"] = True
+        return _load_catalog(**kwargs)
+    except RuntimeError as e:
+        output_error_message(
+            "INTERNAL_ERROR",
+            "Unable to load recipe metadata.",
+            "Reinstall NVFLARE. For a source checkout, regenerate the catalog with "
+            "'python -m nvflare.tool.recipe.generate_recipe_catalog'.",
+            None,
+            exit_code=5,
+            detail=str(e),
+        )
+        raise SystemExit(5)
 
 
 def cmd_recipe_list(cmd_args):
@@ -972,7 +1056,7 @@ def cmd_recipe_list(cmd_args):
     if not is_json_mode() and not is_jsonl_mode():
         print_human("Loading installed recipe catalog...", flush=True)
 
-    catalog = _load_catalog(framework=framework)
+    catalog = _load_catalog_for_cli(framework=framework)
 
     if framework and not catalog:
         output_error_message(
@@ -1042,7 +1126,7 @@ def cmd_recipe_show(cmd_args):
     if not is_json_mode() and not is_jsonl_mode():
         print_human(f"Loading installed recipe metadata for '{getattr(cmd_args, 'name', '')}'...", flush=True)
 
-    catalog = _load_catalog(include_recipe_detail=True)
+    catalog = _load_catalog_for_cli(include_recipe_detail=True)
     entry = next((e for e in catalog if _normalize_recipe_name(e["name"]) == requested_name), None)
     if entry is None:
         output_error_message(

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -97,6 +97,7 @@ _CORE_FRAMEWORK_SUPPORT = {
 }
 _NVFLARE_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 _RECIPE_BASE_CLASS = ("nvflare.recipe.spec", "Recipe")
+_STATIC_ATTR_MISSING = object()
 _DOCUMENTED_RECIPE_SPECS = {
     "fedavg-pt": {
         "module": "nvflare.app_opt.pt.recipes.fedavg",
@@ -452,38 +453,52 @@ def _static_class_node(module_name: str, class_name: str, visiting=None):
     return module_name, tree, None
 
 
-def _static_class_is_recipe(module_name: str, class_name: str, visiting=None) -> bool:
+def _merge_static_mros(sequences: list):
+    sequences = [list(sequence) for sequence in sequences if sequence]
+    merged = []
+    while sequences:
+        candidate = next(
+            (sequence[0] for sequence in sequences if not any(sequence[0] in other[1:] for other in sequences)),
+            None,
+        )
+        if candidate is None:
+            return None
+        merged.append(candidate)
+        sequences = [
+            [item for item in sequence if item != candidate]
+            for sequence in sequences
+            if any(item != candidate for item in sequence)
+        ]
+    return merged
+
+
+def _static_class_mro(module_name: str, class_name: str, visiting=None) -> list:
     reference = (module_name, class_name)
-    if reference == _RECIPE_BASE_CLASS:
-        return True
     visiting = set(visiting or ())
     if reference in visiting:
-        return False
+        return []
     visiting.add(reference)
 
     resolved_module, tree, class_node = _static_class_node(module_name, class_name)
     if tree is None or class_node is None:
-        return False
-    return any(
-        _static_class_is_recipe(*base, visiting) for base in _static_base_references(resolved_module, tree, class_node)
-    )
+        return [reference]
+    resolved_reference = (resolved_module, class_node.name)
+    bases = _static_base_references(resolved_module, tree, class_node)
+    base_mros = [_static_class_mro(*base, visiting) for base in bases]
+    merged_bases = _merge_static_mros([*base_mros, bases])
+    return [resolved_reference, *(merged_bases or [])]
 
 
-def _static_class_doc(module_name: str, class_name: str, visiting=None) -> str:
-    reference = (module_name, class_name)
-    visiting = set(visiting or ())
-    if reference in visiting:
-        return ""
-    visiting.add(reference)
+def _static_class_is_recipe(module_name: str, class_name: str) -> bool:
+    return _RECIPE_BASE_CLASS in _static_class_mro(module_name, class_name)
 
-    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
-    if tree is None or class_node is None:
-        return ""
-    doc = ast.get_docstring(class_node)
-    if doc:
-        return doc
-    for base in _static_base_references(resolved_module, tree, class_node):
-        doc = _static_class_doc(*base, visiting)
+
+def _static_class_doc(module_name: str, class_name: str) -> str:
+    for mro_module, mro_class in _static_class_mro(module_name, class_name):
+        _, _, class_node = _static_class_node(mro_module, mro_class)
+        if class_node is None:
+            continue
+        doc = ast.get_docstring(class_node)
         if doc:
             return doc
     return ""
@@ -530,35 +545,33 @@ def _static_class_attr(class_node: ast.ClassDef, *names):
             if target_name in names:
                 assignments[target_name] = value_node
 
+    unresolved = False
     for name in names:
-        value_node = assignments.get(name)
-        if value_node is None:
+        if name not in assignments:
             continue
+        value_node = assignments[name]
         try:
-            return ast.literal_eval(value_node)
-        except (ValueError, TypeError):
-            continue
-    return None
-
-
-def _static_recipe_attrs(module_name: str, class_name: str, visiting=None) -> dict:
-    reference = (module_name, class_name)
-    visiting = set(visiting or ())
-    if reference in visiting:
-        return {}
-    visiting.add(reference)
-
-    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
-    if tree is None or class_node is None:
-        return {}
-    attrs = {}
-    for base in _static_base_references(resolved_module, tree, class_node):
-        attrs.update(_static_recipe_attrs(*base, visiting))
-    for aliases in _RECIPE_DETAIL_ATTR_ALIASES.values():
-        for name in aliases:
-            value = _static_class_attr(class_node, name)
+            value = ast.literal_eval(value_node)
             if value is not None:
-                attrs[name] = _json_safe_value(value)
+                return value
+            unresolved = True
+        except (ValueError, TypeError):
+            unresolved = True
+            continue
+    return None if unresolved else _STATIC_ATTR_MISSING
+
+
+def _static_recipe_attrs(module_name: str, class_name: str) -> dict:
+    attrs = {}
+    for mro_module, mro_class in reversed(_static_class_mro(module_name, class_name)):
+        _, _, class_node = _static_class_node(mro_module, mro_class)
+        if class_node is None:
+            continue
+        for aliases in _RECIPE_DETAIL_ATTR_ALIASES.values():
+            for name in aliases:
+                value = _static_class_attr(class_node, name)
+                if value is not _STATIC_ATTR_MISSING:
+                    attrs[name] = _json_safe_value(value)
     return attrs
 
 
@@ -628,16 +641,19 @@ def _infer_privacy(cli_name: str, class_name: str, module_name: str) -> list:
 
 
 def _static_recipe_metadata(cli_name: str, module_name: str, class_node: ast.ClassDef) -> dict:
-    algorithm = _static_class_attr(class_node, "recipe_algorithm", "algorithm") or _infer_algorithm(
-        cli_name, class_node.name, module_name
-    )
-    aggregation = _static_class_attr(class_node, "recipe_aggregation", "aggregation") or _infer_aggregation(algorithm)
-    state_exchange = _static_class_attr(class_node, "recipe_state_exchange", "state_exchange") or _infer_state_exchange(
-        algorithm
-    )
-    privacy = _as_string_list(_static_class_attr(class_node, "recipe_privacy", "privacy")) or _infer_privacy(
-        cli_name, class_node.name, module_name
-    )
+    algorithm = _static_class_attr(class_node, "recipe_algorithm", "algorithm")
+    if algorithm is _STATIC_ATTR_MISSING or not algorithm:
+        algorithm = _infer_algorithm(cli_name, class_node.name, module_name)
+    aggregation = _static_class_attr(class_node, "recipe_aggregation", "aggregation")
+    if aggregation is _STATIC_ATTR_MISSING or not aggregation:
+        aggregation = _infer_aggregation(algorithm)
+    state_exchange = _static_class_attr(class_node, "recipe_state_exchange", "state_exchange")
+    if state_exchange is _STATIC_ATTR_MISSING or not state_exchange:
+        state_exchange = _infer_state_exchange(algorithm)
+    privacy = _static_class_attr(class_node, "recipe_privacy", "privacy")
+    if privacy is _STATIC_ATTR_MISSING:
+        privacy = None
+    privacy = _as_string_list(privacy) or _infer_privacy(cli_name, class_node.name, module_name)
     return {
         "algorithm": _normalize_filter_value(algorithm) if algorithm else None,
         "aggregation": _normalize_filter_value(aggregation) if aggregation else None,
@@ -703,30 +719,21 @@ def _ast_parameter(name: str, annotation, default_node, kind: str, required: boo
     }
 
 
-def _static_class_function(module_name: str, class_name: str, function_name: str, visiting=None):
-    reference = (module_name, class_name)
-    visiting = set(visiting or ())
-    if reference in visiting:
-        return None, None
-    visiting.add(reference)
-
-    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
-    if tree is None or class_node is None:
-        return None, None
-    function_node = next(
-        (
-            node
-            for node in class_node.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
-        ),
-        None,
-    )
-    if function_node is not None:
-        return resolved_module, function_node
-    for base in _static_base_references(resolved_module, tree, class_node):
-        function_module, function_node = _static_class_function(*base, function_name, visiting)
+def _static_class_function(module_name: str, class_name: str, function_name: str):
+    for mro_module, mro_class in _static_class_mro(module_name, class_name):
+        resolved_module, _, class_node = _static_class_node(mro_module, mro_class)
+        if class_node is None:
+            continue
+        function_node = next(
+            (
+                node
+                for node in class_node.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
+            ),
+            None,
+        )
         if function_node is not None:
-            return function_module, function_node
+            return resolved_module, function_node
     return None, None
 
 

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import ast
-import inspect
 import json
 import sys
 from enum import Enum
@@ -32,30 +31,29 @@ _FILTER_KEYS = {"framework", "privacy", "algorithm", "aggregation", "state_excha
 _JSON_OUTPUT_MODES = ["json"]
 _NO_RETRY_TOKEN_SCHEMA = {"supported": False}
 _LIST_METADATA_KEYS = {"privacy"}
-_CATALOG_RECIPE_CLASS_KEY = "_recipe_cls"
 _CATALOG_RECIPE_ATTRS_KEY = "_recipe_attrs"
 _RECIPE_CATALOG_PATH = Path(__file__).with_name("recipe_catalog.json")
 _RECIPE_CATALOG_SCHEMA_VERSION = 1
-_RECIPE_DETAIL_ATTR_NAMES = (
-    "recipe_framework_support",
-    "framework_support",
-    "recipe_frameworks",
-    "frameworks",
-    "recipe_supported_frameworks",
-    "supported_frameworks",
-    "recipe_optional_dependencies",
-    "optional_dependencies",
-    "recipe_heterogeneity_support",
-    "heterogeneity_support",
-    "recipe_supported_heterogeneity",
-    "supported_heterogeneity",
-    "recipe_privacy_compatible",
-    "privacy_compatible",
-    "recipe_notes",
-    "notes",
-    "recipe_template_references",
-    "template_references",
-)
+_RECIPE_DETAIL_ATTR_ALIASES = {
+    "framework_support": (
+        "recipe_framework_support",
+        "framework_support",
+        "recipe_frameworks",
+        "frameworks",
+        "recipe_supported_frameworks",
+        "supported_frameworks",
+    ),
+    "optional_dependencies": ("recipe_optional_dependencies", "optional_dependencies"),
+    "heterogeneity_support": (
+        "recipe_heterogeneity_support",
+        "heterogeneity_support",
+        "recipe_supported_heterogeneity",
+        "supported_heterogeneity",
+    ),
+    "privacy_compatible": ("recipe_privacy_compatible", "privacy_compatible"),
+    "notes": ("recipe_notes", "notes"),
+    "template_references": ("recipe_template_references", "template_references"),
+}
 _CATALOG_SUMMARY_REQUIRED_FIELDS = {
     "name": str,
     "description": str,
@@ -98,6 +96,7 @@ _CORE_FRAMEWORK_SUPPORT = {
     "fedstats": ["framework_agnostic"],
 }
 _NVFLARE_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+_RECIPE_BASE_CLASS = ("nvflare.recipe.spec", "Recipe")
 _DOCUMENTED_RECIPE_SPECS = {
     "fedavg-pt": {
         "module": "nvflare.app_opt.pt.recipes.fedavg",
@@ -320,17 +319,12 @@ def _normalize_recipe_name(value: str) -> str:
     return str(value).strip().lower().replace("_", "-")
 
 
-def _recipe_attr(recipe_cls, name: str, default=None):
-    if isinstance(recipe_cls, dict):
-        value = recipe_cls.get(f"recipe_{name}")
-        if value is None:
-            value = recipe_cls.get(name)
-        return default if value is None else value
-
-    value = getattr(recipe_cls, f"recipe_{name}", None)
-    if value is None:
-        value = getattr(recipe_cls, name, None)
-    return default if value is None else value
+def _recipe_metadata_attr(metadata: dict, name: str, default=None):
+    for alias in _RECIPE_DETAIL_ATTR_ALIASES[name]:
+        value = (metadata or {}).get(alias)
+        if value is not None:
+            return value
+    return default
 
 
 def _as_string_list(value) -> list:
@@ -363,7 +357,12 @@ def _module_source_path(module_name: str):
     parts = module_name.split(".")
     if not parts or parts[0] != "nvflare":
         return None
-    return _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:]).with_suffix(".py")
+    path = _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:])
+    module_path = path.with_suffix(".py")
+    if module_path.is_file():
+        return module_path
+    package_path = path / "__init__.py"
+    return package_path if package_path.is_file() else module_path
 
 
 def _package_source_path(package_name: str):
@@ -375,53 +374,147 @@ def _package_source_path(package_name: str):
     return _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:])
 
 
-def _ast_base_name(node) -> str:
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        return node.attr
-    return ""
-
-
-def _static_recipe_class(module_name: str):
+def _static_module_tree(module_name: str):
     path = _module_source_path(module_name)
     if not path or not path.is_file():
         return None
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        return ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return None
 
-    imports = _static_imports(tree)
+
+def _resolve_import_from_module(module_name: str, node: ast.ImportFrom):
+    if not node.level:
+        return node.module
+    path = _module_source_path(module_name)
+    package_parts = module_name.split(".")
+    if not path or path.name != "__init__.py":
+        package_parts = package_parts[:-1]
+    parent_levels = node.level - 1
+    if parent_levels > len(package_parts):
+        return None
+    base_parts = package_parts[: len(package_parts) - parent_levels]
+    if node.module:
+        base_parts.extend(node.module.split("."))
+    return ".".join(base_parts)
+
+
+def _static_imports(tree: ast.Module, module_name: str = None) -> dict:
+    imports = {}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            imported_module = _resolve_import_from_module(module_name, node) if module_name else node.module
+            if not imported_module:
+                continue
+            for imported in node.names:
+                imports[imported.asname or imported.name] = (imported_module, imported.name)
+        elif isinstance(node, ast.Import):
+            for imported in node.names:
+                local_name = imported.asname or imported.name.split(".", 1)[0]
+                imports[local_name] = (imported.name, None)
+    return imports
+
+
+def _static_base_references(module_name: str, tree: ast.Module, class_node: ast.ClassDef) -> list:
+    imports = _static_imports(tree, module_name)
+    local_classes = {node.name for node in tree.body if isinstance(node, ast.ClassDef)}
+    references = []
+    for base in class_node.bases:
+        if isinstance(base, ast.Name):
+            if base.id in local_classes:
+                references.append((module_name, base.id))
+            elif base.id in imports and imports[base.id][1]:
+                references.append(imports[base.id])
+        elif isinstance(base, ast.Attribute) and isinstance(base.value, ast.Name):
+            imported = imports.get(base.value.id)
+            if imported and imported[1] is None:
+                references.append((imported[0], base.attr))
+    return references
+
+
+def _static_class_node(module_name: str, class_name: str, visiting=None):
+    reference = (module_name, class_name)
+    visiting = set(visiting or ())
+    if reference in visiting:
+        return module_name, None, None
+    visiting.add(reference)
+
+    tree = _static_module_tree(module_name)
+    if tree is None:
+        return module_name, None, None
+    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
+    if class_node is not None:
+        return module_name, tree, class_node
+    imported = _static_imports(tree, module_name).get(class_name)
+    if imported and imported[1]:
+        return _static_class_node(imported[0], imported[1], visiting)
+    return module_name, tree, None
+
+
+def _static_class_is_recipe(module_name: str, class_name: str, visiting=None) -> bool:
+    reference = (module_name, class_name)
+    if reference == _RECIPE_BASE_CLASS:
+        return True
+    visiting = set(visiting or ())
+    if reference in visiting:
+        return False
+    visiting.add(reference)
+
+    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
+    if tree is None or class_node is None:
+        return False
+    return any(
+        _static_class_is_recipe(*base, visiting) for base in _static_base_references(resolved_module, tree, class_node)
+    )
+
+
+def _static_class_doc(module_name: str, class_name: str, visiting=None) -> str:
+    reference = (module_name, class_name)
+    visiting = set(visiting or ())
+    if reference in visiting:
+        return ""
+    visiting.add(reference)
+
+    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
+    if tree is None or class_node is None:
+        return ""
+    doc = ast.get_docstring(class_node)
+    if doc:
+        return doc
+    for base in _static_base_references(resolved_module, tree, class_node):
+        doc = _static_class_doc(*base, visiting)
+        if doc:
+            return doc
+    return ""
+
+
+def _static_recipe_class(module_name: str):
+    tree = _static_module_tree(module_name)
+    if tree is None:
+        return None
+
     class_nodes = [node for node in tree.body if isinstance(node, ast.ClassDef) and node.name != "Recipe"]
-    candidate_names = set()
-    while True:
-        discovered_names = {
-            node.name
-            for node in class_nodes
-            if any(
-                _ast_base_name(base).endswith("Recipe")
-                or (imports.get(_ast_base_name(base), (None, ""))[1]).endswith("Recipe")
-                or _ast_base_name(base) in candidate_names
-                for base in node.bases
-            )
-        }
-        if discovered_names <= candidate_names:
-            break
-        candidate_names.update(discovered_names)
+    candidate_names = {node.name for node in class_nodes if _static_class_is_recipe(module_name, node.name)}
     candidates = [node for node in class_nodes if node.name in candidate_names]
     if not candidates:
         return None
 
-    inherited_names = {_ast_base_name(base) for candidate in candidates for base in candidate.bases}
+    inherited_names = {
+        base_name
+        for candidate in candidates
+        for base_module, base_name in _static_base_references(module_name, tree, candidate)
+        if base_module == module_name and base_name in candidate_names
+    }
     leaf_candidates = [candidate for candidate in candidates if candidate.name not in inherited_names]
     recipe_class = leaf_candidates[0] if leaf_candidates else candidates[0]
-    doc = ast.get_docstring(recipe_class) or ""
+    doc = _static_class_doc(module_name, recipe_class.name)
     description = next((line.strip() for line in doc.splitlines() if line.strip()), f"{recipe_class.name} recipe")
     return recipe_class, description
 
 
 def _static_class_attr(class_node: ast.ClassDef, *names):
+    assignments = {}
     for node in class_node.body:
         value_node = None
         target_names = []
@@ -431,21 +524,41 @@ def _static_class_attr(class_node: ast.ClassDef, *names):
         elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
             value_node = node.value
             target_names = [node.target.id]
-        if value_node is None or not set(names).intersection(target_names):
+        if value_node is None:
+            continue
+        for target_name in target_names:
+            if target_name in names:
+                assignments[target_name] = value_node
+
+    for name in names:
+        value_node = assignments.get(name)
+        if value_node is None:
             continue
         try:
             return ast.literal_eval(value_node)
         except (ValueError, TypeError):
-            return None
+            continue
     return None
 
 
-def _static_recipe_attrs(class_node: ast.ClassDef) -> dict:
+def _static_recipe_attrs(module_name: str, class_name: str, visiting=None) -> dict:
+    reference = (module_name, class_name)
+    visiting = set(visiting or ())
+    if reference in visiting:
+        return {}
+    visiting.add(reference)
+
+    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
+    if tree is None or class_node is None:
+        return {}
     attrs = {}
-    for name in _RECIPE_DETAIL_ATTR_NAMES:
-        value = _static_class_attr(class_node, name)
-        if value is not None:
-            attrs[name] = _json_safe_value(value)
+    for base in _static_base_references(resolved_module, tree, class_node):
+        attrs.update(_static_recipe_attrs(*base, visiting))
+    for aliases in _RECIPE_DETAIL_ATTR_ALIASES.values():
+        for name in aliases:
+            value = _static_class_attr(class_node, name)
+            if value is not None:
+                attrs[name] = _json_safe_value(value)
     return attrs
 
 
@@ -533,25 +646,8 @@ def _static_recipe_metadata(cli_name: str, module_name: str, class_node: ast.Cla
     }
 
 
-def _static_imports(tree: ast.Module) -> dict:
-    imports = {}
-    for node in tree.body:
-        if isinstance(node, ast.ImportFrom) and node.module:
-            for imported in node.names:
-                imports[imported.asname or imported.name] = (node.module, imported.name)
-    return imports
-
-
 def _static_member_value(module_name: str, class_name: str, member_name: str):
-    path = _module_source_path(module_name)
-    if not path or not path.is_file():
-        return None
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except (OSError, SyntaxError, UnicodeDecodeError):
-        return None
-
-    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
+    _, _, class_node = _static_class_node(module_name, class_name)
     if class_node is None:
         return None
     for node in class_node.body:
@@ -607,30 +703,40 @@ def _ast_parameter(name: str, annotation, default_node, kind: str, required: boo
     }
 
 
-def _static_recipe_parameters(module_name: str, class_name: str) -> list:
-    path = _module_source_path(module_name)
-    if not path or not path.is_file():
-        return []
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except (OSError, SyntaxError, UnicodeDecodeError):
-        return []
+def _static_class_function(module_name: str, class_name: str, function_name: str, visiting=None):
+    reference = (module_name, class_name)
+    visiting = set(visiting or ())
+    if reference in visiting:
+        return None, None
+    visiting.add(reference)
 
-    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
-    if class_node is None:
-        return []
-    init_node = next(
+    resolved_module, tree, class_node = _static_class_node(module_name, class_name)
+    if tree is None or class_node is None:
+        return None, None
+    function_node = next(
         (
             node
             for node in class_node.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__"
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
         ),
         None,
     )
+    if function_node is not None:
+        return resolved_module, function_node
+    for base in _static_base_references(resolved_module, tree, class_node):
+        function_module, function_node = _static_class_function(*base, function_name, visiting)
+        if function_node is not None:
+            return function_module, function_node
+    return None, None
+
+
+def _static_recipe_parameters(module_name: str, class_name: str) -> list:
+    init_module, init_node = _static_class_function(module_name, class_name, "__init__")
     if init_node is None:
         return []
 
-    imports = _static_imports(tree)
+    tree = _static_module_tree(init_module)
+    imports = _static_imports(tree, init_module)
     params = []
     args = init_node.args
     positional = list(args.posonlyargs) + list(args.args)
@@ -656,8 +762,6 @@ def _static_recipe_parameters(module_name: str, class_name: str) -> list:
 
 
 def _json_safe_value(value):
-    if value is inspect.Signature.empty or value is inspect.Parameter.empty:
-        return None
     if isinstance(value, Enum):
         return value.value
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -672,53 +776,12 @@ def _json_safe_value(value):
     return repr(value)
 
 
-def _annotation_to_string(annotation) -> str:
-    if annotation is inspect.Signature.empty or annotation is inspect.Parameter.empty:
-        return None
-    return inspect.formatannotation(annotation).replace("typing.", "")
-
-
-def _recipe_parameters(recipe_cls) -> list:
-    try:
-        signature = inspect.signature(recipe_cls.__init__)
-    except (TypeError, ValueError):
-        return []
-
-    parameters = []
-    for name, param in signature.parameters.items():
-        if name == "self":
-            continue
-        required = param.default is inspect.Parameter.empty and param.kind not in (
-            inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.VAR_KEYWORD,
-        )
-        parameters.append(
-            {
-                "name": name,
-                "type": _annotation_to_string(param.annotation),
-                "required": required,
-                "default": _json_safe_value(param.default),
-                "kind": param.kind.name.lower(),
-            }
-        )
-    return parameters
-
-
-def _entry_parameters(entry: dict, recipe_cls) -> list:
-    if recipe_cls:
-        params = _recipe_parameters(recipe_cls)
-        if params:
-            return params
+def _entry_parameters(entry: dict) -> list:
     return _static_recipe_parameters(entry.get("module"), entry.get("class"))
 
 
-def _framework_support(entry: dict, recipe_cls) -> list:
-    explicit = _as_string_list(
-        entry.get("framework_support")
-        or _recipe_attr(recipe_cls, "framework_support")
-        or _recipe_attr(recipe_cls, "frameworks")
-        or _recipe_attr(recipe_cls, "supported_frameworks")
-    )
+def _framework_support(entry: dict, metadata: dict) -> list:
+    explicit = _as_string_list(entry.get("framework_support") or _recipe_metadata_attr(metadata, "framework_support"))
     if explicit:
         return explicit
 
@@ -728,8 +791,8 @@ def _framework_support(entry: dict, recipe_cls) -> list:
     return [framework] if framework else []
 
 
-def _optional_dependencies(entry: dict, recipe_cls) -> list:
-    explicit = entry.get("optional_dependencies") or _recipe_attr(recipe_cls, "optional_dependencies")
+def _optional_dependencies(entry: dict, metadata: dict) -> list:
+    explicit = entry.get("optional_dependencies") or _recipe_metadata_attr(metadata, "optional_dependencies")
     if explicit is not None:
         return _as_preserved_string_list(explicit)
 
@@ -739,11 +802,9 @@ def _optional_dependencies(entry: dict, recipe_cls) -> list:
     return []
 
 
-def _heterogeneity_support(entry: dict, recipe_cls) -> list:
+def _heterogeneity_support(entry: dict, metadata: dict) -> list:
     explicit = _as_string_list(
-        _recipe_attr(recipe_cls, "heterogeneity_support")
-        or _recipe_attr(recipe_cls, "supported_heterogeneity")
-        or entry.get("heterogeneity_support")
+        entry.get("heterogeneity_support") or _recipe_metadata_attr(metadata, "heterogeneity_support")
     )
     if explicit:
         return explicit
@@ -760,10 +821,10 @@ def _heterogeneity_support(entry: dict, recipe_cls) -> list:
     return ["horizontal"]
 
 
-def _privacy_compatible(entry: dict, parameters: list, recipe_cls) -> list:
+def _privacy_compatible(entry: dict, parameters: list, metadata: dict) -> list:
     privacy = set(_as_string_list(entry.get("privacy")))
     privacy.update(_as_string_list(entry.get("privacy_compatible")))
-    privacy.update(_as_string_list(_recipe_attr(recipe_cls, "privacy_compatible")))
+    privacy.update(_as_string_list(_recipe_metadata_attr(metadata, "privacy_compatible")))
     parameter_names = {p["name"] for p in parameters}
     if "secure" in parameter_names:
         privacy.add("homomorphic_encryption")
@@ -791,10 +852,9 @@ def _client_requirements(entry: dict, parameters: list) -> dict:
     return requirements
 
 
-def _recipe_detail(entry: dict) -> dict:
-    recipe_cls = entry.get(_CATALOG_RECIPE_CLASS_KEY)
-    recipe_metadata = recipe_cls or entry.get(_CATALOG_RECIPE_ATTRS_KEY)
-    parameters = _entry_parameters(entry, recipe_cls)
+def _generate_recipe_detail(entry: dict) -> dict:
+    recipe_metadata = entry.get(_CATALOG_RECIPE_ATTRS_KEY)
+    parameters = _entry_parameters(entry)
     detail = {
         "name": entry.get("name"),
         "description": entry.get("description"),
@@ -809,11 +869,11 @@ def _recipe_detail(entry: dict) -> dict:
         "framework_support": _framework_support(entry, recipe_metadata),
         "heterogeneity_support": _heterogeneity_support(entry, recipe_metadata),
         "privacy_compatible": _privacy_compatible(entry, parameters, recipe_metadata),
-        "notes": _as_preserved_string_list(entry.get("notes") or _recipe_attr(recipe_metadata, "notes")),
+        "notes": _as_preserved_string_list(entry.get("notes") or _recipe_metadata_attr(recipe_metadata, "notes")),
         "parameters": parameters,
         "optional_dependencies": _optional_dependencies(entry, recipe_metadata),
         "template_references": _as_preserved_string_list(
-            entry.get("template_references") or _recipe_attr(recipe_metadata, "template_references")
+            entry.get("template_references") or _recipe_metadata_attr(recipe_metadata, "template_references")
         ),
     }
     return detail
@@ -870,18 +930,15 @@ def _filter_catalog(catalog: list, filters: dict) -> list:
 
 
 def _documented_recipe_entry(name: str, spec: dict) -> dict:
-    entry = {
-        "name": name,
-        "description": spec.get("description"),
-        "framework": spec.get("framework"),
-        "module": spec.get("module"),
-        "class": spec.get("class"),
-        "algorithm": spec.get("algorithm"),
-        "aggregation": spec.get("aggregation"),
-        "state_exchange": spec.get("state_exchange"),
-        "privacy": _as_string_list(spec.get("privacy")),
-    }
+    entry = {"name": name}
     for key in (
+        "description",
+        "framework",
+        "module",
+        "class",
+        "algorithm",
+        "aggregation",
+        "state_exchange",
         "framework_support",
         "heterogeneity_support",
         "privacy_compatible",
@@ -891,6 +948,8 @@ def _documented_recipe_entry(name: str, spec: dict) -> dict:
     ):
         if key in spec:
             entry[key] = spec[key]
+    if "privacy" in spec:
+        entry["privacy"] = _as_string_list(spec["privacy"])
 
     return entry
 
@@ -941,6 +1000,20 @@ def _apply_documented_recipe_specs(catalog: list) -> list:
         if normalized_name in by_name:
             by_name[normalized_name].update(spec_entry)
         else:
+            core_keys = (
+                "name",
+                "description",
+                "framework",
+                "module",
+                "class",
+                "algorithm",
+                "aggregation",
+                "state_exchange",
+            )
+            completed_entry = {key: spec_entry.get(key) for key in core_keys}
+            completed_entry["privacy"] = spec_entry.get("privacy", [])
+            completed_entry.update({key: value for key, value in spec_entry.items() if key not in completed_entry})
+            spec_entry = completed_entry
             catalog.append(spec_entry)
             by_name[normalized_name] = spec_entry
     return sorted(catalog, key=lambda entry: entry["name"])
@@ -974,7 +1047,7 @@ def _discover_recipe_catalog() -> list:
                 "class": recipe_class.name,
             }
             entry.update(_static_recipe_metadata(cli_name, module_name, recipe_class))
-            recipe_attrs = _static_recipe_attrs(recipe_class)
+            recipe_attrs = _static_recipe_attrs(module_name, recipe_class.name)
             if recipe_attrs:
                 entry[_CATALOG_RECIPE_ATTRS_KEY] = recipe_attrs
             results.append(entry)
@@ -988,7 +1061,7 @@ def _generate_recipe_catalog() -> dict:
         "recipes": [
             {
                 "summary": {key: value for key, value in entry.items() if not key.startswith("_")},
-                "detail": _recipe_detail(entry),
+                "detail": _generate_recipe_detail(entry),
             }
             for entry in discovered
         ],

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -104,6 +104,7 @@ _CORE_FRAMEWORK_SUPPORT = {
 _NVFLARE_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 _RECIPE_BASE_CLASS = ("nvflare.recipe.spec", "Recipe")
 _STATIC_ATTR_MISSING = object()
+_STATIC_ATTR_UNRESOLVED = object()
 _DOCUMENTED_RECIPE_SPECS = {
     "fedavg-pt": {
         "module": "nvflare.app_opt.pt.recipes.fedavg",
@@ -559,28 +560,29 @@ def _static_class_attr(class_node: ast.ClassDef, *names):
             continue
         value_node = assignments[name]
         try:
-            value = ast.literal_eval(value_node)
-            if value is not None:
-                return value
-            unresolved = True
+            return ast.literal_eval(value_node)
         except (ValueError, TypeError):
             unresolved = True
             continue
-    return None if unresolved else _STATIC_ATTR_MISSING
+    return _STATIC_ATTR_UNRESOLVED if unresolved else _STATIC_ATTR_MISSING
 
 
 def _static_recipe_attrs(module_name: str, class_name: str, attr_aliases: dict = None) -> dict:
     attr_aliases = _RECIPE_DETAIL_ATTR_ALIASES if attr_aliases is None else attr_aliases
     attrs = {}
+    resolved_attrs = set()
     for mro_module, mro_class in _static_class_mro(module_name, class_name):
         _, _, class_node = _static_class_node(mro_module, mro_class)
         if class_node is None:
             continue
         for name, aliases in attr_aliases.items():
-            if name in attrs:
+            if name in resolved_attrs:
                 continue
             value = _static_class_attr(class_node, *aliases)
-            if value is not _STATIC_ATTR_MISSING:
+            if value is _STATIC_ATTR_MISSING:
+                continue
+            resolved_attrs.add(name)
+            if value is not _STATIC_ATTR_UNRESOLVED:
                 attrs[name] = _json_safe_value(value)
     return {name: attrs[name] for name in attr_aliases if name in attrs}
 

--- a/nvflare/tool/recipe/recipe_cli.py
+++ b/nvflare/tool/recipe/recipe_cli.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import ast
-import importlib
 import inspect
-import pkgutil
+import json
 import sys
 from enum import Enum
 from pathlib import Path
@@ -34,7 +33,8 @@ _JSON_OUTPUT_MODES = ["json"]
 _NO_RETRY_TOKEN_SCHEMA = {"supported": False}
 _LIST_METADATA_KEYS = {"privacy"}
 _CATALOG_RECIPE_CLASS_KEY = "_recipe_cls"
-_RECIPE_BASE_CLASS = None
+_RECIPE_CATALOG_PATH = Path(__file__).with_name("recipe_catalog.json")
+_RECIPE_CATALOG_SCHEMA_VERSION = 1
 _CORE_FRAMEWORK_SUPPORT = {
     "cyclic": ["pytorch", "tensorflow", "numpy", "raw"],
     "fedavg": ["pytorch", "tensorflow", "sklearn", "numpy", "raw"],
@@ -299,96 +299,79 @@ def _module_source_path(module_name: str):
     return _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:]).with_suffix(".py")
 
 
-def _import_module(module_name: str):
-    return importlib.import_module(module_name)
-
-
-def _ast_default_value(node):
-    if node is None:
+def _package_source_path(package_name: str):
+    if not package_name:
         return None
-    try:
-        return _json_safe_value(ast.literal_eval(node))
-    except (ValueError, TypeError):
-        try:
-            return ast.unparse(node)
-        except Exception:
-            return None
-
-
-def _ast_annotation_to_string(node):
-    if node is None:
+    parts = package_name.split(".")
+    if not parts or parts[0] != "nvflare":
         return None
-    try:
-        return ast.unparse(node)
-    except Exception:
-        return None
+    return _NVFLARE_PACKAGE_ROOT.joinpath(*parts[1:])
 
 
-def _ast_parameter(name: str, annotation, default_node, kind: str, required: bool) -> dict:
-    return {
-        "name": name,
-        "type": _ast_annotation_to_string(annotation),
-        "required": required,
-        "default": _ast_default_value(default_node),
-        "kind": kind,
-    }
+def _ast_base_name(node) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
 
 
-def _static_recipe_parameters(module_name: str, class_name: str) -> list:
+def _static_recipe_class(module_name: str):
     path = _module_source_path(module_name)
     if not path or not path.is_file():
-        return []
+        return None
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
-        return []
-
-    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
-    if class_node is None:
-        return []
-    init_node = next(
-        (
-            node
-            for node in class_node.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__"
-        ),
-        None,
-    )
-    if init_node is None:
-        return []
-
-    params = []
-    args = init_node.args
-    positional = list(args.posonlyargs) + list(args.args)
-    positional_defaults = [None] * (len(positional) - len(args.defaults)) + list(args.defaults)
-    for index, (arg, default_node) in enumerate(zip(positional, positional_defaults)):
-        if arg.arg == "self":
-            continue
-        kind = "positional_only" if index < len(args.posonlyargs) else "positional_or_keyword"
-        params.append(_ast_parameter(arg.arg, arg.annotation, default_node, kind, default_node is None))
-
-    if args.vararg is not None:
-        params.append(_ast_parameter(args.vararg.arg, args.vararg.annotation, None, "var_positional", False))
-
-    for arg, default_node in zip(args.kwonlyargs, args.kw_defaults):
-        params.append(_ast_parameter(arg.arg, arg.annotation, default_node, "keyword_only", default_node is None))
-
-    if args.kwarg is not None:
-        params.append(_ast_parameter(args.kwarg.arg, args.kwarg.annotation, None, "var_keyword", False))
-
-    return params
-
-
-def _try_import_recipe_class(module_name: str, class_name: str):
-    try:
-        module = _import_module(module_name)
-    except (ImportError, SyntaxError):
         return None
-    return getattr(module, class_name, None)
+
+    class_nodes = [node for node in tree.body if isinstance(node, ast.ClassDef) and node.name != "Recipe"]
+    candidate_names = set()
+    while True:
+        discovered_names = {
+            node.name
+            for node in class_nodes
+            if any(
+                _ast_base_name(base).endswith("Recipe") or _ast_base_name(base) in candidate_names
+                for base in node.bases
+            )
+        }
+        if discovered_names <= candidate_names:
+            break
+        candidate_names.update(discovered_names)
+    candidates = [node for node in class_nodes if node.name in candidate_names]
+    if not candidates:
+        return None
+
+    inherited_names = {_ast_base_name(base) for candidate in candidates for base in candidate.bases}
+    leaf_candidates = [candidate for candidate in candidates if candidate.name not in inherited_names]
+    recipe_class = leaf_candidates[0] if leaf_candidates else candidates[0]
+    doc = ast.get_docstring(recipe_class) or ""
+    description = next((line.strip() for line in doc.splitlines() if line.strip()), f"{recipe_class.name} recipe")
+    return recipe_class, description
 
 
-def _infer_algorithm(cli_name: str, recipe_cls) -> str:
-    text = _normalize_filter_value(f"{cli_name} {recipe_cls.__name__} {recipe_cls.__module__}")
+def _static_class_attr(class_node: ast.ClassDef, *names):
+    for node in class_node.body:
+        value_node = None
+        target_names = []
+        if isinstance(node, ast.Assign):
+            value_node = node.value
+            target_names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            value_node = node.value
+            target_names = [node.target.id]
+        if value_node is None or not set(names).intersection(target_names):
+            continue
+        try:
+            return ast.literal_eval(value_node)
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _infer_algorithm(cli_name: str, class_name: str, module_name: str) -> str:
+    text = _normalize_filter_value(f"{cli_name} {class_name} {module_name}")
     algorithm_markers = [
         ("kmeans", "kmeans"),
         ("svm", "svm"),
@@ -442,8 +425,8 @@ def _infer_state_exchange(algorithm: str) -> str:
     return None
 
 
-def _infer_privacy(cli_name: str, recipe_cls) -> list:
-    text = _normalize_filter_value(f"{cli_name} {recipe_cls.__name__} {recipe_cls.__module__}")
+def _infer_privacy(cli_name: str, class_name: str, module_name: str) -> list:
+    text = _normalize_filter_value(f"{cli_name} {class_name} {module_name}")
     privacy = []
     if "_he" in text or "he_" in text or "withhe" in text or "homomorphic" in text:
         privacy.append("homomorphic_encryption")
@@ -452,17 +435,145 @@ def _infer_privacy(cli_name: str, recipe_cls) -> list:
     return privacy
 
 
-def _recipe_metadata(cli_name: str, recipe_cls) -> dict:
-    algorithm = _recipe_attr(recipe_cls, "algorithm") or _infer_algorithm(cli_name, recipe_cls)
-    aggregation = _recipe_attr(recipe_cls, "aggregation") or _infer_aggregation(algorithm)
-    state_exchange = _recipe_attr(recipe_cls, "state_exchange") or _infer_state_exchange(algorithm)
-    privacy = _as_string_list(_recipe_attr(recipe_cls, "privacy")) or _infer_privacy(cli_name, recipe_cls)
+def _static_recipe_metadata(cli_name: str, module_name: str, class_node: ast.ClassDef) -> dict:
+    algorithm = _static_class_attr(class_node, "recipe_algorithm", "algorithm") or _infer_algorithm(
+        cli_name, class_node.name, module_name
+    )
+    aggregation = _static_class_attr(class_node, "recipe_aggregation", "aggregation") or _infer_aggregation(algorithm)
+    state_exchange = _static_class_attr(class_node, "recipe_state_exchange", "state_exchange") or _infer_state_exchange(
+        algorithm
+    )
+    privacy = _as_string_list(_static_class_attr(class_node, "recipe_privacy", "privacy")) or _infer_privacy(
+        cli_name, class_node.name, module_name
+    )
     return {
         "algorithm": _normalize_filter_value(algorithm) if algorithm else None,
         "aggregation": _normalize_filter_value(aggregation) if aggregation else None,
         "state_exchange": _normalize_filter_value(state_exchange) if state_exchange else None,
         "privacy": privacy,
     }
+
+
+def _static_imports(tree: ast.Module) -> dict:
+    imports = {}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for imported in node.names:
+                imports[imported.asname or imported.name] = (node.module, imported.name)
+    return imports
+
+
+def _static_member_value(module_name: str, class_name: str, member_name: str):
+    path = _module_source_path(module_name)
+    if not path or not path.is_file():
+        return None
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return None
+
+    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
+    if class_node is None:
+        return None
+    for node in class_node.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == member_name for target in node.targets
+        ):
+            try:
+                return ast.literal_eval(node.value)
+            except (ValueError, TypeError):
+                return None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == member_name:
+            try:
+                return ast.literal_eval(node.value)
+            except (ValueError, TypeError):
+                return None
+    return None
+
+
+def _ast_default_value(node, imports: dict = None):
+    if node is None:
+        return None
+    try:
+        return _json_safe_value(ast.literal_eval(node))
+    except (ValueError, TypeError):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            imported = (imports or {}).get(node.value.id)
+            if imported:
+                value = _static_member_value(imported[0], imported[1], node.attr)
+                if value is not None:
+                    return _json_safe_value(value)
+        try:
+            return ast.unparse(node)
+        except Exception:
+            return None
+
+
+def _ast_annotation_to_string(node):
+    if node is None:
+        return None
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return None
+
+
+def _ast_parameter(name: str, annotation, default_node, kind: str, required: bool, imports: dict) -> dict:
+    return {
+        "name": name,
+        "type": _ast_annotation_to_string(annotation),
+        "required": required,
+        "default": _ast_default_value(default_node, imports),
+        "kind": kind,
+    }
+
+
+def _static_recipe_parameters(module_name: str, class_name: str) -> list:
+    path = _module_source_path(module_name)
+    if not path or not path.is_file():
+        return []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+
+    class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name), None)
+    if class_node is None:
+        return []
+    init_node = next(
+        (
+            node
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "__init__"
+        ),
+        None,
+    )
+    if init_node is None:
+        return []
+
+    imports = _static_imports(tree)
+    params = []
+    args = init_node.args
+    positional = list(args.posonlyargs) + list(args.args)
+    positional_defaults = [None] * (len(positional) - len(args.defaults)) + list(args.defaults)
+    for index, (arg, default_node) in enumerate(zip(positional, positional_defaults)):
+        if arg.arg == "self":
+            continue
+        kind = "positional_only" if index < len(args.posonlyargs) else "positional_or_keyword"
+        params.append(_ast_parameter(arg.arg, arg.annotation, default_node, kind, default_node is None, imports))
+
+    if args.vararg is not None:
+        params.append(_ast_parameter(args.vararg.arg, args.vararg.annotation, None, "var_positional", False, imports))
+
+    for arg, default_node in zip(args.kwonlyargs, args.kw_defaults):
+        params.append(
+            _ast_parameter(arg.arg, arg.annotation, default_node, "keyword_only", default_node is None, imports)
+        )
+
+    if args.kwarg is not None:
+        params.append(_ast_parameter(args.kwarg.arg, args.kwarg.annotation, None, "var_keyword", False, imports))
+
+    return params
 
 
 def _json_safe_value(value):
@@ -675,7 +786,7 @@ def _filter_catalog(catalog: list, filters: dict) -> list:
     return [entry for entry in catalog if _entry_matches_filters(entry, filters)]
 
 
-def _documented_recipe_entry(name: str, spec: dict, include_recipe_class: bool = False) -> dict:
+def _documented_recipe_entry(name: str, spec: dict) -> dict:
     entry = {
         "name": name,
         "description": spec.get("description"),
@@ -698,31 +809,7 @@ def _documented_recipe_entry(name: str, spec: dict, include_recipe_class: bool =
         if key in spec:
             entry[key] = spec[key]
 
-    if include_recipe_class:
-        recipe_cls = _try_import_recipe_class(spec.get("module"), spec.get("class"))
-        if recipe_cls is not None:
-            entry[_CATALOG_RECIPE_CLASS_KEY] = recipe_cls
     return entry
-
-
-def _apply_documented_recipe_specs(catalog: list, include_recipe_class: bool = False) -> list:
-    by_name = {_normalize_recipe_name(entry["name"]): entry for entry in catalog}
-    for name, spec in _DOCUMENTED_RECIPE_SPECS.items():
-        normalized_name = _normalize_recipe_name(name)
-        spec_entry = _documented_recipe_entry(name, spec, include_recipe_class=include_recipe_class)
-        if normalized_name in by_name:
-            existing = by_name[normalized_name]
-            recipe_cls = existing.get(_CATALOG_RECIPE_CLASS_KEY)
-            existing.update({k: v for k, v in spec_entry.items() if v is not None})
-            if recipe_cls is not None:
-                existing[_CATALOG_RECIPE_CLASS_KEY] = recipe_cls
-            elif include_recipe_class and spec_entry.get(_CATALOG_RECIPE_CLASS_KEY) is not None:
-                existing[_CATALOG_RECIPE_CLASS_KEY] = spec_entry[_CATALOG_RECIPE_CLASS_KEY]
-        else:
-            catalog.append(spec_entry)
-            by_name[normalized_name] = spec_entry
-    catalog.sort(key=lambda entry: entry["name"])
-    return catalog
 
 
 def _framework_install_hint(framework: str = None) -> list[str]:
@@ -763,101 +850,78 @@ def _recipe_cli_name(module_name: str, framework: str) -> str:
     return stem
 
 
-def _recipe_description(recipe_cls) -> str:
-    doc = inspect.getdoc(recipe_cls) or ""
-    if not doc:
-        return f"{recipe_cls.__name__} recipe"
-    return next((line.strip() for line in doc.splitlines() if line.strip()), f"{recipe_cls.__name__} recipe")
+def _apply_documented_recipe_specs(catalog: list) -> list:
+    by_name = {_normalize_recipe_name(entry["name"]): entry for entry in catalog}
+    for name, spec in _DOCUMENTED_RECIPE_SPECS.items():
+        normalized_name = _normalize_recipe_name(name)
+        spec_entry = _documented_recipe_entry(name, spec)
+        if normalized_name in by_name:
+            by_name[normalized_name].update(spec_entry)
+        else:
+            catalog.append(spec_entry)
+            by_name[normalized_name] = spec_entry
+    return sorted(catalog, key=lambda entry: entry["name"])
 
 
-def _recipe_base_class():
-    global _RECIPE_BASE_CLASS
-    if _RECIPE_BASE_CLASS is None:
-        from nvflare.recipe.spec import Recipe
-
-        _RECIPE_BASE_CLASS = Recipe
-    return _RECIPE_BASE_CLASS
-
-
-def _iter_recipe_classes(module):
-    recipe_base = _recipe_base_class()
-    for _name, obj in inspect.getmembers(module, inspect.isclass):
-        if obj.__module__ != module.__name__:
-            continue
-        if obj is recipe_base:
-            continue
-        if issubclass(obj, recipe_base):
-            yield obj
-
-
-def _select_recipe_class(module):
-    """Select the single CLI-exposed recipe class for a module.
-
-    Recipe discovery is module-oriented: the CLI name comes from the module name, so a
-    module contributes at most one catalog entry. If a module defines both a reusable base
-    recipe and a concrete subclass, prefer the leaf subclass.
-    """
-
-    classes = list(_iter_recipe_classes(module))
-    if not classes:
-        return None
-    if len(classes) == 1:
-        return classes[0]
-
-    leaf_classes = [cls for cls in classes if not any(cls is not other and issubclass(other, cls) for other in classes)]
-    return leaf_classes[0] if leaf_classes else classes[0]
-
-
-def _load_catalog(framework: str = None, include_recipe_class: bool = False) -> list:
-    """Return available recipes, filtered by framework if given.
-
-    Dynamically discovered recipes are supplemented with documented recipe
-    metadata so recipes remain queryable before optional dependencies are installed.
-    """
+def _discover_recipe_catalog() -> list:
+    """Discover recipe metadata from source without importing recipe modules."""
     results = []
     seen = set()
     for root in _RECIPE_PACKAGE_ROOTS:
-        if framework and root["framework"] != framework:
+        package_path = _package_source_path(root["package"])
+        if not package_path or not package_path.is_dir():
             continue
-        try:
-            package = _import_module(root["package"])
-        except (ImportError, SyntaxError):
-            pass
+        for module_path in sorted(package_path.glob("*.py")):
+            if module_path.name == "__init__.py":
+                continue
+            module_name = f"{root['package']}.{module_path.stem}"
+            recipe_info = _static_recipe_class(module_name)
+            if recipe_info is None:
+                continue
+            recipe_class, description = recipe_info
+            cli_name = _recipe_cli_name(module_name, root["framework"])
+            if cli_name in seen:
+                continue
+            seen.add(cli_name)
+            entry = {
+                "name": cli_name,
+                "description": description,
+                "framework": root["framework"],
+                "module": module_name,
+                "class": recipe_class.name,
+            }
+            entry.update(_static_recipe_metadata(cli_name, module_name, recipe_class))
+            results.append(entry)
+    return _apply_documented_recipe_specs(results)
 
-        else:
-            for _finder, module_name, _is_pkg in pkgutil.iter_modules(package.__path__, package.__name__ + "."):
-                if module_name.endswith(".__init__"):
-                    continue
-                try:
-                    mod = _import_module(module_name)
-                except (ImportError, SyntaxError):
-                    continue
 
-                recipe_cls = _select_recipe_class(mod)
-                if recipe_cls is None:
-                    continue
+def _generate_recipe_catalog() -> dict:
+    discovered = _discover_recipe_catalog()
+    return {
+        "schema_version": _RECIPE_CATALOG_SCHEMA_VERSION,
+        "recipes": [{"summary": entry, "detail": _recipe_detail(entry)} for entry in discovered],
+    }
 
-                cli_name = _recipe_cli_name(module_name, root["framework"])
-                if cli_name in seen:
-                    continue
-                seen.add(cli_name)
-                entry = {
-                    "name": cli_name,
-                    "description": _recipe_description(recipe_cls),
-                    "framework": root["framework"],
-                    "module": module_name,
-                    "class": recipe_cls.__name__,
-                }
-                entry.update(_recipe_metadata(cli_name, recipe_cls))
-                if include_recipe_class:
-                    entry[_CATALOG_RECIPE_CLASS_KEY] = recipe_cls
-                results.append(entry)
 
-    results.sort(key=lambda entry: entry["name"])
-    results = _apply_documented_recipe_specs(results, include_recipe_class=include_recipe_class)
-    if framework:
-        results = [entry for entry in results if entry.get("framework") == framework]
-    return results
+def _read_recipe_catalog() -> list:
+    try:
+        payload = json.loads(_RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"unable to read generated recipe catalog at {_RECIPE_CATALOG_PATH}: {e}") from e
+    if payload.get("schema_version") != _RECIPE_CATALOG_SCHEMA_VERSION or not isinstance(payload.get("recipes"), list):
+        raise RuntimeError(f"invalid generated recipe catalog at {_RECIPE_CATALOG_PATH}")
+    return payload["recipes"]
+
+
+def _load_catalog(framework: str = None, include_recipe_detail: bool = False) -> list:
+    """Return generated recipe metadata, filtered by framework if given.
+
+    Runtime catalog loading only reads JSON. Source discovery and AST inspection
+    are reserved for catalog generation and freshness tests.
+    """
+    entry_type = "detail" if include_recipe_detail else "summary"
+    recipes = [entry[entry_type] for entry in _read_recipe_catalog()]
+    return [entry for entry in recipes if not framework or entry.get("framework") == framework]
 
 
 def cmd_recipe_list(cmd_args):
@@ -978,7 +1042,7 @@ def cmd_recipe_show(cmd_args):
     if not is_json_mode() and not is_jsonl_mode():
         print_human(f"Loading installed recipe metadata for '{getattr(cmd_args, 'name', '')}'...", flush=True)
 
-    catalog = _load_catalog(include_recipe_class=True)
+    catalog = _load_catalog(include_recipe_detail=True)
     entry = next((e for e in catalog if _normalize_recipe_name(e["name"]) == requested_name), None)
     if entry is None:
         output_error_message(
@@ -991,7 +1055,7 @@ def cmd_recipe_show(cmd_args):
         )
         raise SystemExit(4)
 
-    detail = _recipe_detail(entry)
+    detail = entry
     if is_json_mode():
         output_ok(detail)
         return

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
         "nvflare.dashboard.application": extra_files,
         "nvflare.tool.job": job_templates,
         "nvflare.tool.deploy": deploy_templates,
+        "nvflare.tool.recipe": ["recipe_catalog.json"],
     },
     include_package_data=True,
 )

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -557,12 +557,12 @@ def test_data_location_invariants_stay_on_the_always_loaded_path():
 
 
 def test_pytorch_recipe_capability_profiles_match_tensor_disk_offload_support():
-    from nvflare.tool.recipe.recipe_cli import _load_catalog, _recipe_detail
+    from nvflare.tool.recipe.recipe_cli import _load_catalog
 
-    catalog = {entry["name"]: entry for entry in _load_catalog()}
+    catalog = {entry["name"]: entry for entry in _load_catalog(include_recipe_detail=True)}
     parameter_names = {}
     for recipe_name in ("fedavg-pt", "cyclic-pt", "fedeval-pt", "swarm-pt"):
-        detail = _recipe_detail(catalog[recipe_name])
+        detail = catalog[recipe_name]
         parameter_names[recipe_name] = {parameter["name"] for parameter in detail["parameters"]}
 
     assert {"server_expected_format", "enable_tensor_disk_offload"} <= parameter_names["fedavg-pt"]

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -300,42 +300,31 @@ def test_recipe_list_empty_framework_catalog_still_exits_when_output_error_is_mo
 def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
     import json
 
-    from nvflare.recipe.spec import Recipe
     from nvflare.tool import cli_output
-    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, _recipe_detail, cmd_recipe_show
-
-    class FakeRecipe(Recipe):
-        """Fake detailed recipe."""
-
-        optional_dependencies = ["pip install fake-framework"]
-        template_references = ["nvflare/agent/templates/fake"]
-
-        def __init__(
-            self,
-            *,
-            min_clients: int,
-            num_rounds: int = 2,
-            train_script: str = "client.py",
-            per_site_config: dict = None,
-            secure: bool = False,
-        ):
-            pass
+    from nvflare.tool.recipe.recipe_cli import cmd_recipe_show
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
-    detail = _recipe_detail(
-        {
-            "name": "fake-pt",
-            "description": "Fake detailed recipe.",
-            "framework": "pytorch",
-            "module": "fake.recipes.fake",
-            "class": "FakeRecipe",
-            "algorithm": "fedavg",
-            "aggregation": "weighted_average",
-            "state_exchange": "full_model",
-            "privacy": [],
-            _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
-        }
-    )
+    detail = {
+        "name": "fake-pt",
+        "description": "Fake detailed recipe.",
+        "framework": "pytorch",
+        "module": "fake.recipes.fake",
+        "class": "FakeRecipe",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": [],
+        "client_requirements": {
+            "min_clients": {"required": True, "default": None},
+            "requires_training_script": True,
+            "requires_per_site_config": False,
+        },
+        "framework_support": ["pytorch"],
+        "privacy_compatible": ["homomorphic_encryption"],
+        "parameters": [{"name": "num_rounds", "type": "int", "required": False, "default": 2, "kind": "keyword_only"}],
+        "optional_dependencies": ["pip install fake-framework"],
+        "template_references": ["nvflare/agent/templates/fake"],
+    }
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli._load_catalog",
         lambda include_recipe_detail=False, framework=None: [detail],
@@ -360,29 +349,29 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
 
 
 def test_recipe_show_human_output_reports_loading_status(monkeypatch, capsys):
-    from nvflare.recipe.spec import Recipe
     from nvflare.tool import cli_output
-    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, _recipe_detail, cmd_recipe_show
-
-    class FakeRecipe(Recipe):
-        def __init__(self, *, params_transfer_type: str = "FULL"):
-            pass
+    from nvflare.tool.recipe.recipe_cli import cmd_recipe_show
 
     monkeypatch.setattr(cli_output, "_output_format", "txt")
-    detail = _recipe_detail(
-        {
-            "name": "fedavg",
-            "description": "FedAvg recipe.",
-            "framework": "core",
-            "module": "nvflare.recipe.fedavg",
-            "class": "FedAvgRecipe",
-            "algorithm": "fedavg",
-            "aggregation": "weighted_average",
-            "state_exchange": "full_model",
-            "privacy": [],
-            _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
-        }
-    )
+    detail = {
+        "name": "fedavg",
+        "description": "FedAvg recipe.",
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "framework_support": ["pytorch", "tensorflow", "sklearn"],
+        "privacy": [],
+        "privacy_compatible": [],
+        "parameters": [
+            {
+                "name": "params_transfer_type",
+                "type": "str",
+                "required": False,
+                "default": "FULL",
+                "kind": "keyword_only",
+            }
+        ],
+    }
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli._load_catalog",
         lambda include_recipe_detail=False, framework=None: [detail],
@@ -704,6 +693,7 @@ def test_recipe_catalog_generation_discovers_source_without_importing_optional_d
     package_root.mkdir(parents=True)
     (package_root / "kmeans.py").write_text(
         """import unavailable_optional_dependency
+from nvflare.recipe.spec import Recipe
 
 class KMeansFedAvgRecipe(Recipe):
     \"\"\"KMeans recipe.\"\"\"
@@ -761,7 +751,9 @@ def test_recipe_catalog_generation_prefers_leaf_recipe_class(tmp_path, monkeypat
     package_root = tmp_path / "nvflare" / "fake" / "recipes"
     package_root.mkdir(parents=True)
     (package_root / "swarm.py").write_text(
-        """class BaseRecipe(Recipe):
+        """from nvflare.recipe.spec import Recipe
+
+class BaseRecipe(Recipe):
     \"\"\"Base helper recipe.\"\"\"
 
 class FinalWorkflow(BaseRecipe):
@@ -792,7 +784,7 @@ def test_recipe_catalog_generation_resolves_imported_recipe_base_alias(tmp_path,
     package_root = tmp_path / "nvflare" / "fake" / "recipes"
     package_root.mkdir(parents=True)
     (package_root / "alias.py").write_text(
-        """from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedBase
+        """from nvflare.recipe.spec import Recipe as UnifiedBase
 
 class AliasWorkflow(UnifiedBase):
     \"\"\"Recipe with an imported base alias.\"\"\"
@@ -816,13 +808,128 @@ class AliasWorkflow(UnifiedBase):
     assert catalog[0]["description"] == "Recipe with an imported base alias."
 
 
+def test_recipe_catalog_generation_resolves_recipe_ancestry_and_inherited_metadata(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "base.py").write_text(
+        """from nvflare.recipe.spec import Recipe
+
+class Workflow(Recipe):
+    \"\"\"Inherited recipe description.\"\"\"
+
+    recipe_notes = [\"Inherited note.\"]
+
+    def __init__(self, *, num_rounds: int = 2):
+        pass
+""",
+        encoding="utf-8",
+    )
+    (package_root / "child.py").write_text(
+        """from .base import Workflow as Parent
+
+class ConcreteWorkflow(Parent):
+    pass
+""",
+        encoding="utf-8",
+    )
+    (package_root / "unrelated.py").write_text(
+        """class LooksLikeRecipe:
+    \"\"\"Not an NVFLARE recipe.\"\"\"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+
+    recipe_class, description = recipe_cli._static_recipe_class("nvflare.fake.recipes.child")
+
+    assert recipe_class.name == "ConcreteWorkflow"
+    assert description == "Inherited recipe description."
+    assert recipe_cli._static_recipe_class("nvflare.fake.recipes.unrelated") is None
+    assert recipe_cli._static_recipe_attrs("nvflare.fake.recipes.child", "ConcreteWorkflow") == {
+        "recipe_notes": ["Inherited note."]
+    }
+    assert {
+        parameter["name"]
+        for parameter in recipe_cli._static_recipe_parameters("nvflare.fake.recipes.child", "ConcreteWorkflow")
+    } == {"num_rounds"}
+
+
+def test_recipe_catalog_generation_prefers_explicit_literal_metadata_after_dynamic_alias(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "explicit.py").write_text(
+        """from nvflare.recipe.spec import Recipe
+
+class ExplicitMetadata(Recipe):
+    algorithm = compute_algorithm()
+    recipe_algorithm = \"kmeans\"
+    aggregation = compute_aggregation()
+    recipe_aggregation = \"cluster_centers\"
+    state_exchange = compute_state_exchange()
+    recipe_state_exchange = \"cluster_centers\"
+    privacy = compute_privacy()
+    recipe_privacy = {\"z_privacy\", \"a_privacy\"}
+
+    def __init__(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+    monkeypatch.setattr(
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "pytorch"}],
+    )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
+
+    entry = recipe_cli._discover_recipe_catalog()[0]
+
+    assert entry["algorithm"] == "kmeans"
+    assert entry["aggregation"] == "cluster_centers"
+    assert entry["state_exchange"] == "cluster_centers"
+    assert entry["privacy"] == ["a_privacy", "z_privacy"]
+
+
+def test_documented_recipe_specs_do_not_clear_omitted_discovered_metadata(monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    discovered = [
+        {
+            "name": "demo-pt",
+            "description": "Discovered description.",
+            "framework": "pytorch",
+            "module": "nvflare.fake.demo",
+            "class": "DemoWorkflow",
+            "algorithm": "fedavg",
+            "aggregation": "weighted_average",
+            "state_exchange": "full_model",
+            "privacy": ["differential_privacy"],
+        }
+    ]
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {"demo-pt": {"description": "Documented."}})
+
+    entry = recipe_cli._apply_documented_recipe_specs(discovered)[0]
+
+    assert entry["description"] == "Documented."
+    assert entry["framework"] == "pytorch"
+    assert entry["algorithm"] == "fedavg"
+    assert entry["privacy"] == ["differential_privacy"]
+
+
 def test_recipe_catalog_generation_preserves_static_recipe_attributes(tmp_path, monkeypatch):
     from nvflare.tool.recipe import recipe_cli
 
     package_root = tmp_path / "nvflare" / "fake" / "recipes"
     package_root.mkdir(parents=True)
     (package_root / "metadata.py").write_text(
-        """class MetadataRecipe(Recipe):
+        """from nvflare.recipe.spec import Recipe
+
+class MetadataRecipe(Recipe):
     \"\"\"Recipe with explicit metadata.\"\"\"
 
     recipe_framework_support = {\"pytorch\", \"numpy\"}

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -856,6 +856,45 @@ class ConcreteWorkflow(Parent):
     } == {"num_rounds"}
 
 
+def test_static_recipe_metadata_follows_mro_and_explicit_none(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "multiple.py").write_text(
+        """from nvflare.recipe.spec import Recipe
+
+class Left(Recipe):
+    recipe_notes = [\"left\"]
+
+class Right(Recipe):
+    recipe_notes = [\"right\"]
+
+class Child(Left, Right):
+    pass
+
+class Cleared(Left, Right):
+    recipe_notes = None
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+    module_name = "nvflare.fake.recipes.multiple"
+
+    assert [class_name for _, class_name in recipe_cli._static_class_mro(module_name, "Child")] == [
+        "Child",
+        "Left",
+        "Right",
+        "Recipe",
+    ]
+    assert recipe_cli._static_recipe_attrs(module_name, "Child")["recipe_notes"] == ["left"]
+
+    cleared_attrs = recipe_cli._static_recipe_attrs(module_name, "Cleared")
+    assert "recipe_notes" in cleared_attrs
+    assert cleared_attrs["recipe_notes"] is None
+    assert recipe_cli._recipe_metadata_attr(cleared_attrs, "notes") is None
+
+
 def test_recipe_catalog_generation_prefers_explicit_literal_metadata_after_dynamic_alias(tmp_path, monkeypatch):
     from nvflare.tool.recipe import recipe_cli
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -949,6 +949,63 @@ class ExplicitMetadata(Recipe):
     assert entry["privacy"] == ["a_privacy", "z_privacy"]
 
 
+def test_recipe_catalog_generation_infers_only_unresolved_core_metadata(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "kmeans_with_he_dynamic.py").write_text(
+        """from nvflare.recipe.spec import Recipe
+
+class DynamicMetadata(Recipe):
+    algorithm = compute_algorithm()
+    aggregation = compute_aggregation()
+    state_exchange = compute_state_exchange()
+    privacy = compute_privacy()
+""",
+        encoding="utf-8",
+    )
+    (package_root / "kmeans_with_he_none.py").write_text(
+        """from nvflare.recipe.spec import Recipe
+
+class ExplicitNoneMetadata(Recipe):
+    recipe_algorithm = None
+    recipe_aggregation = None
+    recipe_state_exchange = None
+    recipe_privacy = None
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+    monkeypatch.setattr(
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "sklearn"}],
+    )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
+
+    catalog = {entry["name"]: entry for entry in recipe_cli._discover_recipe_catalog()}
+
+    assert {
+        key: catalog["kmeans-with-he-dynamic-sklearn"][key]
+        for key in ("algorithm", "aggregation", "state_exchange", "privacy")
+    } == {
+        "algorithm": "kmeans",
+        "aggregation": "cluster_centers",
+        "state_exchange": "cluster_centers",
+        "privacy": ["homomorphic_encryption"],
+    }
+    assert {
+        key: catalog["kmeans-with-he-none-sklearn"][key]
+        for key in ("algorithm", "aggregation", "state_exchange", "privacy")
+    } == {
+        "algorithm": None,
+        "aggregation": None,
+        "state_exchange": None,
+        "privacy": [],
+    }
+
+
 def test_documented_recipe_specs_do_not_clear_omitted_discovered_metadata(monkeypatch):
     from nvflare.tool.recipe import recipe_cli
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -848,7 +848,7 @@ class ConcreteWorkflow(Parent):
     assert description == "Inherited recipe description."
     assert recipe_cli._static_recipe_class("nvflare.fake.recipes.unrelated") is None
     assert recipe_cli._static_recipe_attrs("nvflare.fake.recipes.child", "ConcreteWorkflow") == {
-        "recipe_notes": ["Inherited note."]
+        "notes": ["Inherited note."]
     }
     assert {
         parameter["name"]
@@ -865,10 +865,18 @@ def test_static_recipe_metadata_follows_mro_and_explicit_none(tmp_path, monkeypa
         """from nvflare.recipe.spec import Recipe
 
 class Left(Recipe):
-    recipe_notes = [\"left\"]
+    recipe_algorithm = \"fedavg\"
+    recipe_aggregation = \"weighted_average\"
+    recipe_state_exchange = \"full_model\"
+    recipe_privacy = {\"left_privacy\"}
+    notes = [\"left\"]
 
 class Right(Recipe):
-    recipe_notes = [\"right\"]
+    recipe_algorithm = \"fedopt\"
+    recipe_aggregation = \"server_optimizer\"
+    recipe_state_exchange = \"weight_diff\"
+    recipe_privacy = {\"right_privacy\"}
+    notes = [\"right\"]
 
 class Child(Left, Right):
     pass
@@ -887,11 +895,18 @@ class Cleared(Left, Right):
         "Right",
         "Recipe",
     ]
-    assert recipe_cli._static_recipe_attrs(module_name, "Child")["recipe_notes"] == ["left"]
+    child_class = recipe_cli._static_class_node(module_name, "Child")[2]
+    assert recipe_cli._static_recipe_metadata("custom-pt", module_name, child_class) == {
+        "algorithm": "fedavg",
+        "aggregation": "weighted_average",
+        "state_exchange": "full_model",
+        "privacy": ["left_privacy"],
+    }
+    assert recipe_cli._static_recipe_attrs(module_name, "Child")["notes"] == ["left"]
 
     cleared_attrs = recipe_cli._static_recipe_attrs(module_name, "Cleared")
-    assert "recipe_notes" in cleared_attrs
-    assert cleared_attrs["recipe_notes"] is None
+    assert "notes" in cleared_attrs
+    assert cleared_attrs["notes"] is None
     assert recipe_cli._recipe_metadata_attr(cleared_attrs, "notes") is None
 
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -16,7 +16,6 @@ import importlib
 import json
 import sys
 from argparse import ArgumentParser, Namespace
-from types import ModuleType
 
 import pytest
 
@@ -303,7 +302,7 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
 
     from nvflare.recipe.spec import Recipe
     from nvflare.tool import cli_output
-    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, cmd_recipe_show
+    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, _recipe_detail, cmd_recipe_show
 
     class FakeRecipe(Recipe):
         """Fake detailed recipe."""
@@ -323,22 +322,23 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
             pass
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
+    detail = _recipe_detail(
+        {
+            "name": "fake-pt",
+            "description": "Fake detailed recipe.",
+            "framework": "pytorch",
+            "module": "fake.recipes.fake",
+            "class": "FakeRecipe",
+            "algorithm": "fedavg",
+            "aggregation": "weighted_average",
+            "state_exchange": "full_model",
+            "privacy": [],
+            _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
+        }
+    )
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli._load_catalog",
-        lambda include_recipe_class=False, framework=None: [
-            {
-                "name": "fake-pt",
-                "description": "Fake detailed recipe.",
-                "framework": "pytorch",
-                "module": "fake.recipes.fake",
-                "class": "FakeRecipe",
-                "algorithm": "fedavg",
-                "aggregation": "weighted_average",
-                "state_exchange": "full_model",
-                "privacy": [],
-                _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
-            }
-        ],
+        lambda include_recipe_detail=False, framework=None: [detail],
     )
 
     cmd_recipe_show(Namespace(name="fake-pt"))
@@ -362,29 +362,30 @@ def test_recipe_show_returns_queryable_metadata(monkeypatch, capsys):
 def test_recipe_show_human_output_reports_loading_status(monkeypatch, capsys):
     from nvflare.recipe.spec import Recipe
     from nvflare.tool import cli_output
-    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, cmd_recipe_show
+    from nvflare.tool.recipe.recipe_cli import _CATALOG_RECIPE_CLASS_KEY, _recipe_detail, cmd_recipe_show
 
     class FakeRecipe(Recipe):
         def __init__(self, *, params_transfer_type: str = "FULL"):
             pass
 
     monkeypatch.setattr(cli_output, "_output_format", "txt")
+    detail = _recipe_detail(
+        {
+            "name": "fedavg",
+            "description": "FedAvg recipe.",
+            "framework": "core",
+            "module": "nvflare.recipe.fedavg",
+            "class": "FedAvgRecipe",
+            "algorithm": "fedavg",
+            "aggregation": "weighted_average",
+            "state_exchange": "full_model",
+            "privacy": [],
+            _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
+        }
+    )
     monkeypatch.setattr(
         "nvflare.tool.recipe.recipe_cli._load_catalog",
-        lambda include_recipe_class=False, framework=None: [
-            {
-                "name": "fedavg",
-                "description": "FedAvg recipe.",
-                "framework": "core",
-                "module": "nvflare.recipe.fedavg",
-                "class": "FedAvgRecipe",
-                "algorithm": "fedavg",
-                "aggregation": "weighted_average",
-                "state_exchange": "full_model",
-                "privacy": [],
-                _CATALOG_RECIPE_CLASS_KEY: FakeRecipe,
-            }
-        ],
+        lambda include_recipe_detail=False, framework=None: [detail],
     )
 
     cmd_recipe_show(Namespace(name="fedavg"))
@@ -404,7 +405,7 @@ def test_recipe_show_unknown_recipe_errors(monkeypatch, capsys):
     from nvflare.tool.recipe.recipe_cli import cmd_recipe_show
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._load_catalog", lambda include_recipe_class=False: [])
+    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._load_catalog", lambda include_recipe_detail=False: [])
 
     with pytest.raises(SystemExit) as exc_info:
         cmd_recipe_show(Namespace(name="missing"))
@@ -460,18 +461,16 @@ def test_recipe_list_schema_includes_command_contract_metadata(capsys):
     assert schema["retry_token"] == {"supported": False}
 
 
-def test_recipe_detail_can_be_built_for_each_discovered_recipe():
-    from nvflare.tool.recipe.recipe_cli import _load_catalog, _recipe_detail
+def test_recipe_detail_is_available_for_each_catalog_recipe():
+    from nvflare.tool.recipe.recipe_cli import _load_catalog
 
-    catalog = _load_catalog(include_recipe_class=True)
+    catalog = _load_catalog(include_recipe_detail=True)
     assert catalog
 
     for entry in catalog:
-        detail = _recipe_detail(entry)
-        assert detail["name"] == entry["name"]
-        assert "parameters" in detail
-        assert "framework_support" in detail
-        assert "privacy_compatible" in detail
+        assert "parameters" in entry
+        assert "framework_support" in entry
+        assert "privacy_compatible" in entry
 
 
 def test_recipe_catalog_includes_all_documented_recipe_variants():
@@ -508,16 +507,6 @@ def test_recipe_show_fedprox_uses_concrete_recipe(monkeypatch, capsys):
     from nvflare.tool.recipe import recipe_cli
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
-    monkeypatch.setattr(
-        recipe_cli,
-        "_RECIPE_PACKAGE_ROOTS",
-        [{"package": "nvflare.app_opt.pt.recipes", "framework": "pytorch"}],
-    )
-    monkeypatch.setattr(
-        recipe_cli,
-        "_DOCUMENTED_RECIPE_SPECS",
-        {"fedprox-pt": recipe_cli._DOCUMENTED_RECIPE_SPECS["fedprox-pt"]},
-    )
 
     recipe_cli.cmd_recipe_show(Namespace(name="fedprox-pt"))
 
@@ -534,13 +523,55 @@ def test_recipe_show_fedprox_uses_concrete_recipe(monkeypatch, capsys):
     assert "Lightning" in data["notes"][0]
 
 
+def test_recipe_list_uses_generated_catalog_without_importing_recipe_modules(monkeypatch, capsys):
+    import importlib
+    import json
+
+    from nvflare.tool import cli_output
+    from nvflare.tool.recipe.recipe_cli import _RECIPE_PACKAGE_ROOTS, cmd_recipe_list
+
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+    real_import_module = importlib.import_module
+    recipe_packages = tuple(root["package"] for root in _RECIPE_PACKAGE_ROOTS)
+
+    def reject_recipe_import(name, *args, **kwargs):
+        if name.startswith(recipe_packages):
+            raise AssertionError(f"recipe listing unexpectedly imported {name}")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", reject_recipe_import)
+
+    cmd_recipe_list(Namespace(framework=None, filters=[]))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    assert len(payload["data"]) == 25
+
+
 def test_recipe_show_uses_static_metadata_when_optional_dependency_is_missing(monkeypatch, capsys):
+    import builtins
+    import importlib
     import json
 
     from nvflare.tool import cli_output
     from nvflare.tool.recipe.recipe_cli import cmd_recipe_show
 
     monkeypatch.setattr(cli_output, "_output_format", "json")
+    real_import = builtins.__import__
+    real_import_module = importlib.import_module
+
+    def reject_xgboost_import(name, *args, **kwargs):
+        if name == "xgboost" or name.startswith("nvflare.app_opt.xgboost"):
+            raise AssertionError(f"recipe metadata unexpectedly imported {name}")
+        return real_import(name, *args, **kwargs)
+
+    def reject_xgboost_import_module(name, *args, **kwargs):
+        if name == "xgboost" or name.startswith("nvflare.app_opt.xgboost"):
+            raise AssertionError(f"recipe metadata unexpectedly imported {name}")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_xgboost_import)
+    monkeypatch.setattr(importlib, "import_module", reject_xgboost_import_module)
 
     cmd_recipe_show(Namespace(name="xgb-horizontal"))
 
@@ -556,272 +587,102 @@ def test_recipe_show_uses_static_metadata_when_optional_dependency_is_missing(mo
     assert data["parameters"]
 
 
-def test_recipe_catalog_is_discovered_from_package_modules(monkeypatch):
-    from nvflare.recipe.spec import Recipe
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
+def test_recipe_catalog_generation_discovers_source_without_importing_optional_dependencies(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
 
-    class FakeRecipe(Recipe):
-        """Demo discovered recipe."""
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "kmeans.py").write_text(
+        """import unavailable_optional_dependency
 
-        def __init__(self):
-            pass
+class KMeansFedAvgRecipe(Recipe):
+    \"\"\"KMeans recipe.\"\"\"
 
-    fake_package = ModuleType("fake.recipes")
-    fake_package.__path__ = ["fake/recipes"]
-
-    fake_module = ModuleType("fake.recipes.fedavg")
-    FakeRecipe.__module__ = "fake.recipes.fedavg"
-    setattr(fake_module, "FakeRecipe", FakeRecipe)
-
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [{"package": "fake.recipes", "framework": "pytorch"}],
+    def __init__(self, *, num_rounds: int = 2):
+        pass
+""",
+        encoding="utf-8",
     )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
-
-    def fake_import_module(name):
-        if name == "fake.recipes":
-            return fake_package
-        if name == "fake.recipes.fedavg":
-            return fake_module
-        raise ImportError(name)
-
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
     monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.recipes.fedavg", False)],
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "sklearn"}],
     )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
 
-    catalog = _load_catalog(framework="pytorch")
+    catalog = recipe_cli._discover_recipe_catalog()
 
     assert catalog == [
         {
-            "name": "fedavg-pt",
-            "description": "Demo discovered recipe.",
-            "framework": "pytorch",
-            "module": "fake.recipes.fedavg",
-            "class": "FakeRecipe",
-            "algorithm": "fedavg",
-            "aggregation": "weighted_average",
-            "state_exchange": "full_model",
+            "name": "kmeans-sklearn",
+            "description": "KMeans recipe.",
+            "framework": "sklearn",
+            "module": "nvflare.fake.recipes.kmeans",
+            "class": "KMeansFedAvgRecipe",
+            "algorithm": "kmeans",
+            "aggregation": "cluster_centers",
+            "state_exchange": "cluster_centers",
             "privacy": [],
         }
     ]
 
 
-def test_recipe_catalog_prefers_specific_algorithm_marker_over_fedavg_class_name(monkeypatch):
-    from nvflare.recipe.spec import Recipe
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
+def test_recipe_catalog_generation_skips_syntax_errors(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
 
-    class KMeansFedAvgRecipe(Recipe):
-        """KMeans recipe."""
-
-        def __init__(self):
-            pass
-
-    fake_package = ModuleType("fake.recipes")
-    fake_package.__path__ = ["fake/recipes"]
-
-    fake_module = ModuleType("fake.recipes.kmeans")
-    KMeansFedAvgRecipe.__module__ = "fake.recipes.kmeans"
-    setattr(fake_module, "KMeansFedAvgRecipe", KMeansFedAvgRecipe)
-
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "broken.py").write_text("class BrokenRecipe(Recipe)\n    pass", encoding="utf-8")
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
     monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [{"package": "fake.recipes", "framework": "sklearn"}],
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "pytorch"}],
     )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
 
-    def fake_import_module(name):
-        if name == "fake.recipes":
-            return fake_package
-        if name == "fake.recipes.kmeans":
-            return fake_module
-        raise ImportError(name)
+    assert recipe_cli._discover_recipe_catalog() == []
 
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
+
+def test_recipe_catalog_generation_prefers_leaf_recipe_class(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "swarm.py").write_text(
+        """class BaseRecipe(Recipe):
+    \"\"\"Base helper recipe.\"\"\"
+
+class FinalWorkflow(BaseRecipe):
+    \"\"\"Concrete exported recipe.\"\"\"
+
+    def __init__(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
     monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.recipes.kmeans", False)],
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "pytorch"}],
     )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
 
-    catalog = _load_catalog(framework="sklearn")
+    catalog = recipe_cli._discover_recipe_catalog()
 
-    assert catalog[0]["algorithm"] == "kmeans"
-    assert catalog[0]["aggregation"] == "cluster_centers"
-    assert catalog[0]["state_exchange"] == "cluster_centers"
-
-
-def test_recipe_catalog_core_framework_is_not_special_catch_all(monkeypatch):
-    from nvflare.recipe.spec import Recipe
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
-
-    class CoreRecipe(Recipe):
-        """Core recipe."""
-
-        def __init__(self):
-            pass
-
-    core_package = ModuleType("fake.core")
-    core_package.__path__ = ["fake/core"]
-
-    core_module = ModuleType("fake.core.fedavg")
-    CoreRecipe.__module__ = "fake.core.fedavg"
-    setattr(core_module, "CoreRecipe", CoreRecipe)
-
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [
-            {"package": "fake.core", "framework": "core"},
-            {"package": "fake.pt", "framework": "pytorch"},
-        ],
-    )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
-
-    def fake_import_module(name):
-        if name == "fake.core":
-            return core_package
-        if name == "fake.core.fedavg":
-            return core_module
-        raise ModuleNotFoundError(name)
-
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.core.fedavg", False)],
-    )
-
-    assert _load_catalog(framework="pytorch") == []
-    assert _load_catalog(framework="core") == [
-        {
-            "name": "fedavg",
-            "description": "Core recipe.",
-            "framework": "core",
-            "module": "fake.core.fedavg",
-            "class": "CoreRecipe",
-            "algorithm": "fedavg",
-            "aggregation": "weighted_average",
-            "state_exchange": "full_model",
-            "privacy": [],
-        }
-    ]
+    assert catalog[0]["class"] == "FinalWorkflow"
+    assert catalog[0]["description"] == "Concrete exported recipe."
 
 
-def test_recipe_catalog_skips_plain_import_errors_from_optional_recipes(monkeypatch):
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
+def test_generated_recipe_catalog_is_current():
+    from nvflare.tool.recipe.generate_recipe_catalog import _render_catalog
+    from nvflare.tool.recipe.recipe_cli import _RECIPE_CATALOG_PATH
 
-    fake_package = ModuleType("fake.recipes")
-    fake_package.__path__ = ["fake/recipes"]
-
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [{"package": "fake.recipes", "framework": "pytorch"}],
-    )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
-
-    def fake_import_module(name):
-        if name == "fake.recipes":
-            return fake_package
-        if name == "fake.recipes.broken":
-            raise ImportError("broken recipe import")
-        raise ModuleNotFoundError(name)
-
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.recipes.broken", False)],
-    )
-
-    assert _load_catalog(framework="pytorch") == []
-
-
-def test_recipe_catalog_skips_syntax_errors_from_optional_recipes(monkeypatch):
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
-
-    fake_package = ModuleType("fake.recipes")
-    fake_package.__path__ = ["fake/recipes"]
-
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [{"package": "fake.recipes", "framework": "pytorch"}],
-    )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
-
-    def fake_import_module(name):
-        if name == "fake.recipes":
-            return fake_package
-        if name == "fake.recipes.broken":
-            raise SyntaxError("invalid syntax")
-        raise ModuleNotFoundError(name)
-
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.recipes.broken", False)],
-    )
-
-    assert _load_catalog(framework="pytorch") == []
-
-
-def test_recipe_catalog_prefers_leaf_recipe_class_when_module_has_base_and_subclass(monkeypatch):
-    from nvflare.recipe.spec import Recipe
-    from nvflare.tool.recipe.recipe_cli import _load_catalog
-
-    class BaseRecipe(Recipe):
-        """Base helper recipe."""
-
-        def __init__(self):
-            pass
-
-    class FinalRecipe(BaseRecipe):
-        """Concrete exported recipe."""
-
-        def __init__(self):
-            pass
-
-    fake_package = ModuleType("fake.recipes")
-    fake_package.__path__ = ["fake/recipes"]
-
-    fake_module = ModuleType("fake.recipes.swarm")
-    BaseRecipe.__module__ = "fake.recipes.swarm"
-    FinalRecipe.__module__ = "fake.recipes.swarm"
-    setattr(fake_module, "BaseRecipe", BaseRecipe)
-    setattr(fake_module, "FinalRecipe", FinalRecipe)
-
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli._RECIPE_PACKAGE_ROOTS",
-        [{"package": "fake.recipes", "framework": "pytorch"}],
-    )
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._DOCUMENTED_RECIPE_SPECS", {})
-
-    def fake_import_module(name):
-        if name == "fake.recipes":
-            return fake_package
-        if name == "fake.recipes.swarm":
-            return fake_module
-        raise ImportError(name)
-
-    monkeypatch.setattr("nvflare.tool.recipe.recipe_cli._import_module", fake_import_module)
-    monkeypatch.setattr(
-        "nvflare.tool.recipe.recipe_cli.pkgutil.iter_modules",
-        lambda path, prefix="": [(None, "fake.recipes.swarm", False)],
-    )
-
-    catalog = _load_catalog(framework="pytorch")
-
-    assert catalog == [
-        {
-            "name": "swarm-pt",
-            "description": "Concrete exported recipe.",
-            "framework": "pytorch",
-            "module": "fake.recipes.swarm",
-            "class": "FinalRecipe",
-            "algorithm": "swarm",
-            "aggregation": None,
-            "state_exchange": "full_model",
-            "privacy": [],
-        }
-    ]
+    assert (
+        _RECIPE_CATALOG_PATH.read_text(encoding="utf-8") == _render_catalog()
+    ), "recipe catalog is stale; run 'python -m nvflare.tool.recipe.generate_recipe_catalog'"
 
 
 def test_recipe_cli_import_does_not_consume_recipe_export_args(monkeypatch):

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -443,6 +443,7 @@ def test_recipe_list_reports_missing_generated_catalog(monkeypatch, capsys, tmp_
         [],
         {"schema_version": 999, "recipes": []},
         {"schema_version": 1, "recipes": [{}]},
+        {"schema_version": 1, "recipes": [{"summary": {}, "detail": {}}]},
     ],
 )
 def test_recipe_show_reports_invalid_generated_catalog(payload, monkeypatch, capsys, tmp_path):
@@ -464,6 +465,31 @@ def test_recipe_show_reports_invalid_generated_catalog(payload, monkeypatch, cap
     assert payload["error_code"] == "INTERNAL_ERROR"
     assert payload["exit_code"] == 5
     assert "invalid generated recipe catalog" in payload["message"]
+
+
+def test_recipe_catalog_entry_validation_requires_fields_and_types():
+    from nvflare.tool.recipe import recipe_cli
+
+    catalog = json.loads(recipe_cli._RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
+    valid_entry = catalog["recipes"][0]
+    assert recipe_cli._is_valid_catalog_entry(valid_entry)
+
+    for section in ("summary", "detail"):
+        invalid_entry = json.loads(json.dumps(valid_entry))
+        invalid_entry[section] = {}
+        assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
+
+    invalid_entry = json.loads(json.dumps(valid_entry))
+    invalid_entry["summary"]["framework"] = []
+    assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
+
+    invalid_entry = json.loads(json.dumps(valid_entry))
+    invalid_entry["detail"]["framework_support"] = "pytorch"
+    assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
+
+    invalid_entry = json.loads(json.dumps(valid_entry))
+    invalid_entry["detail"]["parameters"] = [None]
+    assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
 
 
 def test_recipe_show_schema_succeeds_without_name(capsys):
@@ -764,8 +790,9 @@ def test_recipe_catalog_generation_preserves_static_recipe_attributes(tmp_path, 
         """class MetadataRecipe(Recipe):
     \"\"\"Recipe with explicit metadata.\"\"\"
 
-    recipe_framework_support = [\"pytorch\", \"numpy\"]
-    recipe_optional_dependencies = [\"pip install demo-framework\"]
+    recipe_framework_support = {\"pytorch\", \"numpy\"}
+    recipe_optional_dependencies = {\"pip install z-framework\", \"pip install a-framework\"}
+    recipe_privacy = {\"z_privacy\", \"a_privacy\"}
     recipe_heterogeneity_support = [\"non_iid\"]
     recipe_privacy_compatible = [\"differential_privacy\"]
     recipe_notes = [\"Custom recipe note.\"]
@@ -784,13 +811,19 @@ def test_recipe_catalog_generation_preserves_static_recipe_attributes(tmp_path, 
     )
     monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
 
-    generated = recipe_cli._generate_recipe_catalog()["recipes"][0]
+    from nvflare.tool.recipe.generate_recipe_catalog import _render_catalog
+
+    generated = json.loads(_render_catalog())["recipes"][0]
 
     assert "_recipe_attrs" not in generated["summary"]
-    assert generated["detail"]["framework_support"] == ["pytorch", "numpy"]
-    assert generated["detail"]["optional_dependencies"] == ["pip install demo-framework"]
+    assert generated["summary"]["privacy"] == ["a_privacy", "z_privacy"]
+    assert generated["detail"]["framework_support"] == ["numpy", "pytorch"]
+    assert generated["detail"]["optional_dependencies"] == [
+        "pip install a-framework",
+        "pip install z-framework",
+    ]
     assert generated["detail"]["heterogeneity_support"] == ["non_iid"]
-    assert generated["detail"]["privacy_compatible"] == ["differential_privacy"]
+    assert generated["detail"]["privacy_compatible"] == ["a_privacy", "differential_privacy", "z_privacy"]
     assert generated["detail"]["notes"] == ["Custom recipe note."]
     assert generated["detail"]["template_references"] == ["nvflare/example/template"]
 

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -417,6 +417,55 @@ def test_recipe_show_unknown_recipe_errors(monkeypatch, capsys):
     assert "nvflare recipe list --format json" in captured.out
 
 
+def test_recipe_list_reports_missing_generated_catalog(monkeypatch, capsys, tmp_path):
+    from nvflare.tool import cli_output
+    from nvflare.tool.recipe import recipe_cli
+
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+    monkeypatch.setattr(recipe_cli, "_RECIPE_CATALOG_PATH", tmp_path / "missing.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        recipe_cli.cmd_recipe_list(Namespace(framework=None, filters=[]))
+
+    assert exc_info.value.code == 5
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["exit_code"] == 5
+    assert "Unable to load recipe metadata" in payload["message"]
+    assert "regenerate the catalog" in payload["hint"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"schema_version": 999, "recipes": []},
+        {"schema_version": 1, "recipes": [{}]},
+    ],
+)
+def test_recipe_show_reports_invalid_generated_catalog(payload, monkeypatch, capsys, tmp_path):
+    from nvflare.tool import cli_output
+    from nvflare.tool.recipe import recipe_cli
+
+    invalid_catalog = tmp_path / "invalid.json"
+    invalid_catalog.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+    monkeypatch.setattr(recipe_cli, "_RECIPE_CATALOG_PATH", invalid_catalog)
+
+    with pytest.raises(SystemExit) as exc_info:
+        recipe_cli.cmd_recipe_show(Namespace(name="fedavg-pt"))
+
+    assert exc_info.value.code == 5
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert payload["exit_code"] == 5
+    assert "invalid generated recipe catalog" in payload["message"]
+
+
 def test_recipe_show_schema_succeeds_without_name(capsys):
     from unittest.mock import patch
 
@@ -674,6 +723,76 @@ class FinalWorkflow(BaseRecipe):
 
     assert catalog[0]["class"] == "FinalWorkflow"
     assert catalog[0]["description"] == "Concrete exported recipe."
+
+
+def test_recipe_catalog_generation_resolves_imported_recipe_base_alias(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "alias.py").write_text(
+        """from nvflare.recipe.fedavg import FedAvgRecipe as UnifiedBase
+
+class AliasWorkflow(UnifiedBase):
+    \"\"\"Recipe with an imported base alias.\"\"\"
+
+    def __init__(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+    monkeypatch.setattr(
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "pytorch"}],
+    )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
+
+    catalog = recipe_cli._discover_recipe_catalog()
+
+    assert catalog[0]["class"] == "AliasWorkflow"
+    assert catalog[0]["description"] == "Recipe with an imported base alias."
+
+
+def test_recipe_catalog_generation_preserves_static_recipe_attributes(tmp_path, monkeypatch):
+    from nvflare.tool.recipe import recipe_cli
+
+    package_root = tmp_path / "nvflare" / "fake" / "recipes"
+    package_root.mkdir(parents=True)
+    (package_root / "metadata.py").write_text(
+        """class MetadataRecipe(Recipe):
+    \"\"\"Recipe with explicit metadata.\"\"\"
+
+    recipe_framework_support = [\"pytorch\", \"numpy\"]
+    recipe_optional_dependencies = [\"pip install demo-framework\"]
+    recipe_heterogeneity_support = [\"non_iid\"]
+    recipe_privacy_compatible = [\"differential_privacy\"]
+    recipe_notes = [\"Custom recipe note.\"]
+    recipe_template_references = [\"nvflare/example/template\"]
+
+    def __init__(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(recipe_cli, "_NVFLARE_PACKAGE_ROOT", tmp_path / "nvflare")
+    monkeypatch.setattr(
+        recipe_cli,
+        "_RECIPE_PACKAGE_ROOTS",
+        [{"package": "nvflare.fake.recipes", "framework": "pytorch"}],
+    )
+    monkeypatch.setattr(recipe_cli, "_DOCUMENTED_RECIPE_SPECS", {})
+
+    generated = recipe_cli._generate_recipe_catalog()["recipes"][0]
+
+    assert "_recipe_attrs" not in generated["summary"]
+    assert generated["detail"]["framework_support"] == ["pytorch", "numpy"]
+    assert generated["detail"]["optional_dependencies"] == ["pip install demo-framework"]
+    assert generated["detail"]["heterogeneity_support"] == ["non_iid"]
+    assert generated["detail"]["privacy_compatible"] == ["differential_privacy"]
+    assert generated["detail"]["notes"] == ["Custom recipe note."]
+    assert generated["detail"]["template_references"] == ["nvflare/example/template"]
 
 
 def test_generated_recipe_catalog_is_current():

--- a/tests/unit_test/tool/recipe_cli_test.py
+++ b/tests/unit_test/tool/recipe_cli_test.py
@@ -467,12 +467,32 @@ def test_recipe_show_reports_invalid_generated_catalog(payload, monkeypatch, cap
     assert "invalid generated recipe catalog" in payload["message"]
 
 
+def test_recipe_show_reports_invalid_parameter_metadata(monkeypatch, capsys, tmp_path):
+    from nvflare.tool import cli_output
+    from nvflare.tool.recipe import recipe_cli
+
+    catalog = json.loads(recipe_cli._RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
+    catalog["recipes"][0]["detail"]["parameters"] = [{}]
+    invalid_catalog = tmp_path / "invalid-parameter.json"
+    invalid_catalog.write_text(json.dumps(catalog), encoding="utf-8")
+    monkeypatch.setattr(cli_output, "_output_format", "json")
+    monkeypatch.setattr(recipe_cli, "_RECIPE_CATALOG_PATH", invalid_catalog)
+
+    with pytest.raises(SystemExit) as exc_info:
+        recipe_cli.cmd_recipe_show(Namespace(name=catalog["recipes"][0]["detail"]["name"]))
+
+    assert exc_info.value.code == 5
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert "invalid generated recipe catalog" in payload["message"]
+
+
 def test_recipe_catalog_entry_validation_requires_fields_and_types():
     from nvflare.tool.recipe import recipe_cli
 
     catalog = json.loads(recipe_cli._RECIPE_CATALOG_PATH.read_text(encoding="utf-8"))
+    assert all(recipe_cli._is_valid_catalog_entry(entry) for entry in catalog["recipes"])
     valid_entry = catalog["recipes"][0]
-    assert recipe_cli._is_valid_catalog_entry(valid_entry)
 
     for section in ("summary", "detail"):
         invalid_entry = json.loads(json.dumps(valid_entry))
@@ -487,8 +507,23 @@ def test_recipe_catalog_entry_validation_requires_fields_and_types():
     invalid_entry["detail"]["framework_support"] = "pytorch"
     assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
 
+    parameter = valid_entry["detail"]["parameters"][0]
+    for field, invalid_value in (
+        ("name", None),
+        ("type", []),
+        ("required", 1),
+        ("kind", None),
+    ):
+        invalid_entry = json.loads(json.dumps(valid_entry))
+        invalid_parameter = dict(parameter)
+        invalid_parameter[field] = invalid_value
+        invalid_entry["detail"]["parameters"] = [invalid_parameter]
+        assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
+
     invalid_entry = json.loads(json.dumps(valid_entry))
-    invalid_entry["detail"]["parameters"] = [None]
+    invalid_parameter = dict(parameter)
+    invalid_parameter.pop("default")
+    invalid_entry["detail"]["parameters"] = [invalid_parameter]
     assert not recipe_cli._is_valid_catalog_entry(invalid_entry)
 
 


### PR DESCRIPTION
## Summary
- serve `nvflare recipe list` and `nvflare recipe show` from a packaged, generated metadata catalog
- discover recipe classes through static inheritance analysis and extract constructor metadata with AST only when regenerating the catalog
- add a freshness check so new recipes and constructor changes cannot leave the catalog stale
- preserve the existing 25-recipe list output while preventing unrelated optional frameworks from loading

## Motivation
`nvflare recipe list` without a framework filter previously discovered every recipe package dynamically, causing the XGBoost recipe package and its native XGBoost library to be loaded. `nvflare recipe show fedavg-pt` used the same unfiltered discovery path, so it could also fail on macOS when `libomp` was unavailable even though the requested recipe was PyTorch-only. Recipe metadata queries should not require optional framework packages or native runtimes.

## Validation
- `python -m pytest tests/unit_test/tool/recipe_cli_test.py tests/unit_test/tool/agent/agent_json_contract_test.py tests/unit_test/tool/agent_skill_checks/seed_skills_test.py -q` (81 passed)
- `python -m pytest tests/unit_test/tool -q` (2,777 passed, 39 skipped; one sandbox-denied Unix-socket test passed when rerun with socket permission)
- full CLI startup import guard: both `recipe list` and `recipe show fedavg-pt` succeeded while XGBoost imports were rejected
- `python -m nvflare.tool.recipe.generate_recipe_catalog --check`
- `./runtest.sh -s`
- generated catalog confirmed present in installed package metadata
