### PR TITLE
Allow client-to-client Collab calls through transit cells

### DIFF
--- a/nvflare/collab/runtime/dispatch.py
+++ b/nvflare/collab/runtime/dispatch.py
@@ -100,17 +100,10 @@ class _CollabStreamFilter:
         ):
             return None
 
-        # CoreCell invokes incoming filters before it decides whether to
-        # deliver or forward a message. Only authorize streams addressed to
-        # this job cell; a transit stream will be authorized by its final
-        # destination before receiver state is allocated there.
-        if message.get_header(MessageHeaderKey.DESTINATION) != self.authorizer.local_fqcn:
-            return None
-
         rejection = self.authorizer.authorize(message.headers)
         if rejection:
             self.byte_receiver.reject(message, rejection)
-            # Incoming filters stop delivery when they return a Message. The
+            # Incoming request filters stop delivery when they return a Message. The
             # stream rejection itself is reported on ByteStreamer's generic
             # error topics, so this outer fire-and-forget reply is discarded.
             return Message()
@@ -144,7 +137,9 @@ def prepare_for_remote_call(cell, app, logger, executor, participants: dict[str,
     authorizer = CollabCallAuthorizer(app, cell.get_fqcn(), participants, logger)
     adapter = Adapter(_submit_app_method, cell.core_cell.my_info, cell)
     stream_filter = _CollabStreamFilter(authorizer, cell.byte_receiver)
-    cell.core_cell.add_incoming_filter(STREAM_CHANNEL, STREAM_DATA_TOPIC, stream_filter.filter)
+    # Request filters run only after CoreCell has routed the frame to this
+    # destination, but before ByteReceiver allocates stream state.
+    cell.core_cell.add_incoming_request_filter(STREAM_CHANNEL, STREAM_DATA_TOPIC, stream_filter.filter)
     cell.register_blob_cb(
         channel=MSG_CHANNEL,
         topic=MSG_TOPIC,

--- a/nvflare/collab/runtime/dispatch.py
+++ b/nvflare/collab/runtime/dispatch.py
@@ -100,6 +100,13 @@ class _CollabStreamFilter:
         ):
             return None
 
+        # CoreCell invokes incoming filters before it decides whether to
+        # deliver or forward a message. Only authorize streams addressed to
+        # this job cell; a transit stream will be authorized by its final
+        # destination before receiver state is allocated there.
+        if message.get_header(MessageHeaderKey.DESTINATION) != self.authorizer.local_fqcn:
+            return None
+
         rejection = self.authorizer.authorize(message.headers)
         if rejection:
             self.byte_receiver.reject(message, rejection)

--- a/tests/unit_test/collab/runtime/dispatch_test.py
+++ b/tests/unit_test/collab/runtime/dispatch_test.py
@@ -109,8 +109,8 @@ def test_prepare_for_remote_call_registers_blob_callback():
     assert registration["logger"] is logger
     assert registration["executor"] is executor
     assert "preflight_cb" not in registration
-    cell.core_cell.add_incoming_filter.assert_called_once()
-    filter_registration = cell.core_cell.add_incoming_filter.call_args.args
+    cell.core_cell.add_incoming_request_filter.assert_called_once()
+    filter_registration = cell.core_cell.add_incoming_request_filter.call_args.args
     assert filter_registration[:2] == (STREAM_CHANNEL, STREAM_DATA_TOPIC)
     assert callable(filter_registration[2])
 
@@ -138,31 +138,13 @@ def test_collab_stream_filter_rejects_before_receive_state_is_created():
     byte_receiver.reject.assert_called_once_with(message, rejection)
 
 
-def test_collab_stream_filter_ignores_transit_streams():
-    authorizer = MagicMock(local_fqcn="server")
-    byte_receiver = MagicMock()
-    stream_filter = _CollabStreamFilter(authorizer, byte_receiver)
-    message = Message(
-        {
-            MessageHeaderKey.ORIGIN: "site-1.job",
-            MessageHeaderKey.DESTINATION: "site-2.job",
-            StreamHeaderKey.STREAM_ID: 123,
-            StreamHeaderKey.CHANNEL: MSG_CHANNEL,
-            StreamHeaderKey.TOPIC: MSG_TOPIC,
-        }
-    )
-
-    assert stream_filter.filter(message) is None
-    authorizer.authorize.assert_not_called()
-    byte_receiver.reject.assert_not_called()
-
-
 def test_collab_stream_filter_ignores_other_streams():
-    authorizer = MagicMock()
+    authorizer = MagicMock(local_fqcn="site-1.job")
     byte_receiver = MagicMock()
     stream_filter = _CollabStreamFilter(authorizer, byte_receiver)
     message = Message(
         {
+            MessageHeaderKey.DESTINATION: "site-1.job",
             StreamHeaderKey.CHANNEL: "other-channel",
             StreamHeaderKey.TOPIC: "other-topic",
         }

--- a/tests/unit_test/collab/runtime/dispatch_test.py
+++ b/tests/unit_test/collab/runtime/dispatch_test.py
@@ -116,7 +116,7 @@ def test_prepare_for_remote_call_registers_blob_callback():
 
 
 def test_collab_stream_filter_rejects_before_receive_state_is_created():
-    authorizer = MagicMock()
+    authorizer = MagicMock(local_fqcn="site-1.job")
     rejection = StreamError("Collab call rejected")
     authorizer.authorize.return_value = rejection
     byte_receiver = MagicMock()
@@ -124,6 +124,7 @@ def test_collab_stream_filter_rejects_before_receive_state_is_created():
     message = Message(
         {
             MessageHeaderKey.ORIGIN: "server.other-job",
+            MessageHeaderKey.DESTINATION: "site-1.job",
             StreamHeaderKey.STREAM_ID: 123,
             StreamHeaderKey.CHANNEL: MSG_CHANNEL,
             StreamHeaderKey.TOPIC: MSG_TOPIC,
@@ -135,6 +136,25 @@ def test_collab_stream_filter_rejects_before_receive_state_is_created():
     assert isinstance(response, Message)
     authorizer.authorize.assert_called_once_with(message.headers)
     byte_receiver.reject.assert_called_once_with(message, rejection)
+
+
+def test_collab_stream_filter_ignores_transit_streams():
+    authorizer = MagicMock(local_fqcn="server")
+    byte_receiver = MagicMock()
+    stream_filter = _CollabStreamFilter(authorizer, byte_receiver)
+    message = Message(
+        {
+            MessageHeaderKey.ORIGIN: "site-1.job",
+            MessageHeaderKey.DESTINATION: "site-2.job",
+            StreamHeaderKey.STREAM_ID: 123,
+            StreamHeaderKey.CHANNEL: MSG_CHANNEL,
+            StreamHeaderKey.TOPIC: MSG_TOPIC,
+        }
+    )
+
+    assert stream_filter.filter(message) is None
+    authorizer.authorize.assert_not_called()
+    byte_receiver.reject.assert_not_called()
 
 
 def test_collab_stream_filter_ignores_other_streams():


### PR DESCRIPTION
## Summary

- authorize Collab stream frames only at their final job-cell destination
- allow intermediate CellNet nodes to forward client-to-client Collab traffic
- preserve pre-allocation participant and envelope authorization at the receiving job cell
- add focused coverage for transit streams

## Background

CoreCell invokes incoming filters before checking whether a message is addressed locally or needs forwarding. The Collab stream filter therefore rejected generation-1 client-to-client traffic at the intermediate server because the destination did not match the server cell. The sender then received an uncorrelated stream error and the workflow stalled.

Transit cells now leave the stream untouched. The final destination still runs the existing exact destination, participant, protocol, target, and method checks before ByteReceiver allocates receive state.

## Validation

- 29 focused Collab authorization and security tests passed
- 117 Collab unit tests passed
- shipped two-client swarm example completed successfully in SimEnv with client-to-client traffic routed through the server
- scoped Black, isort, Flake8, and whitespace checks passed
- repository style wrapper was run with Python 3.12.13 from ~/venv/3.12; it reached Black and reported only three generated node_modules/flatted.py files outside this change that would be reformatted