### PR TITLE
Fix external trainer settlement and receiver parsing

### DIFF
--- a/docs/design/client_api_execution_modes.md
+++ b/docs/design/client_api_execution_modes.md
@@ -303,11 +303,13 @@ trainer to stop and starts the natural-exit reaper. This also covers inline resu
 reply can race END_RUN even though they create no download transaction. Teardown cannot safely
 return with a daemon reaper because ClientRunner tears down streaming and the CJ Cell immediately
 after END_RUN. A result transfer retains its own `DownloadService` idle/receiver policy, but that
-longer data-transfer budget does not govern CJ process ownership. END_RUN gives a still-live result
-source one acknowledged SHUTDOWN interval, then force-stops every remaining owned process group.
-A source already known to be settled instead receives its configured natural-exit budget and a
-small configured TERM grace, both inside a 30-second cleanup cap, so normal post-send checkpoint
-work is not cut off at the live-source acknowledgement deadline. A run-abort-marked `ABORT_TASK`
+longer data-transfer budget does not govern CJ process ownership. END_RUN uses a short acknowledged
+SHUTDOWN request to sample send-barrier state throughout a 30-second session-scale interval. The
+trainer publishes transfer-barrier completion before waiting for `RESULT_SOURCE_SETTLED`, and the
+reaper makes a final SHUTDOWN probe at the deadline. Therefore a completed transfer is treated as
+settled even if its separate settlement acknowledgement is delayed. A source already known to be
+settled instead receives its configured natural-exit budget and a small configured TERM grace inside
+the cleanup budget. A run-abort-marked `ABORT_TASK`
 latches aborted teardown even when `execute()` already returned the lazy result, sends ABORT
 immediately, and bypasses the normal result-source drain interval. Task/workflow-only cancellation
 sends ABORT without poisoning later tasks, and normal END_RUN carries no run-abort marker. Other
@@ -320,9 +322,18 @@ For a per-task trainer whose accepted result already has a registered natural-ex
 
 Startup waits at most `launch_timeout` for the trainer to complete its HELLO handshake. The
 default is 300 seconds; callers may explicitly use `None` when an unbounded wait is required. For
-ordinary shutdown, a `shutdown_timeout` of zero is kept as zero and starts process-group termination
-immediately after the orderly SHUTDOWN notification. An accepted result whose publication is
-still live receives the short acknowledgement interval described above before process cleanup.
+ordinary teardown without a live accepted result source, a `shutdown_timeout` of zero is kept as
+zero and starts process-group termination immediately after the orderly SHUTDOWN notification. The
+same setting also bounds the finalize execute-gate wait, supplies the accepted-source disconnect
+grace, bounds the post-settlement process-group exit wait, and feeds the settled per-task reaper
+budget. Zero skips the direct orderly-exit and finalize-gate waits, but the accepted-source
+disconnect and post-settlement group-exit roles normalize it to the 30-second backend default. That
+fallback also feeds the fixed 30-second settled-reaper budget, which reserves up to 5 seconds for
+termination. This zero configuration is the live default for `ScriptRunner`.
+The accepted-result reaper caps `stop_grace_period` at 5 seconds inside its fixed 30-second cleanup
+budget, while ordinary forced teardown honors the full configured grace. An accepted result whose
+publication is still live receives the 30-second transfer-barrier interval described above and one
+final bounded SHUTDOWN state probe before process cleanup.
 
 The backend starts the command in an owned process group on POSIX, monitors process-group exit and
 the authenticated heartbeat lease, and rejects messages from stale sessions or unexpected Cell
@@ -331,13 +342,15 @@ trainer watches that owner and terminates its isolated process group if the CJ d
 normal finalization can reap it. Attach mode never receives or watches a CJ process ID because the
 attached process is externally owned. With a positive orderly-shutdown bound, shutdown sends a
 bounded Cell request and charges its acknowledgement time against that bound; a zero bound keeps the
-immediate fire-and-forget notification for ordinary teardown. A live accepted-result publication
+immediate fire-and-forget notification for ordinary teardown without a live accepted result. A live accepted-result publication
 always uses a short, acknowledged SHUTDOWN request because the trainer cannot be force-stopped
 before its send barrier settles; the source reaper retries transient control-path failures. Its
 acknowledgement also
 reports whether `send()` still owns that barrier. This state transition is serialized with
