### PR TITLE
Add Q3 2026 webinar recording

### DIFF
--- a/web/src/pages/webinars.astro
+++ b/web/src/pages/webinars.astro
@@ -6,6 +6,15 @@ const base_url = import.meta.env.BASE_URL;
 
 const webinars = [
   {
+    quarter: "Q3 2026",
+    title: "From Skills to Scale with AI Agents",
+    description:
+      "See how NVIDIA FLARE agentic and Auto-FL skills streamline workflow development and iteration, and how Slurm integration can scale federated learning efficiently on shared HPC infrastructure.",
+    link: "https://www.youtube.com/watch?v=2Q7jXoOJmFE",
+    embed_link: "https://www.youtube-nocookie.com/embed/2Q7jXoOJmFE?rel=0",
+    cta: "Watch recording",
+  },
+  {
     quarter: "Q2 2026",
     title: "Production Federated Learning, Multicloud Deployment, and Agent-Assisted Research",
     description:


### PR DESCRIPTION
## Summary

- add the Q3 2026 webinar, "From Skills to Scale with AI Agents"
- feature the new YouTube recording using the existing privacy-enhanced embed pattern
- retain the Q2 2026 webinar under "More in the series"

Event: https://www.aicamp.ai/event/eventdetails/W2026082010
Recording: https://youtu.be/2Q7jXoOJmFE

## Testing

- `npm run build`
- `git diff --check`
- `./runtest.sh -s` *(unable to start because uv attempted to install dependencies into an externally managed Homebrew Python environment)*