### PR TITLE
Make blocking Collab group results re-iterable

### DIFF
--- a/nvflare/collab/api/call_opt.py
+++ b/nvflare/collab/api/call_opt.py
@@ -30,7 +30,8 @@ class CallOption:
 
         Args:
             expect_result: whether result is expected from the remote object.
-            blocking: whether the call is blocking. Only for group calls.
+            blocking: whether a group call waits for all outcomes and returns re-iterable results. A non-blocking
+                group call returns a live, single-pass result stream.
             timeout: when expecting result, the max number of secs to wait for result.
             secure: whether to use P2P secure messaging.
             optional: whether the call is optional.

--- a/nvflare/collab/api/group.py
+++ b/nvflare/collab/api/group.py
@@ -98,14 +98,13 @@ class Group:
 
         If expect_result is False, then the call immediately returns None.
 
-        If expect_result is True, a ResultQueue object is returned. Successful results are appended to the queue
-        as (site_name, result) tuples when they become available. Per-site failures are available in
-        ResultQueue.failures as a mapping from site name to CollabCallError.
+        If expect_result is True, successful results are returned as (site_name, result) tuples. Per-site failures
+        are available in the result collection's failures mapping from site name to CollabCallError.
 
         The blocking flag is only meaningful when expect_result is True. If blocking is True, the call does not
-        return until results are received from all sites (or timed out), and the returned ResultQueue is frozen into
-        a re-iterable snapshot. If blocking is False, the call immediately returns a live, single-pass ResultQueue
-        that the application should iterate to process results as they arrive.
+        return until results are received from all sites (or timed out), and returns a re-iterable frozen snapshot.
+        If blocking is False, the call immediately returns a live, single-pass ResultQueue that the application
+        should iterate to process results as they arrive.
 
         """
 

--- a/nvflare/collab/api/group.py
+++ b/nvflare/collab/api/group.py
@@ -103,9 +103,9 @@ class Group:
         ResultQueue.failures as a mapping from site name to CollabCallError.
 
         The blocking flag is only meaningful when expect_result is True. If blocking is True, the call does not
-        return until results are received from all sites (or timed out). If blocking is False, the call immediately
-        returns. In both cases, the ResultQueue object is returned, and the application should iterate through it
-        to process site results.
+        return until results are received from all sites (or timed out), and the returned ResultQueue is frozen into
+        a re-iterable snapshot. If blocking is False, the call immediately returns a live, single-pass ResultQueue
+        that the application should iterate to process results as they arrive.
 
         """
 
@@ -168,7 +168,7 @@ class Group:
 
                     # wait for responses
                     waiter.wait_for_responses(self._abort_signal)
-                    return waiter.results
+                    return waiter.results.freeze()
             except Exception as ex:
                 self._logger.error(f"exception {type(ex)} occurred: {ex}")
                 raise

--- a/nvflare/collab/api/group.py
+++ b/nvflare/collab/api/group.py
@@ -118,7 +118,7 @@ class Group:
                     )
 
                     assert isinstance(self._app, App)
-                    waiter = ResultWaiter([p.name for p in self._proxies])
+                    waiter = ResultWaiter([p.name for p in self._proxies], retain_history=self._call_opt.blocking)
                     max_parallel = self._call_opt.parallel
                     if max_parallel <= 0:
                         max_parallel = len(self._proxies)

--- a/nvflare/collab/api/group_call_context.py
+++ b/nvflare/collab/api/group_call_context.py
@@ -47,6 +47,9 @@ class ResultQueue:
         self.num_successes = 0
         self.failures = {}
         self.update_lock = threading.Lock()