-SHUTDOWN: either `send()` sees the stop and closes after terminal settlement, or the backend learns
-that settlement already happened and can stop the persistent process. A standard trainer loop also releases its Cell
+SHUTDOWN: once downstream transfer cleanup releases the barrier, the backend can learn that the
+source is settled while the trainer is still waiting for the task-correlated settlement reply.
+Either `send()` then sees the stop and closes after the reply, or the backend can safely stop the
+persistent process without reporting the completed source as lost. A standard trainer loop also releases its Cell
 synchronously when `receive()` or `is_running()` observes the shutdown (or abort), so existing
 scripts do not need an explicit `flare.shutdown()` at loop exit. The backend then terminates any
 surviving owned POSIX process group with a bounded soft/hard stop sequence. Because a directly launched trainer does not run under

--- a/docs/programming_guide/timeouts.rst
+++ b/docs/programming_guide/timeouts.rst
@@ -460,11 +460,20 @@ modes. Heartbeats apply only to the out-of-process modes.
    * - ``shutdown_timeout``
      - ``external_process``
      - ``None``
-     - Wait for orderly exit before forced process-tree termination.
+     - Natural-exit wait after orderly shutdown, also reused for the finalize
+       gate, accepted-source disconnect fallback, post-settlement group-exit
+       wait, and settled-result reaper budget. ``None`` selects 30 seconds.
+       Zero skips direct orderly-exit and finalize-gate waits but maps to 30
+       seconds for accepted-source disconnect and post-settlement group-exit
+       waits; that fallback also feeds the fixed settled-reaper budget. A
+       still-live accepted source receives a 30-second transfer-barrier interval
+       and one final bounded SHUTDOWN state probe before forced cleanup.
    * - ``stop_grace_period``
      - ``external_process``
      - 30.0
-     - Grace period between soft and hard process termination.
+     - Grace period between soft and hard process termination. Accepted-result
+       reaper cleanup silently caps this phase at 5 seconds;
+       ordinary teardown honors the configured value.
    * - ``heartbeat_interval``
      - ``external_process``, ``attach``
      - 5.0
@@ -1055,7 +1064,9 @@ All standard recipes support these timeout parameters (fedavg.py, cyclic.py):
      - Purpose
    * - shutdown_timeout
      - 0.0
-     - Wait time before shutdown for cleanup
+     - External-process orderly-exit wait. Zero skips direct orderly-exit and
+       finalize-gate waits but maps to 30 seconds for accepted-source disconnect
+       and post-settlement group-exit waits and feeds the settled-reaper budget.
    * - task_assignment_timeout
      - 10
      - Timeout for cyclic task assignment (CyclicRecipe only)
@@ -1678,10 +1689,16 @@ process group and applies these shutdown bounds:
      - Purpose
    * - shutdown_timeout
      - backend default
-     - Time for orderly trainer exit before forced termination begins
+     - Orderly-exit wait, also reused for the finalize gate, accepted-source
+       disconnect fallback, post-settlement group-exit wait, and settled-result
+       reaper budget. Zero maps to a 30-second disconnect grace for an accepted
+       result source. A still-live accepted source also receives a fixed 30-second
+       settlement interval before forced cleanup.
    * - stop_grace_period
      - 30.0
-     - Time between soft and hard process-group termination
+     - Time between soft and hard process-group termination. Accepted-result
+       reaper cleanup silently caps this phase at 5 seconds; ordinary teardown
+       uses the full value.
 
 Attach mode never terminates the externally owned trainer process.
 

--- a/nvflare/app_common/executors/client_api/external_process_backend.py
+++ b/nvflare/app_common/executors/client_api/external_process_backend.py
@@ -54,7 +54,7 @@ from nvflare.client.cell.bootstrap import (
     bootstrap_file_name,
     write_bootstrap_config,
 )
-from nvflare.client.cell.defs import CHANNEL, PROTOCOL_VERSION, MsgKey, Topic
+from nvflare.client.cell.defs import CHANNEL, PROTOCOL_VERSION, SESSION_CONTROL_TIMEOUT, MsgKey, Topic
 from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.fuel.f3.cellnet.defs import CellChannel, MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as CellReturnCode
