### PR TITLE
Align agent skills with current specification

### DIFF
--- a/dev_tools/agent/skills/checks/frontmatter.py
+++ b/dev_tools/agent/skills/checks/frontmatter.py
@@ -32,7 +32,7 @@ YAML_ANCHOR_OR_ALIAS_RE = re.compile(r"(^|[:\s\[{,])([&*])[A-Za-z0-9_-]+(?=\s|$|
 REQUIRED_FRONTMATTER_FIELDS = ("name", "description")
 # `author` (name plus NVIDIA email inside the spec `metadata` map) is required
 # by the company skills guideline (NVCARPS).
-REQUIRED_METADATA_FIELDS = ("author", "min-flare-version", "blast-radius")
+REQUIRED_METADATA_FIELDS = ("author", "version", "min-flare-version", "blast-radius")
 # The NVIDIA skills catalog uses a team identity, never an individual: once
 # `npx skills add` copies the frontmatter out of the repo, `author` acts as the
 # support contact, and a personal inbox goes stale when people change teams.
@@ -40,11 +40,10 @@ AUTHOR_RE = re.compile(r"^[^<>@]+ <[A-Za-z0-9._%+-]+@nvidia\.com>$")
 REQUIRED_PUBLIC_METADATA_FIELDS = ("category",)
 # The only frontmatter keys agentskills.io permits at the top level, plus
 # `title`, an optional display-name field the company skills guideline
-# (NVCARPS) allows at the top level, and `version`, which the NVIDIA skills
-# catalog (github.com/NVIDIA/skills) declares at the top level. Everything
-# else (NVFLARE custom fields) must be nested under `metadata`.
+# (NVCARPS) allows at the top level. The Agent Skills Specification treats
+# `version` as additional metadata, so it must be nested under `metadata`.
 SPEC_TOP_LEVEL_FIELDS = frozenset(
-    {"name", "title", "description", "license", "compatibility", "metadata", "allowed-tools", "version"}
+    {"name", "title", "description", "license", "compatibility", "metadata", "allowed-tools"}
 )
 PUBLIC_EXEMPT_STATUS = {"draft", "internal", "private"}
 # Company skills guideline (NVCARPS) constraints, enforced on top of the

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,15 +28,15 @@ with `status: internal`, plus `references/` and `assets/`).
 `SKILL.md` frontmatter uses the portable fields from the
 [agentskills.io spec](https://agentskills.io/specification) plus the NVIDIA
 catalog extensions documented below. NVFLARE's required fields (`author`,
-`min-flare-version`, `blast-radius`, and public-skill `category`) are nested
-under the `metadata:` map:
+`version`, `min-flare-version`, `blast-radius`, and public-skill `category`) are
+nested under the `metadata:` map:
 
 ```yaml
 ---
 name: nvflare-your-skill
 description: Short trigger-oriented description.
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: read_only
@@ -54,8 +54,9 @@ Every skill must include a team `author` identity under `metadata:` in the
 product-facing runtime metadata. Draft, internal, and private skills
 (`metadata.status`) may omit `category` while they are not publishable.
 
-Bundled skills declare catalog `version` at the top level, following the
-NVIDIA skills catalog convention.
+Bundled skills declare `version` as a string under `metadata`, following the
+Agent Skills Specification. A root-level `version` is ignored by conforming
+consumers and rejected by the NVFLARE validator.
 
 `blast-radius` must be one of:
 

--- a/skills/nvflare-autofl-report/SKILL.md
+++ b/skills/nvflare-autofl-report/SKILL.md
@@ -2,9 +2,9 @@
 name: nvflare-autofl-report
 description: "Generate a reproducible final report, literature-outcome synthesis, JSON summary, and refreshed progress plot for a stopped or interrupted NVFLARE Auto-FL campaign."
 license: Apache-2.0
-version: "0.1.0"
 compatibility: "Requires NVFLARE 2.9.0+, Python, and artifacts from an NVFLARE Auto-FL campaign."
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: edits_files

--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -2,9 +2,9 @@
 name: nvflare-autofl
 description: "Use for agent-assisted Auto-FL optimization of an existing NVFLARE job in simulation, POC, or production. Do not use for code conversion, diagnosis-only work, or deployment setup."
 license: Apache-2.0
-version: "0.1.0"
 compatibility: "Requires NVFLARE 2.9.0+, Python, and permission to run NVFLARE jobs in the selected environment."
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   tags: "nvflare, federated-learning, optimization"
   min-flare-version: "2.9.0"

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -43,6 +43,17 @@ workflows: do not merge or automatically chain them, do not route the combinatio
 workflow to run first before generating or running either job. Recommend `nvflare-fed-stats` first only when the
 user's purpose is to understand data distribution; handle conversion later as a separate request.
 
+## Available Scripts
+
+| Script | Purpose | Arguments |
+| --- | --- | --- |
+| `scripts/resolve_model_snapshot.py` | Resolve a local or Hub model/dataset snapshot and emit JSON evidence. | Identifier; required `--source`; optional source-root, download, revision, cache, and repository-type flags. |
+
+Use `run_script()` only during the validation phase after loading `references/huggingface-validation.md`. For example:
+
+- `run_script("scripts/resolve_model_snapshot.py", ["--source", "local", "--source-root", "<absolute-source-root>", "<configured-path>"])`
+- `run_script("scripts/resolve_model_snapshot.py", ["--source", "hub", "<org/model>"])`
+
 ## Workflow
 
 1. Load `../nvflare-shared/references/conversion-common.md` and apply it for the
@@ -182,19 +193,8 @@ user's purpose is to understand data distribution; handle conversion later as a 
 - Site partitioning, custom aggregation, the Source Of Truth Boundary, and user
   input/authorization follow `../nvflare-shared/references/conversion-common.md`.
 
-Always read this converter SKILL.md together with
-`../nvflare-shared/references/conversion-common.md`. Complete each workflow
-phase before loading the next phase's reference. Do not preload validation,
-state/DDP, broad workflow, dependency, or reporting references. The standard
-FedAvg path loads, in order:
-`../nvflare-shared/references/conversion-common.md`,
-`references/huggingface-detection.md`,
-`../nvflare-shared/references/site-data-and-paths.md` only when generated
-splits, relative-path resolution, or per-site data locations are involved,
-`../nvflare-shared/references/pytorch-family-recipe-construction.md`,
-`references/huggingface-conversion.md`,
-`../nvflare-shared/references/pytorch-model-exchange.md`,
-`../nvflare-shared/references/validation-evidence.md`, and
-`references/huggingface-validation.md`. Load
-`references/huggingface-state-and-distributed.md` and other shared references
-only under the triggers above. Do not depend on repository examples.
+Always read this converter SKILL.md together with `../nvflare-shared/references/conversion-common.md`. Complete each workflow phase before loading the next phase's reference.
+Do not preload validation, state/DDP, broad workflow, dependency, or reporting references. The standard FedAvg path loads, in order:
+`../nvflare-shared/references/conversion-common.md`, `references/huggingface-detection.md`, and `../nvflare-shared/references/site-data-and-paths.md` only for its stated triggers;
+`../nvflare-shared/references/pytorch-family-recipe-construction.md`, `references/huggingface-conversion.md`, and `../nvflare-shared/references/pytorch-model-exchange.md`;
+then `../nvflare-shared/references/validation-evidence.md` and `references/huggingface-validation.md`; load `references/huggingface-state-and-distributed.md` and other shared references only under the triggers above. Do not depend on repository examples.

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-convert-huggingface
 description: "Convert existing Hugging Face Transformers Trainer or TRL SFTTrainer training code into an NVFLARE federated job using flare.patch(trainer), local validation, and job export; use when the user names Hugging Face or preliminary source inspection identifies one Hugging Face owner, and not for manual PyTorch loops, Lightning, inference-only pipelines, deployment, or experiment workflows."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: runs_simulator

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-convert-lightning
 description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use when the user names PyTorch Lightning or preliminary source inspection identifies one Lightning owner, and not for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: runs_simulator

--- a/skills/nvflare-convert-pytorch/SKILL.md
+++ b/skills/nvflare-convert-pytorch/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-convert-pytorch
 description: "Convert existing plain or manual PyTorch training code into an NVFLARE federated job using Client API model exchange, local validation, and job export; use when the user names plain PyTorch or preliminary source inspection identifies one plain-PyTorch owner, and not for Lightning, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: runs_simulator

--- a/skills/nvflare-diagnose-job/SKILL.md
+++ b/skills/nvflare-diagnose-job/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-diagnose-job
 description: "Use when the user asks why a reported NVFLARE job failure signal occurred: the job failed, stalled, timed out, lost clients, ended with EXECUTION_EXCEPTION, or produced suspicious errors. Diagnose in simulation, POC, or production by collecting bounded evidence and mapping failure patterns to recovery actions."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: read_only

--- a/skills/nvflare-fed-stats/SKILL.md
+++ b/skills/nvflare-fed-stats/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-fed-stats
 description: "Compute federated statistics over tabular data (count, sum, mean, stddev, var, histogram, quantile, noise-protected min/max) and image data (count, failure_count, pixel-intensity histogram) across NVFLARE sites via FedStatsRecipe — automatic and non-interactive from the dataset, feature names (header or supplied), and optionally a README or notes declaring which statistics to compute; do not use for model training conversion, hierarchical statistics, deployment, POC/production lifecycle, or failed-job diagnosis."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: runs_simulator

--- a/skills/nvflare-orient/SKILL.md
+++ b/skills/nvflare-orient/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-orient
 description: "Route open-ended NVFLARE advice and only conversion requests whose preliminary source inspection reports unresolved or conflicting ownership; never load this skill merely to inspect a concrete conversion request before selecting its detected framework converter."
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: read_only

--- a/skills/nvflare-shared/SKILL.md
+++ b/skills/nvflare-shared/SKILL.md
@@ -2,8 +2,8 @@
 name: nvflare-shared
 description: Internal NVFLARE conversion references and templates. Use only when another NVFLARE skill directs you to a shared workflow, policy, or asset.
 license: Apache-2.0
-version: "0.1.0"
 metadata:
+  version: "0.1.0"
   author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"
   min-flare-version: "2.9.0"
   blast-radius: read_only
@@ -18,10 +18,9 @@ metadata:
 
 ## Purpose
 
-Internal, non-triggered skill that holds guidance and templates shared by the
-NVFLARE conversion skills so the same rules are authored once. It is installed
-alongside every NVFLARE skill and referenced by relative path; it is not
-selected or invoked on its own.
+Use this internal, non-triggered skill only to load guidance and templates named
+by an NVFLARE conversion skill. Resolve its references by relative path from the
+consuming skill. Do not select or invoke it independently.
 
 ## Instructions
 

--- a/skills/nvflare-shared/references/conversion-workflow.md
+++ b/skills/nvflare-shared/references/conversion-workflow.md
@@ -422,49 +422,7 @@ reconstruct either contract from this broad workflow reference.
 
 ## Execution Environment And Local Validation
 
-Conversion validation uses `SimEnv` from `nvflare.recipe`; build the environment
-under the canonical single-topology-owner rule in the always-loaded common
-conversion reference, then call `recipe.execute(env)` from `job.py`. Do not
-reconstruct that topology policy from this broad workflow reference.
-
-For normal first-user simulation, `python job.py` is the intended local
-experience because no exported job folder may exist yet. The exported job folder
-is still the deployable artifact: POC or production submission uses the job
-folder with product submission commands such as `nvflare job submit -j`.
-
-Validate the artifact being claimed. If the final claim is that the recipe runs
-locally, use `python job.py`. If the final claim includes an exported,
-deployable job folder, create it with `python job.py --export --export-dir
-<runtime-dir>/job_config` and validate that exported folder with the product
-simulator CLI: `nvflare simulator <exported-job-dir> -w
-<runtime-dir>/workspace -n <num_clients> -t <num_threads> -l concise` (or `-c
-site-1,site-2,...`). Do not write Python code to call simulator APIs such as
-`simulator_run()` for exported-job validation.
-
-`PocEnv` and `ProdEnv` are outside conversion scope; do not generate or run
-them from a conversion skill. Homomorphic-encryption recipes reject `SimEnv` and
-require those provisioned environments, so HE is not supported by conversion.
-If any other selected recipe rejects `SimEnv`, follow the selecting reference's
-ask/fail-closed rule and report the job as unvalidated instead of switching
-recipes or environments to force a run.
-
-- Choose one final full-run path based on the artifact being validated. Use
-  `python job.py` for local recipe or first-user simulation validation. Use
-  `python job.py --export --export-dir <runtime-dir>/job_config` plus
-  `nvflare simulator <exported-job-dir> ...` when validating an exported,
-  deployable job folder. Do not run both full simulations unless the first one
-  failed and the second is a scoped rerun after a fix.
-- Prefer synthetic data flags or small fixtures when the original dataset is
-  unavailable.
-- Complete the dependency phase before Python import checks,
-  recipe-construction preflight, export, or simulation.
-- Follow `validation-evidence.md` for validation command isolation and terminal
-  evidence.
-- Never run destructive cleanup against the source tree or its git state, such
-  as git clean/reset/checkout operations or recursive deletion over source or
-  user files. Scope any cleanup to generated runtime or output directories under
-  the runtime location convention, never the user's project or working tree.
-- After successful simulation, follow `metrics-and-artifact-reporting.md`.
+Load `validation-evidence.md` for the complete local-validation path, command selection, simulation constraints, safety rules, and evidence requirements.
 
 ## Final Validation Run Must Finish Before You Finalize
 

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -4,6 +4,10 @@ Use this reference before declaring a generated or exported NVFLARE job valid.
 
 ## Local Validation
 
+Build local simulations with `SimEnv` from `nvflare.recipe`. Apply the canonical
+single-topology-owner rule in `conversion-common.md`, then call
+`recipe.execute(env)` from `job.py`.
+
 Choose one final full-run path based on the artifact being validated:
 
 - Local recipe or first-user simulation validation: run `python job.py`.
@@ -19,6 +23,13 @@ job configuration needed for that simulation behind the scenes. Creating an
 export does not authorize submitting it to POC or production; submission is
 outside conversion-skill scope.
 
+Use `SimEnv` only. Do not generate or run `PocEnv` or `ProdEnv` from a
+conversion skill. Homomorphic-encryption recipes reject `SimEnv` and require
+those provisioned environments, so do not offer HE as a conversion capability.
+If another selected recipe rejects `SimEnv`, follow the selecting reference's
+ask-or-fail-closed rule and report the job as unvalidated; do not switch recipes
+or environments merely to force a run.
+
 Do not accept generated job-local `--export` or `--export-dir` arguments, or an
 alias such as `--export_only`, as replacements for the NVFLARE Recipe interface.
 If generated code parses or manually branches on those system arguments or a
@@ -30,6 +41,10 @@ scoped rerun after a fix. Do not write Python code to call simulator APIs for
 exported-job validation.
 - Prefer synthetic data flags or small fixtures when the original dataset is
   unavailable.
+- Never run destructive cleanup against the source tree or its Git state. Do
+  not use Git clean/reset/checkout operations or recursive deletion over source
+  or user files. Scope cleanup to generated runtime or output directories under
+  the runtime location convention.
 - Keep validation commands single-purpose. Run dependency installation, cleanup,
   export, and simulation as separate commands.
 - Treat an unavailable optional capability or host-diagnostic utility as
@@ -40,6 +55,7 @@ exported-job validation.
   or `nvidia-smi` to a required command where their absence changes its status.
 - If validation cannot run, save the conversion as a draft and report the
   concrete blocker.
+- After successful simulation, follow `metrics-and-artifact-reporting.md`.
 
 ## Terminal Simulation Evidence
 

--- a/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
+++ b/tests/unit_test/tool/agent_skill_checks/fixtures/valid/nvflare-example-skill/SKILL.md
@@ -2,6 +2,7 @@
 name: nvflare-example-skill
 description: Example fixture skill used by frontmatter validator tests.
 metadata:
+  version: "0.1.0"
   author: "Test Author <test-author@nvidia.com>"
   min-flare-version: "2.8.0"
   blast-radius: read_only

--- a/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/frontmatter_test.py
@@ -36,17 +36,17 @@ SKILLS_ROOT = REPO_ROOT / "skills"
 
 def test_shipped_skills_frontmatter_matches_nvidia_skill_profile():
     # Every shipped skill keeps only the portable fields and intentional NVIDIA
-    # catalog extensions; NVFLARE custom fields (min-flare-version,
-    # blast-radius, category, ...) live under `metadata:`.
+    # catalog extensions; version and NVFLARE custom fields
+    # (min-flare-version, blast-radius, category, ...) live under `metadata:`.
     skill_dirs = [d for d in sorted(SKILLS_ROOT.iterdir()) if not should_skip_skill_dir(d)]
     assert skill_dirs, "no shipped skills found"
     for skill_dir in skill_dirs:
         metadata = parse_skill_frontmatter(skill_dir / "SKILL.md")
         extra = set(metadata) - SPEC_TOP_LEVEL_FIELDS
         assert not extra, f"{skill_dir.name}: non-spec top-level frontmatter keys {sorted(extra)}"
-        assert metadata.get("version") == "0.1.0"
+        assert "version" not in metadata
         assert isinstance(metadata.get("metadata"), dict)
-        assert "version" not in metadata["metadata"]
+        assert metadata["metadata"].get("version") == "0.1.0"
         assert "min-flare-version" in metadata["metadata"]
         assert "blast-radius" in metadata["metadata"]
         assert validate_skill_dir(skill_dir).ok
@@ -140,6 +140,7 @@ def test_validate_skill_dir_reports_missing_required_fields(tmp_path):
         "name: nvflare-missing-fields\n"
         "description: Missing required fields.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         "---\n"
         "\n"
@@ -162,6 +163,7 @@ def test_validate_skill_dir_reports_wrong_type_fields(tmp_path):
         "name: nvflare-wrong-type\n"
         "description: Wrong type fixture.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         "  min-flare-version: 2.8\n"
         "  blast-radius: read_only\n"
@@ -374,6 +376,7 @@ def _write_skill(tmp_path, skill_name, *, name=None, blast_radius="read_only", c
         f"name: {name or skill_name}\n"
         "description: Test skill fixture.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         f"  blast-radius: {blast_radius}\n"
@@ -417,6 +420,7 @@ def test_validate_skill_dir_rejects_description_over_1024_chars(tmp_path):
         "name: nvflare-long-description\n"
         f"description: {'x' * 1025}\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"
@@ -439,6 +443,7 @@ def test_validate_skill_dir_rejects_compatibility_over_500_chars(tmp_path):
         "description: Test skill fixture.\n"
         f"compatibility: {'y' * 501}\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"
@@ -474,6 +479,7 @@ def test_validate_skill_dir_requires_author_in_metadata(tmp_path):
         "name: nvflare-no-author\n"
         "description: Test skill fixture.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"
         "  category: Test\n"
@@ -507,6 +513,7 @@ def test_validate_skill_dir_rejects_author_without_team_identity_format(tmp_path
         "name: nvflare-bad-author\n"
         "description: Test skill fixture.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         f'  author: "{author}"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"
@@ -520,9 +527,9 @@ def test_validate_skill_dir_rejects_author_without_team_identity_format(tmp_path
     assert "skill-author-format-invalid" in _issue_codes(result)
 
 
-def test_validate_skill_dir_accepts_top_level_license_and_version(tmp_path):
-    # The NVIDIA skills catalog declares `license` and `version` at the top
-    # level; both must pass the top-level field check.
+def test_validate_skill_dir_accepts_top_level_license_and_metadata_version(tmp_path):
+    # The Agent Skills Specification permits license at the top level and
+    # arbitrary string-valued fields such as version under metadata.
     skill_dir = tmp_path / "nvflare-licensed"
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text(
@@ -530,8 +537,8 @@ def test_validate_skill_dir_accepts_top_level_license_and_version(tmp_path):
         "name: nvflare-licensed\n"
         "description: Test skill fixture.\n"
         "license: Apache-2.0\n"
-        'version: "0.1.0"\n'
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"
@@ -545,6 +552,31 @@ def test_validate_skill_dir_accepts_top_level_license_and_version(tmp_path):
     assert result.ok, result.issues
 
 
+def test_validate_skill_dir_rejects_top_level_version(tmp_path):
+    skill_dir = tmp_path / "nvflare-top-level-version"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: nvflare-top-level-version\n"
+        "description: Test skill fixture.\n"
+        'version: "0.1.0"\n'
+        "metadata:\n"
+        '  version: "0.1.0"\n'
+        '  author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"\n'
+        '  min-flare-version: "2.8.0"\n'
+        "  blast-radius: read_only\n"
+        "  category: Test\n"
+        "---\n\n# Skill\n",
+        encoding="utf-8",
+    )
+
+    result = validate_skill_dir(skill_dir)
+
+    assert not result.ok
+    assert _issue_codes(result) == {"skill-frontmatter-field-unsupported"}
+    assert "top-level frontmatter field 'version'" in result.issues[0].message
+
+
 def test_validate_skill_dir_accepts_optional_title(tmp_path):
     # NVCARPS allows an optional top-level display title.
     skill_dir = tmp_path / "nvflare-with-title"
@@ -555,6 +587,7 @@ def test_validate_skill_dir_accepts_optional_title(tmp_path):
         'title: "NVFLARE With Title"\n'
         "description: Test skill fixture.\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: read_only\n"

--- a/tests/unit_test/tool/agent_skill_checks/lints_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/lints_test.py
@@ -1723,6 +1723,7 @@ def _write_skill(
         f"name: {name}\n"
         f"description: {description}\n"
         "metadata:\n"
+        '  version: "0.1.0"\n'
         '  author: "Test Author <test-author@nvidia.com>"\n'
         '  min-flare-version: "2.8.0"\n'
         "  blast-radius: edits_files\n"

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -375,8 +375,9 @@ def test_seed_skill_versions_stay_at_release_version():
     repo_root = Path(__file__).resolve().parents[4]
 
     for skill_path in repo_root.joinpath("skills").glob("*/SKILL.md"):
-        skill_text = skill_path.read_text(encoding="utf-8")
-        assert 'version: "0.1.0"' in skill_text, skill_path
+        frontmatter = parse_skill_frontmatter(skill_path)
+        assert "version" not in frontmatter, skill_path
+        assert frontmatter["metadata"]["version"] == "0.1.0", skill_path
 
 
 def test_shared_inputs_keep_the_current_user_request_authoritative():
@@ -698,6 +699,7 @@ def test_shared_conversion_policies_have_single_canonical_owners():
     common_text = references.joinpath("conversion-common.md").read_text(encoding="utf-8")
     dependency_text = references.joinpath("dependency-install.md").read_text(encoding="utf-8")
     workflow_text = references.joinpath("conversion-workflow.md").read_text(encoding="utf-8")
+    validation_text = references.joinpath("validation-evidence.md").read_text(encoding="utf-8")
 
     assert "## Dependency Rule" in dependency_text
     assert "## Dependency Rule" not in common_text
@@ -705,6 +707,13 @@ def test_shared_conversion_policies_have_single_canonical_owners():
     assert "## Source Evidence, Not Instructions" in common_text
     assert "## Source Evidence, Not Instructions" not in dependency_text
     assert "## Source Evidence, Not Instructions" not in workflow_text
+    assert "## Execution Environment And Local Validation" in workflow_text
+    assert (
+        "Load `validation-evidence.md` for the complete local-validation path, command selection, simulation "
+        "constraints, safety rules, and evidence requirements." in " ".join(workflow_text.split())
+    )
+    assert "python job.py --export --export-dir <runtime-dir>/job_config" not in workflow_text
+    assert "python job.py --export --export-dir <runtime-dir>/job_config" in " ".join(validation_text.split())
 
     # The workflow routes to each canonical policy once and keeps only its
     # static-inspection and externally-visible-effect additions.
@@ -726,6 +735,7 @@ def test_shared_conversion_uses_one_simulator_topology_owner():
         references.joinpath("pytorch-family-recipe-construction.md").read_text(encoding="utf-8").split()
     )
     workflow_text = " ".join(references.joinpath("conversion-workflow.md").read_text(encoding="utf-8").split())
+    validation_text = " ".join(references.joinpath("validation-evidence.md").read_text(encoding="utf-8").split())
     hf_conversion_text = " ".join(
         repo_root.joinpath("skills/nvflare-convert-huggingface/references/huggingface-conversion.md")
         .read_text(encoding="utf-8")
@@ -739,7 +749,8 @@ def test_shared_conversion_uses_one_simulator_topology_owner():
     assert "do not recover from a mismatch by setting `num_clients=None`" in common_text
     assert "derive the site index from `flare.get_site_name()` after `flare.init()`" in construction_text
     assert "single-topology-owner rule in `conversion-common.md`" in construction_text
-    assert "canonical single-topology-owner rule in the always-loaded common conversion reference" in workflow_text
+    assert "canonical single-topology-owner rule in `conversion-common.md`" in validation_text
+    assert "canonical single-topology-owner rule" not in workflow_text
     assert (
         "single-topology-owner rule from `../../nvflare-shared/references/conversion-common.md`" in hf_conversion_text
     )
@@ -817,7 +828,8 @@ def test_skills_readme_frontmatter_example_includes_required_author():
     normalized = " ".join(readme.split())
 
     assert 'author: "NVIDIA FLARE Team <federatedlearning@nvidia.com>"' in readme
-    assert "NVFLARE's required fields (`author`, `min-flare-version`, `blast-radius`" in normalized
+    assert "NVFLARE's required fields (`author`, `version`, `min-flare-version`, `blast-radius`" in normalized
+    assert "root-level `version` is ignored" in normalized
 
 
 def test_shared_skill_metadata_and_progressive_disclosure_structure():
@@ -828,6 +840,9 @@ def test_shared_skill_metadata_and_progressive_disclosure_structure():
 
     assert 50 <= len(metadata["description"]) <= 150
     assert "Use only when" in metadata["description"]
+    assert "version" not in metadata
+    assert metadata["metadata"]["version"] == "0.1.0"
+    assert "Use this internal, non-triggered skill only to load" in " ".join(shared_text.split())
     assert "min-flare-version:" in shared_text
     assert "blast-radius:" in shared_text
     assert "min_flare_version:" not in shared_text


### PR DESCRIPTION
## Summary

Align the bundled NVFLARE skills with the current Agent Skills frontmatter contract, improve instruction quality, document the Hugging Face helper script, and remove duplicated local-validation guidance.

## Changes

### Agent Skills frontmatter

- Move `version: "0.1.0"` from the root of every bundled `SKILL.md` into the `metadata` mapping.
- Require `metadata.version` in the NVFLARE frontmatter validator.
- Remove root-level `version` from the validator allowlist so misplaced versions are reported instead of silently accepted.
- Update the skills README, valid fixture, and frontmatter/lint tests for the new structure.
- Add regression coverage confirming all nine bundled skills use `metadata.version` and reject root-level `version`.

### Instruction quality

- Rewrite the `nvflare-shared` purpose with direct imperative verbs: `Use`, `Resolve`, and `Do not`.
- Retain its existing `## Instructions` and `## Examples` sections, whose actions use imperative verbs such as `Load`, `Treat`, and `Apply`.
- Add an `## Available Scripts` table to `nvflare-convert-huggingface` for its bundled `scripts/resolve_model_snapshot.py` helper.
- Add explicit `run_script()` examples for local-path and Hugging Face Hub snapshot resolution.
- Keep the Hugging Face skill within the repository hard limit of 200 lines by reflowing its unchanged reference-loading guidance.