+        self._iteration_started = False
+        self._frozen_items = None
+        self._frozen_next_index = 0
 
     def append(self, item, is_whole=True):
         """Append an item to the result queue.
@@ -85,12 +88,22 @@ class ResultQueue:
             return self.num_whole_items_received == self.limit
 
     def __iter__(self):
+        with self.update_lock:
+            if self._frozen_items is not None:
+                return iter(self._frozen_items)
         return self
 
     def __next__(self):
         while True:
             # Check the queue and completion count atomically with append().
             with self.update_lock:
+                if self._frozen_items is not None:
+                    if self._frozen_next_index >= len(self._frozen_items):
+                        raise StopIteration()
+                    item = self._frozen_items[self._frozen_next_index]
+                    self._frozen_next_index += 1
+                    return item
+                self._iteration_started = True
                 try:
                     item = self.q.get_nowait()
                 except queue.Empty:
@@ -109,6 +122,25 @@ class ResultQueue:
             item = self.q.get(block=True)
             if item is not _FAILURE_MARKER:
                 return item
+
+    def freeze(self):
+        """Freeze a completed, unconsumed queue into a re-iterable snapshot."""
+        with self.update_lock:
+            if self.num_whole_items_received < self.limit:
+                raise RuntimeError("cannot freeze result queue before all outcomes are received")
+            if self._iteration_started:
+                raise RuntimeError("cannot freeze result queue after iteration has started")
+            if self._frozen_items is None:
+                items = []
+                while True:
+                    try:
+                        item = self.q.get_nowait()
+                    except queue.Empty:
+                        break
+                    if item is not _FAILURE_MARKER:
+                        items.append(item)
+                self._frozen_items = tuple(items)
+            return self
 
     def __len__(self):
         """Return the number of successful whole results received.

--- a/nvflare/collab/api/group_call_context.py
+++ b/nvflare/collab/api/group_call_context.py
@@ -33,6 +33,21 @@ def _get_site_name(target_name: str):
     return target_name.split(".", 1)[0]
 
 
+class FrozenResultQueue:
+    """Immutable, re-iterable snapshot of completed group-call results."""
+
+    def __init__(self, items, failures, num_successes):
+        self._items = tuple(items)
+        self.failures = dict(failures)
+        self._num_successes = num_successes
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self):
+        return self._num_successes
+
+
 class ResultQueue:
     def __init__(self, limit: int, retain_history=True):
         if limit <= 0:
@@ -48,7 +63,7 @@ class ResultQueue:
         self.failures = {}
         self.update_lock = threading.Lock()
         self._items = [] if retain_history else None
-        self._frozen_items = None
+        self._frozen_results = None
 
     def append(self, item, is_whole=True):
         """Append an item to the result queue.
@@ -89,17 +104,12 @@ class ResultQueue:
             return self.num_whole_items_received == self.limit
 
     def __iter__(self):
-        with self.update_lock:
-            if self._frozen_items is not None:
-                return iter(self._frozen_items)
         return self
 
     def __next__(self):
         while True:
             # Check the queue and completion count atomically with append().
             with self.update_lock:
-                if self._frozen_items is not None:
-                    raise TypeError("frozen results are re-iterable; use iter(results) before calling next()")
                 try:
                     item = self.q.get_nowait()
                 except queue.Empty:
@@ -116,8 +126,9 @@ class ResultQueue:
             # More outcomes are expected. Do not hold update_lock while
             # waiting, because append() needs it to enqueue the next item.
             item = self.q.get(block=True)
-            if item is not _FAILURE_MARKER:
-                return item
+            if item is _FAILURE_MARKER:
+                continue
+            return item
 
     def freeze(self):
         """Freeze a completed queue into a re-iterable snapshot."""
@@ -126,9 +137,9 @@ class ResultQueue:
                 raise RuntimeError("cannot freeze result queue before all outcomes are received")
             if self._items is None:
                 raise RuntimeError("cannot freeze result queue without retained history")
-            if self._frozen_items is None:
-                self._frozen_items = tuple(self._items)
-            return self
+            if self._frozen_results is None:
+                self._frozen_results = FrozenResultQueue(self._items, self.failures, self.num_successes)
+            return self._frozen_results
 
     def __len__(self):
         """Return the number of successful whole results received.

--- a/nvflare/collab/api/group_call_context.py
+++ b/nvflare/collab/api/group_call_context.py
@@ -34,7 +34,7 @@ def _get_site_name(target_name: str):
 
 
 class ResultQueue:
-    def __init__(self, limit: int):
+    def __init__(self, limit: int, retain_history=True):
         if limit <= 0:
             raise ValueError(f"bad queue limit {limit}: must be > 0")
 
@@ -47,9 +47,8 @@ class ResultQueue:
         self.num_successes = 0
         self.failures = {}
         self.update_lock = threading.Lock()
-        self._iteration_started = False
+        self._items = [] if retain_history else None
         self._frozen_items = None
-        self._frozen_next_index = 0
 
     def append(self, item, is_whole=True):
         """Append an item to the result queue.
@@ -63,6 +62,8 @@ class ResultQueue:
         with self.update_lock:
             if self.num_whole_items_received < self.limit:
                 self.q.put_nowait(item)
+                if self._items is not None:
+                    self._items.append(item)
                 if is_whole:
                     # increment num_whole_items_received only if the item is whole!
                     # note: num_whole_items_received is not the number of all items received.
@@ -98,12 +99,7 @@ class ResultQueue:
             # Check the queue and completion count atomically with append().
             with self.update_lock:
                 if self._frozen_items is not None:
-                    if self._frozen_next_index >= len(self._frozen_items):
-                        raise StopIteration()
-                    item = self._frozen_items[self._frozen_next_index]
-                    self._frozen_next_index += 1
-                    return item
-                self._iteration_started = True
+                    raise TypeError("frozen results are re-iterable; use iter(results) before calling next()")
                 try:
                     item = self.q.get_nowait()
                 except queue.Empty:
@@ -124,22 +120,14 @@ class ResultQueue:
                 return item
 
     def freeze(self):
-        """Freeze a completed, unconsumed queue into a re-iterable snapshot."""
+        """Freeze a completed queue into a re-iterable snapshot."""
         with self.update_lock:
             if self.num_whole_items_received < self.limit:
                 raise RuntimeError("cannot freeze result queue before all outcomes are received")
-            if self._iteration_started:
-                raise RuntimeError("cannot freeze result queue after iteration has started")
+            if self._items is None:
+                raise RuntimeError("cannot freeze result queue without retained history")
             if self._frozen_items is None:
-                items = []
-                while True:
-                    try:
-                        item = self.q.get_nowait()
-                    except queue.Empty:
-                        break
-                    if item is not _FAILURE_MARKER:
-                        items.append(item)
-                self._frozen_items = tuple(items)
+                self._frozen_items = tuple(self._items)
             return self
 
     def __len__(self):
@@ -153,7 +141,7 @@ class ResultQueue:
 
 class ResultWaiter(threading.Event):
 
-    def __init__(self, sites: list[str]):
+    def __init__(self, sites: list[str], retain_history=True):
         super().__init__()
         self.sites = sites
         self._expected_sites = {_get_site_name(site) for site in sites}
@@ -161,7 +149,7 @@ class ResultWaiter(threading.Event):
             raise ValueError(f"sites must be unique but got {sites}")
         self._received_sites = set()
         self._result_lock = threading.Lock()
-        self.results = ResultQueue(len(self._expected_sites))
+        self.results = ResultQueue(len(self._expected_sites), retain_history=retain_history)
         self.standing_call_count = 0
         self.call_count_decreased = threading.Condition(threading.Lock())
         self.logger = get_obj_logger(self)

--- a/nvflare/collab/api/proxy_list.py
+++ b/nvflare/collab/api/proxy_list.py
@@ -74,15 +74,16 @@ class ProxyList:
         """This is called to define the behavior (Call Option) of the group call.
 
         Args:
-            blocking:
-            expect_result:
-            timeout:
-            optional:
-            secure:
-            target:
+            blocking: whether to wait for all outcomes and return re-iterable results. If False, return a live,
+                single-pass result stream.
+            expect_result: whether results are expected from the remote objects.
+            timeout: maximum number of seconds to wait for each result.
+            optional: whether the calls are optional.
+            secure: whether to use P2P secure messaging.
+            target: name of the Collab object to call at each site.
             parallel: maximum number of calls that may remain in flight at once.