@@ -75,11 +75,12 @@ _RESULT_POLL_INTERVAL = 0.5
 _RESULT_SOURCE_FAILURE_DELIVERY_WAIT = 14.0
 _HELLO_POLL_INTERVAL = 0.1
 
-_DEFAULT_SHUTDOWN_TIMEOUT = 30.0
+_DEFAULT_SHUTDOWN_TIMEOUT = SESSION_CONTROL_TIMEOUT
 
-# The result reaper retries SHUTDOWN when send() is still settling.
+# The result reaper samples send() state throughout a session-scale interval and
+# makes one final bounded state probe before force-cleaning a live source.
 _LIVE_RESULT_SHUTDOWN_ACK_TIMEOUT = 5.0
-_RESULT_REAPER_MAX_TOTAL_TIMEOUT = 30.0
+_RESULT_REAPER_MAX_TOTAL_TIMEOUT = SESSION_CONTROL_TIMEOUT
 _RESULT_REAPER_FORCE_TERM_GRACE = 5.0
 
 _LOG_THREAD_JOIN_TIMEOUT = 5.0
@@ -579,13 +580,15 @@ class ExternalProcessBackend(CellBackendBase):
                 self.logger.error(secure_format_traceback())
             self._cleanup_trainer(trainer)
 
-    def _request_trainer_shutdown(self, trainer: _TrainerSession, wait_timeout: float) -> None:
-        """Send at most one orderly SHUTDOWN without taking ownership of process death."""
+    def _request_trainer_shutdown(
+        self, trainer: _TrainerSession, wait_timeout: float, force_probe: bool = False
+    ) -> None:
+        """Request orderly SHUTDOWN and sample an accepted result source until it settles."""
         with trainer._shutdown_request_lock:
             if trainer.shutdown_requested.is_set():
                 return
             now = time.monotonic()
-            if now < trainer._next_shutdown_retry:
+            if not force_probe and now < trainer._next_shutdown_retry:
                 return
             trainer._next_shutdown_retry = now + _SHUTDOWN_RETRY_INTERVAL
             if trainer.session_id is None or not self._process_group_alive(trainer):
@@ -610,6 +613,9 @@ class ExternalProcessBackend(CellBackendBase):
                         source_live = body.get(MsgKey.RESULT_SOURCE_LIVE)
                         if source_live is True:
                             trainer.result_source_live.set()
+                            # Keep probing: this acknowledgement describes the current
+                            # transfer barrier and is not a terminal SHUTDOWN acknowledgement.
+                            return
                         elif source_live is False:
                             trainer.result_source_live.clear()
                             trainer.result_source_task_id = None
@@ -675,6 +681,19 @@ class ExternalProcessBackend(CellBackendBase):
                 if remaining > 0:
                     reaper.join(timeout=min(_NATURAL_EXIT_REAP_INTERVAL, remaining))
                     continue