### Shared-reference deduplication

- Make `references/validation-evidence.md` the single owner of the complete local-validation path, including:
  - `SimEnv` construction and execution
  - local versus exported-job command selection
  - simulation environment constraints
  - destructive-cleanup safeguards
  - terminal evidence and post-simulation reporting
- Replace the duplicated validation block in `references/conversion-workflow.md` with a one-line pointer to the canonical reference.
- Add regression checks preventing export commands and topology guidance from being duplicated back into the workflow reference.

## Validation

- Hugging Face SkillEvaluator quality score: 91.5 (grade A), increased from 84.5 and above the 85.0 Tier 1 floor.
- Official Agent Skills reference validator passed for all nine bundled skills.
- `python -m pytest tests/unit_test/tool/agent_skill_checks -q` — 478 passed, 37 skipped.
- `python -m dev_tools.agent.skills.checks` — 0 errors, warnings, or informational findings.
- `./runtest.sh -s` — Black, isort, Flake8, and agent-skill lint passed.
- `git diff --check` passed.

## Validation limitations

- The complete local Tier 1 command reports the corrected 91.5 quality score, but its Semgrep check cannot complete on the macOS development host because the local Semgrep installation has an empty X.509 trust store. The corresponding Linux CI prerequisite is installed by the repository workflow.
- The local Tier 2 dedup scan requires an embedding provider, which is not configured in the development environment. Repository regression tests cover the intended single-owner structure.
- Dedicated NVSkills CI is not requested because it does not support fork-based PRs.