### PR TITLE
[Auto-FL] Report direction-adjusted literature improvement

### DIFF
--- a/skills/nvflare-autofl-report/scripts/generate_report.py
+++ b/skills/nvflare-autofl-report/scripts/generate_report.py
@@ -889,6 +889,11 @@ def literature_outcomes(
                 "best_candidate": None if segment_best is None else segment_best.name,
                 "best_score": None if segment_best is None else segment_best.score,
                 "delta_from_incumbent": delta,
+                "improvement_from_incumbent": (
+                    None
+                    if before is None or segment_best is None
+                    else improvement_amount(segment_best.score, before.score, mode)
+                ),
                 "candidate_attempts": [record.name for record in attempts],
                 "completion": completion,
                 "candidate_results": [
@@ -1084,27 +1089,27 @@ def family_outcomes(records: Sequence[RunRecord], helped_rows: set[int], mode: s
     return sorted(outcomes, key=lambda item: (order[item["outcome"]], item["algorithm_family"]))
 
 
-def literature_digest(reviews: Sequence[Dict[str, Any]], mode: str = "max") -> Dict[str, Any]:
+def literature_digest(reviews: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     counts = dict(sorted(Counter(review["outcome"] for review in reviews).items()))
-    helped = [review for review in reviews if review["outcome"] == "helped"]
+    helped = [
+        review
+        for review in reviews
+        if review["outcome"] == "helped" and review["improvement_from_incumbent"] is not None
+    ]
     strongest = None
     if helped:
-
-        def improvement(review: Dict[str, Any]) -> float:
-            if review["best_score"] is None or review["incumbent_score"] is None:
-                return -math.inf
-            return improvement_amount(review["best_score"], review["incumbent_score"], mode)
-
         strongest = max(
             helped,
-            key=improvement,
+            key=lambda review: review["improvement_from_incumbent"],
         )
         strongest = {
             "event": strongest["event"],
             "literature_event_id": strongest["literature_event_id"],
             "best_candidate": strongest["best_candidate"],
             "best_score": strongest["best_score"],
+            "incumbent_score": strongest["incumbent_score"],
             "delta_from_incumbent": strongest["delta_from_incumbent"],
+            "improvement_from_incumbent": strongest["improvement_from_incumbent"],
             "sources": strongest["sources"],
         }
     return {"counts": counts, "strongest_helped": strongest}
@@ -1140,7 +1145,7 @@ def outcome_summary(
         "not_confirmed": representative_non_improvements(non_improvements, max_non_improvements),
         "failures": failure_outcomes(failures, max_non_improvements),
         "families": family_outcomes(records, helped_rows, mode),
-        "literature": literature_digest(reviews, mode),
+        "literature": literature_digest(reviews),
     }
 
 
@@ -1747,8 +1752,8 @@ def report_markdown(summary: Dict[str, Any], records: Sequence[RunRecord]) -> st
         if strongest:
             lines.append(
                 f"Strongest literature-linked improvement: `{strongest['event']}` led to "
-                f"`{strongest['best_candidate']}` with delta "
-                f"`{format_delta(strongest['delta_from_incumbent'])}` versus its incumbent."
+                f"`{strongest['best_candidate']}` with objective improvement "
+                f"`{format_delta(strongest['improvement_from_incumbent'])}` versus its incumbent."
             )
         lines.extend(
             [

--- a/tests/unit_test/tool/autofl_skill_report_test.py
+++ b/tests/unit_test/tool/autofl_skill_report_test.py
@@ -197,6 +197,22 @@ def _generate(reporter, tmp_path, monkeypatch, *extra):
     return reporter.generate(args)
 
 
+def _set_minimization_contract(tmp_path):
+    tmp_path.joinpath("autofl.yaml").write_text(
+        "objective:\n"
+        "  metric: val_loss\n"
+        "  requested_metric: val_loss\n"
+        "  optimization_metric: val_loss\n"
+        "  mode: min\n"
+        "  mode_contract_source: job:key_metric_mode\n",
+        encoding="utf-8",
+    )
+    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update({"mode": "min", "baseline_score": 1.0, "best_score": 0.6, "improvement": 0.4})
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
 def test_atomic_write_text_removes_temp_file_after_write_failure(tmp_path, monkeypatch):
     reporter = _load_reporter()
     named_temporary_file = reporter.tempfile.NamedTemporaryFile
@@ -773,6 +789,7 @@ def test_report_synthesizes_literature_against_checkpoint_incumbent(tmp_path, mo
     assert literature[0]["incumbent_score"] == 0.5
     assert literature[0]["best_candidate"] == "inherited_tuning"
     assert literature[0]["delta_from_incumbent"] == pytest.approx(0.15)
+    assert literature[0]["improvement_from_incumbent"] == pytest.approx(0.15)
     assert summary["outcome_summary"]["literature"] == {
         "counts": {"helped": 1},
         "strongest_helped": {
@@ -780,7 +797,9 @@ def test_report_synthesizes_literature_against_checkpoint_incumbent(tmp_path, mo
             "literature_event_id": "lit-0001",
             "best_candidate": "inherited_tuning",
             "best_score": 0.65,
+            "incumbent_score": 0.5,
             "delta_from_incumbent": pytest.approx(0.15),
+            "improvement_from_incumbent": pytest.approx(0.15),
             "sources": ["Li18 arXiv:1812.06127", "Karimireddy19"],
         },
     }
@@ -1467,19 +1486,7 @@ def test_report_supports_native_minimization_contract(tmp_path, monkeypatch):
             _row("discard", "higher_loss", "0.8", base_candidate="lower_loss"),
         ],
     )
-    tmp_path.joinpath("autofl.yaml").write_text(
-        "objective:\n"
-        "  metric: val_loss\n"
-        "  requested_metric: val_loss\n"
-        "  optimization_metric: val_loss\n"
-        "  mode: min\n"
-        "  mode_contract_source: job:key_metric_mode\n",
-        encoding="utf-8",
-    )
-    state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
-    state = json.loads(state_path.read_text(encoding="utf-8"))
-    state.update({"mode": "min", "baseline_score": 1.0, "best_score": 0.6, "improvement": 0.4})
-    state_path.write_text(json.dumps(state), encoding="utf-8")
+    _set_minimization_contract(tmp_path)
 
     summary = _generate(reporter, tmp_path, monkeypatch)
     report = tmp_path.joinpath("autofl_final_report.md").read_text(encoding="utf-8")
@@ -1489,8 +1496,61 @@ def test_report_supports_native_minimization_contract(tmp_path, monkeypatch):
     assert summary["best"]["name"] == "lower_loss"
     assert summary["selection"]["improvement_from_baseline"] == pytest.approx(0.4)
     assert summary["state_accounting"]["consistent"] is True
+    assert summary["literature_reviews"] == []
+    assert summary["outcome_summary"]["literature"] == {"counts": {}, "strongest_helped": None}
     assert "`min` direction" in report
+    assert "No literature checkpoints were recorded in the ledger." in report
+
+
+def test_report_adjusts_literature_improvement_for_minimization(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    _write_rows(
+        tmp_path,
+        [
+            _row("baseline", "baseline", "1.0"),
+            _row("literature", "loss_review", literature_event_id="lit-min"),
+            _row("keep", "lower_loss", "0.6", base_candidate="baseline", literature_event_id="lit-min"),
+            _row("discard", "higher_loss", "0.8", base_candidate="lower_loss", literature_event_id="lit-min"),
+        ],
+    )
+    _set_minimization_contract(tmp_path)
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+    report = tmp_path.joinpath("autofl_final_report.md").read_text(encoding="utf-8")
+
+    literature = summary["outcome_summary"]["literature"]["strongest_helped"]
+    assert literature["incumbent_score"] == pytest.approx(1.0)
+    assert literature["delta_from_incumbent"] == pytest.approx(-0.4)
+    assert literature["improvement_from_incumbent"] == pytest.approx(0.4)
     assert "objective improvement `+0.400000`" in report
+    assert (
+        "Strongest literature-linked improvement: `loss_review` led to `lower_loss` with objective improvement "
+        "`+0.400000` versus its incumbent."
+    ) in report
+
+
+def test_report_omits_strongest_literature_headline_without_incumbent(tmp_path, monkeypatch):
+    reporter = _load_reporter()
+    _write_campaign(tmp_path)
+    _write_rows(
+        tmp_path,
+        [
+            _row("literature", "early_review", literature_event_id="lit-early"),
+            _row("keep", "early_candidate", "0.7", literature_event_id="lit-early"),
+            _row("baseline", "baseline", "0.5"),
+        ],
+    )
+
+    summary = _generate(reporter, tmp_path, monkeypatch)
+    report = tmp_path.joinpath("autofl_final_report.md").read_text(encoding="utf-8")
+
+    literature = summary["literature_reviews"][0]
+    assert literature["outcome"] == "helped"
+    assert literature["incumbent_score"] is None
+    assert literature["improvement_from_incumbent"] is None
+    assert summary["outcome_summary"]["literature"]["strongest_helped"] is None
+    assert "Strongest literature-linked improvement:" not in report
 
 
 def test_report_keeps_strict_improvement_independent_of_plateau_tolerance(tmp_path, monkeypatch):

--- a/tests/unit_test/tool/autofl_skill_report_test.py
+++ b/tests/unit_test/tool/autofl_skill_report_test.py
@@ -209,7 +209,7 @@ def _set_minimization_contract(tmp_path):
     )
     state_path = tmp_path / ".nvflare/autofl/campaign_state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
-    state.update({"mode": "min", "baseline_score": 1.0, "best_score": 0.6, "improvement": 0.4})
+    state.update({"mode": "min", "baseline_score": 1.0, "improvement": 0.4})
     state_path.write_text(json.dumps(state), encoding="utf-8")
 
 
@@ -1523,7 +1523,6 @@ def test_report_adjusts_literature_improvement_for_minimization(tmp_path, monkey
     assert literature["incumbent_score"] == pytest.approx(1.0)
     assert literature["delta_from_incumbent"] == pytest.approx(-0.4)
     assert literature["improvement_from_incumbent"] == pytest.approx(0.4)
-    assert "objective improvement `+0.400000`" in report
     assert (
         "Strongest literature-linked improvement: `loss_review` led to `lower_loss` with objective improvement "
         "`+0.400000` versus its incumbent."
@@ -1536,9 +1535,9 @@ def test_report_omits_strongest_literature_headline_without_incumbent(tmp_path, 
     _write_rows(
         tmp_path,
         [
+            _row("baseline", "baseline"),
             _row("literature", "early_review", literature_event_id="lit-early"),
             _row("keep", "early_candidate", "0.7", literature_event_id="lit-early"),
-            _row("baseline", "baseline", "0.5"),
         ],
     )
 


### PR DESCRIPTION
## Summary

- add direction-adjusted `improvement_from_incumbent` to detailed literature outcomes and the compact strongest-helped payload
- preserve the raw `delta_from_incumbent` for ledger-compatible consumers
- rank and render the literature headline using the stored direction-adjusted improvement
- omit the strongest-helped headline when a literature checkpoint has no comparable incumbent
- cover minimization reports both with and without literature checkpoints

## Background

This is a follow-up to #5169. Literature checkpoint selection already honors metric direction, but the strongest-improvement headline still rendered the raw delta. For a minimizing objective that moves from 1.0 to 0.6, it therefore labeled `-0.4` as an improvement even though the report contract specifies a positive direction-adjusted improvement.

The JSON change is additive, and the Markdown wording now matches the existing executive-summary terminology. Raw deltas remain available in the detailed tables, where they are explicitly labeled as deltas. No documentation or schema-version change is needed because the report contract already defines this behavior.

## Validation

- `python3.12 -m pytest tests/unit_test/tool/autofl_skill_report_test.py -q` — 117 passed
- `./runtest.sh --skip-install -s` — Black, isort, Flake8, and agent-skill lint passed
- `git diff --check`

### Types of changes

- [x] Non-breaking change (bug fix)
- [x] New tests added to cover the changes
- [ ] Breaking change
- [ ] Documentation updated