+
+                if live and not self._abort:
+                    # Close the polling race at the hard deadline. The trainer publishes
+                    # transfer-barrier completion before waiting for RESULT_SOURCE_SETTLED,
+                    # so this probe can observe a clean source even if that request is queued.
+                    self._request_trainer_shutdown(
+                        trainer,
+                        wait_timeout=_LIVE_RESULT_SHUTDOWN_ACK_TIMEOUT,
+                        force_probe=True,
+                    )
+                    live = trainer.result_source_live.is_set()
+                    if not live:
+                        continue
 
                 self.logger.warning(
                     f"timed out waiting for accepted result source {trainer.trainer_fqcn} "
@@ -894,16 +913,18 @@ class ExternalProcessBackend(CellBackendBase):
         return shutdown_bound if shutdown_bound > 0 else _DEFAULT_SHUTDOWN_TIMEOUT
 
     def _result_reaper_wait_bound(self) -> float:
-        """Bound live result sources to one END_RUN acknowledgement interval.
+        """Give a live result source a session-scale transfer interval.
 
         A source transaction has its own streaming idle timeout, but END_RUN cannot
         wait for that independently long timeout: the outer job process may tear down
-        the CJ first and orphan an owned per-task trainer. Give an admitted send one
-        SHUTDOWN acknowledgement interval, then force-clean every still-owned launch.
-        The separately configured natural-exit grace is for sources already known to
-        be settled, not for an unconsumed result at END_RUN.
+        the CJ first and orphan an owned per-task trainer. The short SHUTDOWN request
+        repeatedly samples whether send() still owns its transfer barrier, including
+        one final sample at the deadline. This lets completed transfer cleanup settle
+        the source even when its task-correlated settlement request is delayed. The
+        separately configured natural-exit grace is for sources already known to be
+        settled.
         """
-        return _LIVE_RESULT_SHUTDOWN_ACK_TIMEOUT
+        return _RESULT_REAPER_MAX_TOTAL_TIMEOUT
 
     def _settled_result_reaper_budget(self) -> Tuple[float, float]:
         """Return natural-exit and TERM budgets for a settled one-task trainer.

--- a/nvflare/app_common/executors/client_api_executor.py
+++ b/nvflare/app_common/executors/client_api_executor.py
@@ -115,12 +115,18 @@ class ClientAPIExecutor(Executor):
                 trainer to complete its HELLO/session setup (this replaces the legacy
                 external_pre_init_timeout). Defaults to 300 seconds for compatibility with
                 prior releases; an explicit None means no timeout.
-            shutdown_timeout (Optional[float]): external_process only. How long to wait for the
-                trainer to exit naturally after an orderly SHUTDOWN before starting forced
-                process-tree termination. None means the backend default.
+            shutdown_timeout (Optional[float]): external_process only. Primarily the natural-exit
+                wait after orderly SHUTDOWN; it also bounds the finalize/execute gate, supplies the
+                accepted-source disconnect grace, bounds the post-settlement process-group exit
+                wait, and feeds the settled per-task reaper budget. None selects the 30-second
+                backend default. Zero skips the direct orderly-exit and finalize-gate waits. In the
+                accepted-source roles, zero is normalized to 30 seconds for disconnect and
+                post-settlement group-exit waits; that fallback also feeds the fixed 30-second
+                settled-reaper budget, which reserves up to 5 seconds for termination.
             stop_grace_period (float): external_process only. Grace period between SIGTERM and
                 SIGKILL when terminating the trainer process group (design: "Process-tree
-                termination").
+                termination"). The accepted-result reaper silently caps this phase at 5 seconds;
+                ordinary teardown honors the configured value.
             heartbeat_interval (float): out-of-process only (external_process/attach). Interval
                 (seconds) for session heartbeats.
             heartbeat_timeout (float): out-of-process only (external_process/attach). Session lease

--- a/nvflare/client/cell/api.py
+++ b/nvflare/client/cell/api.py
@@ -44,7 +44,7 @@ from nvflare.client.cell.bootstrap import (
     get_bootstrap_client_api_type,
     read_bootstrap_config,
 )
-from nvflare.client.cell.defs import CHANNEL, PROTOCOL_VERSION, MsgKey, Topic
+from nvflare.client.cell.defs import CHANNEL, PROTOCOL_VERSION, SESSION_CONTROL_TIMEOUT, MsgKey, Topic
 from nvflare.client.config import ConfigKey, ExchangeFormat, TransferType
 from nvflare.client.converter_utils import convert_params
 from nvflare.client.decomposers import register_framework_decomposers
@@ -52,6 +52,7 @@ from nvflare.client.utils import DIFF_FUNCS
 from nvflare.fuel.f3.cellnet.cell import Cell
 from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as CellReturnCode
+from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.cellnet.utils import make_reply as make_cell_reply
 from nvflare.fuel.f3.cellnet.utils import new_cell_message
 from nvflare.fuel.f3.streaming.download_service import DownloadService
@@ -66,7 +67,7 @@ from nvflare.fuel.utils.fobs.decomposers.via_downloader import (
 )
 from nvflare.fuel.utils.log_utils import get_obj_logger
 
-_HELLO_TIMEOUT = 30.0
+_HELLO_TIMEOUT = SESSION_CONTROL_TIMEOUT
 _HELLO_RETRY_INTERVAL = 1.0
 # Queue polling bounds abort/stop detection latency.
 _RECEIVE_POLL_INTERVAL = 0.5
@@ -74,7 +75,7 @@ _HEARTBEAT_JOIN_TIMEOUT = 1.0
 _OWNER_WATCHDOG_INTERVAL = 0.5
 _CJ_TIMEOUT_ABORT_GRACE = 1.0
 _OWNER_TERM_GRACE = 5.0
-_RESULT_SOURCE_SETTLED_TIMEOUT = 1.0
+_RESULT_SOURCE_SETTLED_TIMEOUT = SESSION_CONTROL_TIMEOUT
 _RESULT_SOURCE_SETTLED_ATTEMPTS = 3
 _RESULT_SOURCE_SETTLED_RETRY_BACKOFF = 0.1
 
@@ -573,12 +574,14 @@ class CellClientAPI(APISpec):
                 self._clear_result_transfer_waiters()
                 self._maybe_cleanup_memory()
             finally:
-                # Keep send ownership while publishing settlement. A concurrent SHUTDOWN
-                # must defer Cell teardown until the CJ has observed that this source is done.
+                # Downstream transfer cleanup is the send barrier. Publish that transition
+                # before the separately acknowledged settlement request so a concurrent
+                # SHUTDOWN can report the source as settled even when that request is delayed.
+                with self._lock:
+                    self._result_send_active = False
                 if result_accepted:
                     self._notify_result_source_settled(task.get(MsgKey.TASK_ID))
                 with self._lock:
-                    self._result_send_active = False
                     should_shutdown = self._stopped or (result_accepted and not self._launch_once)
                 # One-shot sessions close only after acceptance and downstream settlement.
                 if should_shutdown:
@@ -614,7 +617,9 @@ class CellClientAPI(APISpec):
                 self.logger.debug(f"result-source settlement notification failed: {e}")
             if attempt + 1 < _RESULT_SOURCE_SETTLED_ATTEMPTS:
                 time.sleep(_RESULT_SOURCE_SETTLED_RETRY_BACKOFF)
-        self.logger.debug("result-source settlement was not acknowledged")
+        self.logger.warning(
+            f"result-source settlement was not acknowledged after {_RESULT_SOURCE_SETTLED_ATTEMPTS} attempts"
+        )
 
     def _wait_for_result_transfers(self, result_waiters) -> None:
         """Wait for strict terminal success of every result DownloadService transaction."""
@@ -919,17 +924,13 @@ class CellClientAPI(APISpec):
 
     @staticmethod
     def _normalize_result_receiver_ids(receiver_ids):
-        if receiver_ids is None:
-            return None
         if isinstance(receiver_ids, str):
-            values = [receiver_ids]
-        else:
-            try:
-                values = list(receiver_ids)
-            except TypeError:
-                return None
-        normalized = tuple(str(receiver_id) for receiver_id in values if receiver_id is not None and str(receiver_id))
-        return normalized or None
+            receiver_ids = (receiver_ids,)
+        if isinstance(receiver_ids, (list, tuple)):
+            valid = tuple(dict.fromkeys(r for r in receiver_ids if isinstance(r, str) and not FQCN.validate(r)))
+            if valid:
+                return valid
+        return None
 
     def _check_session_alive(self) -> None:
         reason = self._session_end_reason()

--- a/nvflare/client/cell/defs.py
+++ b/nvflare/client/cell/defs.py
@@ -20,6 +20,9 @@ CHANNEL = "client_api"
 # managed external-process sessions. HELLO carries it for future negotiation.
 PROTOCOL_VERSION = 1
 
+# Session-scale budget shared by trainer control requests and backend result-source reaping.
+SESSION_CONTROL_TIMEOUT = 30.0
+
 
 class Topic:
     """Cell protocol topics.

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -107,7 +107,11 @@ class ScriptRunner:
             params_transfer_type: Whether the trainer returns FULL parameters or a DIFF.
             launch_once: Launch once per job or once per task in ``external_process`` mode.
             launch_timeout: Maximum time for the external trainer to initialize and connect.
-            shutdown_timeout: Wait for orderly trainer exit before forced termination.
+            shutdown_timeout: External-process orderly-exit wait. This also feeds several
+                accepted-result cleanup bounds in ``ClientAPIExecutor``. The default zero skips
+                direct orderly-exit and finalize-gate waits, but maps to 30 seconds for accepted-
+                source disconnect and post-settlement group-exit waits and feeds the fixed settled-
+                reaper budget; see ``ClientAPIExecutor.shutdown_timeout`` for all roles.
             memory_gc_rounds: Force memory cleanup every N rounds; zero disables it.
             cuda_empty_cache: Empty the CUDA cache during configured memory cleanup.
             execution_mode: Optional explicit ``in_process`` or ``external_process`` mode.

--- a/tests/unit_test/app_common/executors/external_process_backend_test.py
+++ b/tests/unit_test/app_common/executors/external_process_backend_test.py
@@ -847,6 +847,41 @@ class TestInitializeAndFinalize:
         assert env.harness.signals_sent() == []
         assert backend._result_reapers == set()
 
+    def test_live_result_reaper_allows_settlement_after_shutdown_ack_deadline(self, env, monkeypatch):
+        monkeypatch.setattr(ebp, "_LIVE_RESULT_SHUTDOWN_ACK_TIMEOUT", 0.01)
+        monkeypatch.setattr(ebp, "_NATURAL_EXIT_REAP_INTERVAL", 0.005)
+        backend, _ = _initialized_backend(env, shutdown_timeout=0.2, stop_grace_period=0.05)
+        process = env.harness.processes[0]
+        trainer = backend._active_launch
+        trainer.result_source_live.set()
+        trainer.result_accepted.set()
+        trainer.result_source_task_id = "task-1"
+        env.cell.on_shutdown = lambda *_args: make_cell_reply(CellReturnCode.OK, body={MsgKey.RESULT_SOURCE_LIVE: True})
+        backend._reap_trainer_after_result(trainer)
+        settlement_replies = []
+
+        def settle_source():
+            settlement_replies.append(
+                env.cell.deliver(
+                    Topic.RESULT_SOURCE_SETTLED,
+                    trainer.trainer_fqcn,
+                    {MsgKey.SESSION_ID: trainer.session_id, MsgKey.TASK_ID: "task-1"},
+                )
+            )
+
+        threading.Timer(0.05, settle_source).start()
+        threading.Timer(0.07, process.exit, args=[0]).start()
+
+        backend.finalize(FLContext())
+
+        assert settlement_replies[0].payload == {
+            MsgKey.REPLY_TOPIC: Topic.RESULT_SOURCE_SETTLED,
+            MsgKey.TASK_ID: "task-1",
+        }
+        assert process.returncode == 0
+        assert env.harness.signals_sent() == []
+        assert backend._result_reapers == set()
+
     def test_abort_stops_registered_result_reaper_without_shutdown_ack_wait(self, env, monkeypatch):
         monkeypatch.setattr(ebp, "_NATURAL_EXIT_REAP_INTERVAL", 0.005)
         backend, _ = _initialized_backend(env, shutdown_timeout=30.0)
@@ -997,10 +1032,45 @@ class TestInitializeAndFinalize:
         backend.finalize(FLContext())
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.5, "a connected but wedged trainer must not hang END_RUN forever"
+        assert elapsed < ebp._RESULT_REAPER_MAX_TOTAL_TIMEOUT + 0.2
         assert process.returncode is not None
         assert backend._result_reapers == set()
         assert "forcing trainer cleanup" in caplog.text
+
+    def test_finalize_reprobes_source_at_deadline_before_forced_cleanup(self, env, monkeypatch, client_job_exit):
+        monkeypatch.setattr(ebp, "_RESULT_REAPER_MAX_TOTAL_TIMEOUT", 0.08)
+        monkeypatch.setattr(ebp, "_LIVE_RESULT_SHUTDOWN_ACK_TIMEOUT", 0.01)
+        monkeypatch.setattr(ebp, "_NATURAL_EXIT_REAP_INTERVAL", 0.005)
+        backend, _ = _initialized_backend(env, shutdown_timeout=0.0, stop_grace_period=0.0)
+        process = env.harness.processes[0]
+        trainer = backend._active_launch
+        trainer.result_source_live.set()
+        transfer_settled = threading.Event()
+        shutdown_states = []
+
+        def on_shutdown(*_args):
+            source_live = not transfer_settled.is_set()
+            shutdown_states.append(source_live)
+            if not source_live:
+                process.exit(0)
+            return make_cell_reply(CellReturnCode.OK, body={MsgKey.RESULT_SOURCE_LIVE: source_live})
+
+        env.cell.on_shutdown = on_shutdown
+        settlement_timer = threading.Timer(0.04, transfer_settled.set)
+        settlement_timer.start()
+        try:
+            backend.finalize(FLContext())
+        finally:
+            settlement_timer.cancel()
+            settlement_timer.join(timeout=0.2)
+
+        assert shutdown_states[0] is True
+        assert shutdown_states[-1] is False
+        assert len(shutdown_states) >= 2
+        assert env.harness.signals_sent() == []
+        assert backend._result_reapers == set()
+        assert backend._active_launch is None
+        client_job_exit.assert_not_called()
 
     def test_zero_shutdown_live_result_uses_backend_grace_and_releases_on_truth(self, env, monkeypatch):
         monkeypatch.setattr(ebp, "_DEFAULT_SHUTDOWN_TIMEOUT", 0.1)
@@ -3104,7 +3174,7 @@ class TestLaunchPerTask:
         backend.finalize(FLContext())
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.5
+        assert elapsed < ebp._RESULT_REAPER_MAX_TOTAL_TIMEOUT + 0.2
         assert all(process.returncode is not None for process in env.harness.processes)
         assert backend._result_reapers == set()
         assert backend._active_launch is None

--- a/tests/unit_test/client/cell/api_test.py
+++ b/tests/unit_test/client/cell/api_test.py
@@ -111,6 +111,7 @@ class FakeCell:
         self.requests = []  # (topic, target, payload)
         self.request_messages = []
         self.request_kwargs = []
+        self.request_timeouts = []
         self.fired = []  # (topic, targets, payload)
         self.on_request = None
         self.on_session_ready = None
@@ -140,6 +141,7 @@ class FakeCell:
         self.requests.append((topic, target, request.payload))
         self.request_messages.append(request)
         self.request_kwargs.append(kwargs)
+        self.request_timeouts.append(timeout)
         if topic == Topic.SESSION_READY:
             if self.on_session_ready is not None:
                 return self.on_session_ready(topic, target, request)
@@ -1608,10 +1610,29 @@ class TestReceiveSend:
         finally:
             api.shutdown()
 
+    @pytest.mark.parametrize("receiver_ids", [(), ["invalid/receiver", 42]])
+    def test_send_uses_count_tracking_when_no_valid_receiver_identity(self, bootstrap_path, env, receiver_ids):
+        api = _init_api(bootstrap_path, env)
+        try:
+            _deliver_task(env, result_receiver_ids=receiver_ids)
+            api.receive()
+
+            api.send(FLModel(params={"w": [2.0]}, params_type=ParamsType.FULL))
+
+            result_request = [m for m in env.request_messages if MsgKey.RESULT in m.payload][0]
+            result_kwargs = env.request_kwargs[env.request_messages.index(result_request)]
+            assert result_kwargs["receiver_ids"] is None
+            assert result_kwargs["num_receivers"] == 1
+        finally:
+            api.shutdown()
+
     def test_send_preserves_declared_ultimate_result_receivers(self, bootstrap_path, env):
         api = _init_api(bootstrap_path, env)
         try:
-            _deliver_task(env, result_receiver_ids=["server.job", "peer.job"])
+            _deliver_task(
+                env,
+                result_receiver_ids=["server.job", "server.job", "invalid/receiver", 42, "peer.job"],
+            )
             api.receive()
 
             api.send(FLModel(params={"w": [2.0]}, params_type=ParamsType.FULL))
@@ -2026,6 +2047,46 @@ class TestReceiveSend:
         finally:
             api.shutdown()
 
+    def test_shutdown_reports_transfer_settled_while_settlement_ack_is_pending(self, bootstrap_path, env):
+        settlement_started = threading.Event()
+        release_settlement = threading.Event()
+
+        def on_request(topic, target, request):
+            if topic == Topic.HELLO:
+                return _hello_accepted_reply()
+            if topic == Topic.RESULT_READY:
+                return _result_accepted_reply()
+            return make_cell_reply(CellReturnCode.OK)
+
+        env.on_request = on_request
+        api = _init_api(bootstrap_path, env)
+        errors = []
+        try:
+            _deliver_task(env)
+            api.receive()
+
+            def wait_for_settlement(_task_id):
+                settlement_started.set()
+                assert release_settlement.wait(1.0)
+
+            api._notify_result_source_settled = wait_for_settlement
+            sender = threading.Thread(target=lambda: _send_and_capture_error(api, FLModel(params={"w": [2.0]}), errors))
+            sender.start()
+            assert settlement_started.wait(0.5)
+
+            reply = env.deliver(Topic.SHUTDOWN, CJ_FQCN, {MsgKey.SESSION_ID: SESSION_ID})
+
+            assert reply.payload == {MsgKey.RESULT_SOURCE_LIVE: False}
+            assert sender.is_alive()
+            assert env.stopped is False
+            release_settlement.set()
+            sender.join(timeout=0.5)
+            assert not sender.is_alive()
+            assert errors == []
+        finally:
+            release_settlement.set()
+            api.shutdown()
+
     def test_result_source_settled_retries_until_task_correlated_ack(self, bootstrap_path, env, monkeypatch):
         monkeypatch.setattr(cell_api, "_RESULT_SOURCE_SETTLED_RETRY_BACKOFF", 0.0)
         attempts = 0
@@ -2061,6 +2122,40 @@ class TestReceiveSend:
             api.send(FLModel(params={"w": [2.0]}))
 
             assert attempts == 2
+            settlement_timeouts = [
+                timeout
+                for (topic, _, _), timeout in zip(env.requests, env.request_timeouts)
+                if topic == Topic.RESULT_SOURCE_SETTLED
+            ]
+            assert settlement_timeouts == [cell_api._HELLO_TIMEOUT, cell_api._HELLO_TIMEOUT]
+        finally:
+            api.shutdown()
+
+    def test_result_source_settled_give_up_is_warning(self, bootstrap_path, env, monkeypatch, caplog):
+        monkeypatch.setattr(cell_api, "_RESULT_SOURCE_SETTLED_RETRY_BACKOFF", 0.0)
+        attempts = 0
+
+        def on_request(topic, target, request):
+            nonlocal attempts
+            if topic == Topic.HELLO:
+                return _hello_accepted_reply()
+            if topic == Topic.RESULT_READY:
+                return _result_accepted_reply()
+            if topic == Topic.RESULT_SOURCE_SETTLED:
+                attempts += 1
+                return make_cell_reply(CellReturnCode.COMM_ERROR)
+            return make_cell_reply(CellReturnCode.OK)
+
+        env.on_request = on_request
+        api = _init_api(bootstrap_path, env)
+        try:
+            _deliver_task(env)
+            api.receive()
+
+            api.send(FLModel(params={"w": [2.0]}))
+
+            assert attempts == 3
+            assert "result-source settlement was not acknowledged after 3 attempts" in caplog.text
         finally:
             api.shutdown()
 


### PR DESCRIPTION
## Summary

- give `RESULT_SOURCE_SETTLED` a 30-second per-attempt control budget, matching `RESULT_READY`, while retaining three retries and warning when all attempts are unacknowledged
- make END_RUN re-sample the trainer's transfer barrier and perform a final bounded SHUTDOWN probe, so a completed download is not reported lost merely because the separate settlement acknowledgement is delayed
- validate and deduplicate trainer-side `RECEIVER_IDS` while preserving count-based tracking (`receiver_ids=None`) when no valid identity is supplied
- document all five current roles of `shutdown_timeout`, its zero-value behavior for ordinary and accepted-source teardown, and the accepted-result reaper's 5-second `stop_grace_period` clamp

## Why

A client job can legitimately remain busy for more than one second while streaming the next task. The previous settlement timeout could therefore miss all acknowledgements and leave a clean trainer exit classified as an unsettled source loss after every result download had completed.

During END_RUN, equal 30-second trainer and reaper deadlines alone are insufficient because the reaper interval can start before downstream transfer completion. The trainer now publishes transfer-barrier completion before waiting for the task-correlated settlement reply. The backend keeps probing while that barrier is live and makes a final probe at its deadline, allowing the completed source to become settled even if `RESULT_SOURCE_SETTLED` is still queued.

Separately, invalid or duplicate `RECEIVER_IDS` entries were interpreted differently by the trainer and client job. The aligned parser keeps valid ordered identities, removes duplicates, and retains the prior identity-free count fallback when none are usable, avoiding an invented receiver identity that could wait for the full streaming timeout.

## Testing

- `python -m pytest -q tests/unit_test/client/cell/api_test.py tests/unit_test/app_common/executors/external_process_backend_test.py` — 231 passed, 2 skipped on the exact signed commit rebased on current `main`
- Black, isort, and flake8 passed for every touched Python file
- `git diff --check` passed
