### PR TITLE
Add NVFlare Day 2026 link

### DIFF
--- a/web/src/components/hero.astro
+++ b/web/src/components/hero.astro
@@ -67,6 +67,9 @@ const base_url = import.meta.env.BASE_URL;
                   <li>
                       <a href="https://developer.nvidia.com/flare-day-2025" class="rounded-lg block px-4 py-2 hover:text-gray-900">2025</a>
                   </li>
+                  <li>
+                      <a href="https://events.nvidia.com/flare-day-2026" class="rounded-lg block px-4 py-2 hover:text-gray-900">2026</a>
+                  </li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- add the NVFlare Day 2026 event page to the homepage FLARE Day dropdown

## Testing

- `npm run build` (from `web/`)