-            process_resp_cb:
-            **cb_kwargs:
+            process_resp_cb: callback for processing each response.
+            **cb_kwargs: keyword arguments passed to process_resp_cb.
 
         Returns:
 

--- a/tests/unit_test/collab/group_test.py
+++ b/tests/unit_test/collab/group_test.py
@@ -96,3 +96,26 @@ def test_nonblocking_group_returns_before_bounded_dispatch_completes():
 
     assert second_dispatched.wait(timeout=1.0)
     assert sorted(returned["results"]) == [("site-1", "first"), ("site-2", "second")]
+    assert list(returned["results"]) == []
+
+
+def test_blocking_group_results_are_reiterable():
+    app = ClientApp(object())
+
+    def dispatch(gcc, *_args, **_kwargs):
+        gcc.set_result(f"result-{gcc.target_name}")
+        gcc.call_completed()
+
+    proxies = [
+        _proxy(app, "site-1", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
+        _proxy(app, "site-2", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
+    ]
+
+    results = Group(app, Signal(), proxies).train()
+
+    expected = [("site-1", "result-site-1"), ("site-2", "result-site-2")]
+    assert list(results) == expected
+    assert list(results) == expected
+    expected_by_site = dict(expected)
+    assert dict(results) == expected_by_site
+    assert dict(results) == expected_by_site

--- a/tests/unit_test/collab/group_test.py
+++ b/tests/unit_test/collab/group_test.py
@@ -119,29 +119,3 @@ def test_blocking_group_results_are_reiterable():
     expected_by_site = dict(expected)
     assert dict(results) == expected_by_site
     assert dict(results) == expected_by_site
-
-
-def test_blocking_group_results_include_results_consumed_by_callback():
-    app = ClientApp(object())
-    consumed = []
-
-    def process_response(gcc, result):
-        if gcc.target_name == "site-2":
-            consumed.append(next(gcc.waiter.results))
-        return result
-
-    def dispatch(gcc, *_args, **_kwargs):
-        gcc.set_result(f"result-{gcc.target_name}")
-        gcc.call_completed()
-
-    proxies = [
-        _proxy(app, "site-1", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
-        _proxy(app, "site-2", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
-    ]
-
-    results = Group(app, Signal(), proxies, process_resp_cb=process_response).train()
-
-    expected = [("site-1", "result-site-1"), ("site-2", "result-site-2")]
-    assert consumed == [expected[0]]
-    assert list(results) == expected
-    assert list(results) == expected

--- a/tests/unit_test/collab/group_test.py
+++ b/tests/unit_test/collab/group_test.py
@@ -119,3 +119,29 @@ def test_blocking_group_results_are_reiterable():
     expected_by_site = dict(expected)
     assert dict(results) == expected_by_site
     assert dict(results) == expected_by_site
+
+
+def test_blocking_group_results_include_results_consumed_by_callback():
+    app = ClientApp(object())
+    consumed = []
+
+    def process_response(gcc, result):
+        if gcc.target_name == "site-2":
+            consumed.append(next(gcc.waiter.results))
+        return result
+
+    def dispatch(gcc, *_args, **_kwargs):
+        gcc.set_result(f"result-{gcc.target_name}")
+        gcc.call_completed()
+
+    proxies = [
+        _proxy(app, "site-1", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
+        _proxy(app, "site-2", {"train": []}, MagicMock(call_target_in_group=MagicMock(side_effect=dispatch))),
+    ]
+
+    results = Group(app, Signal(), proxies, process_resp_cb=process_response).train()
+
+    expected = [("site-1", "result-site-1"), ("site-2", "result-site-2")]
+    assert consumed == [expected[0]]
+    assert list(results) == expected
+    assert list(results) == expected

--- a/tests/unit_test/collab/invocation_test.py
+++ b/tests/unit_test/collab/invocation_test.py
@@ -256,6 +256,29 @@ def test_frozen_result_queue_is_reiterable_and_preserves_partial_results():
     assert len(result_queue) == 2
 
 
+def test_frozen_result_queue_preserves_previously_consumed_results():
+    result_queue = ResultQueue(limit=2)
+    expected = [("site-1", "first"), ("site-2", "second")]
+    result_queue.append(expected[0])
+
+    assert next(result_queue) == expected[0]
+
+    result_queue.append(expected[1])
+    result_queue.freeze()
+
+    assert list(result_queue) == expected
+    assert list(result_queue) == expected
+
+
+def test_frozen_result_queue_rejects_direct_next():
+    result_queue = ResultQueue(limit=1)
+    result_queue.append(("site-1", "result"))
+    result_queue.freeze()
+
+    with pytest.raises(TypeError, match="use iter"):
+        next(result_queue)
+
+
 def test_frozen_result_queue_preserves_failures_without_yielding_markers():
     result_queue = ResultQueue(limit=2)
     error = CollabCallError("site-1", "train", TimeoutError("timed out"))
@@ -269,14 +292,13 @@ def test_frozen_result_queue_preserves_failures_without_yielding_markers():
     assert result_queue.failures == {"site-1": error}
 
 
-def test_result_queue_rejects_freeze_before_completion_or_after_consumption():
+def test_result_queue_rejects_freeze_before_completion():
     incomplete_queue = ResultQueue(limit=2)
     incomplete_queue.append(("site-1", "first"))
     with pytest.raises(RuntimeError, match="before all outcomes"):
         incomplete_queue.freeze()
 
-    consumed_queue = ResultQueue(limit=1)
-    consumed_queue.append(("site-1", "first"))
-    assert next(consumed_queue) == ("site-1", "first")
-    with pytest.raises(RuntimeError, match="after iteration has started"):
-        consumed_queue.freeze()
+    live_queue = ResultQueue(limit=1, retain_history=False)
+    live_queue.append(("site-1", "result"))
+    with pytest.raises(RuntimeError, match="without retained history"):
+        live_queue.freeze()

--- a/tests/unit_test/collab/invocation_test.py
+++ b/tests/unit_test/collab/invocation_test.py
@@ -16,6 +16,8 @@ import queue
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from nvflare.apis.signal import Signal
 from nvflare.collab.api._invocation import _InvocationDispatcher
 from nvflare.collab.api.call_opt import CallOption
@@ -235,3 +237,46 @@ def test_result_queue_does_not_drop_last_concurrent_item():
 
     assert not consumer.is_alive()
     assert outcome == [("result", item)]
+
+
+def test_frozen_result_queue_is_reiterable_and_preserves_partial_results():
+    result_queue = ResultQueue(limit=2)
+    expected = [
+        ("site-1", "partial"),
+        ("site-1", "first"),
+        ("site-2", "second"),
+    ]
+    result_queue.append(expected[0], is_whole=False)
+    result_queue.append(expected[1])
+    result_queue.append(expected[2])
+
+    assert result_queue.freeze() is result_queue
+    assert list(result_queue) == expected
+    assert list(result_queue) == expected
+    assert len(result_queue) == 2
+
+
+def test_frozen_result_queue_preserves_failures_without_yielding_markers():
+    result_queue = ResultQueue(limit=2)
+    error = CollabCallError("site-1", "train", TimeoutError("timed out"))
+    result_queue.append_failure("site-1", error)
+    result_queue.append(("site-2", "result"))
+
+    result_queue.freeze()
+
+    assert list(result_queue) == [("site-2", "result")]
+    assert list(result_queue) == [("site-2", "result")]
+    assert result_queue.failures == {"site-1": error}
+
+
+def test_result_queue_rejects_freeze_before_completion_or_after_consumption():
+    incomplete_queue = ResultQueue(limit=2)
+    incomplete_queue.append(("site-1", "first"))
+    with pytest.raises(RuntimeError, match="before all outcomes"):
+        incomplete_queue.freeze()
+
+    consumed_queue = ResultQueue(limit=1)
+    consumed_queue.append(("site-1", "first"))
+    assert next(consumed_queue) == ("site-1", "first")
+    with pytest.raises(RuntimeError, match="after iteration has started"):
+        consumed_queue.freeze()

--- a/tests/unit_test/collab/invocation_test.py
+++ b/tests/unit_test/collab/invocation_test.py
@@ -250,10 +250,10 @@ def test_frozen_result_queue_is_reiterable_and_preserves_partial_results():
     result_queue.append(expected[1])
     result_queue.append(expected[2])
 
-    assert result_queue.freeze() is result_queue
-    assert list(result_queue) == expected
-    assert list(result_queue) == expected
-    assert len(result_queue) == 2
+    frozen_results = result_queue.freeze()
+    assert list(frozen_results) == expected
+    assert list(frozen_results) == expected
+    assert len(frozen_results) == 2
 
 
 def test_frozen_result_queue_preserves_previously_consumed_results():
@@ -264,19 +264,19 @@ def test_frozen_result_queue_preserves_previously_consumed_results():
     assert next(result_queue) == expected[0]
 
     result_queue.append(expected[1])
-    result_queue.freeze()
+    frozen_results = result_queue.freeze()
 
-    assert list(result_queue) == expected
-    assert list(result_queue) == expected
+    assert list(frozen_results) == expected
+    assert list(frozen_results) == expected
 
 
-def test_frozen_result_queue_rejects_direct_next():
+def test_frozen_result_queue_is_not_an_iterator():
     result_queue = ResultQueue(limit=1)
     result_queue.append(("site-1", "result"))
-    result_queue.freeze()
+    frozen_results = result_queue.freeze()
 
-    with pytest.raises(TypeError, match="use iter"):
-        next(result_queue)
+    with pytest.raises(TypeError, match="not an iterator"):
+        next(frozen_results)
 
 
 def test_frozen_result_queue_preserves_failures_without_yielding_markers():
@@ -285,11 +285,24 @@ def test_frozen_result_queue_preserves_failures_without_yielding_markers():
     result_queue.append_failure("site-1", error)
     result_queue.append(("site-2", "result"))
 
-    result_queue.freeze()
+    frozen_results = result_queue.freeze()
 
-    assert list(result_queue) == [("site-2", "result")]
-    assert list(result_queue) == [("site-2", "result")]
-    assert result_queue.failures == {"site-1": error}
+    assert list(frozen_results) == [("site-2", "result")]
+    assert list(frozen_results) == [("site-2", "result")]
+    assert frozen_results.failures == {"site-1": error}
+
+
+def test_freezing_does_not_change_existing_live_iterator():
+    result_queue = ResultQueue(limit=2)
+    expected = [("site-1", "first"), ("site-2", "second")]
+    live_iterator = iter(result_queue)
+    result_queue.append(expected[0])
+    result_queue.append(expected[1])
+
+    frozen_results = result_queue.freeze()
+
+    assert list(live_iterator) == expected
+    assert list(frozen_results) == expected
 
 
 def test_result_queue_rejects_freeze_before_completion():


### PR DESCRIPTION
## Problem

Blocking Collab group calls wait for every site outcome but return the same live, destructive result iterator used by non-blocking calls. A second pass over those completed results silently yields no entries, which can cause multi-stage aggregation code to compute an empty result without any error.

## Changes

- freeze completed blocking-call results into an ordered, replayable snapshot
- preserve the existing `(site, result)` iteration contract, partial-result ordering, and `.failures`
- keep non-blocking result streams live and single-pass
- document the blocking and non-blocking contracts
- add regression coverage for repeated list/dict conversion, partial results, failures, and invalid freezing

## Validation

- `python -m pytest -q tests/unit_test/collab` — 120 passed
- focused regression tests — 14 passed
- scoped Black, isort, and Flake8 checks passed

The full style wrapper could not install into the externally managed Homebrew Python environment, so the equivalent scoped checks were run directly.