### PR TITLE
[Auto-FL] Lazily load core metric heuristic in job importer

### DIFF
--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -40,10 +40,8 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
 
-try:
-    from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better as _core_looks_lower_is_better
-except ImportError:
-    _core_looks_lower_is_better = None
+_UNRESOLVED = object()
+_core_looks_lower_is_better = _UNRESOLVED
 
 AUTOFL_CONFIG_SCHEMA_VERSION = "nvflare.autofl.config.v1"
 IMPORTER_VERSION = "nvflare-autofl-job-importer/v1"
@@ -70,6 +68,7 @@ LOWER_IS_BETTER_METRIC_TOKENS = {
     "rmse",
     "wer",
 }
+ALREADY_NEGATED_METRIC_TOKEN = "neg"
 
 SUPPORTED_ENV_NAMES = {"PocEnv", "ProdEnv", "SimEnv"}
 NON_OPTIMIZATION_RECIPE_NAMES = {"FedEvalRecipe", "FedStatsRecipe", "NumpyCrossSiteEvalRecipe"}
@@ -1230,18 +1229,32 @@ def _resolve_stop_condition_mode(
     return None, None
 
 
+def _resolve_core_heuristic():
+    global _core_looks_lower_is_better
+
+    if _core_looks_lower_is_better is _UNRESOLVED:
+        try:
+            from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better
+        except Exception:  # Core initialization failures must preserve the standalone fallback.
+            _core_looks_lower_is_better = None
+        else:
+            _core_looks_lower_is_better = _looks_lower_is_better
+    return _core_looks_lower_is_better
+
+
 def likely_lower_is_better_metric(metric: str) -> bool:
     """Return whether a metric name is an obvious lower-is-better objective."""
 
-    if _core_looks_lower_is_better is not None:
-        return _core_looks_lower_is_better(metric)
+    core_heuristic = _resolve_core_heuristic()
+    if core_heuristic is not None:
+        return core_heuristic(metric)
     return _fallback_looks_lower_is_better(metric)
 
 
 def _fallback_looks_lower_is_better(metric: str) -> bool:
     name = metric.lower()
     tokens = re.split(r"[^a-z0-9]+", name)
-    if "neg" in tokens:
+    if ALREADY_NEGATED_METRIC_TOKEN in tokens:
         return False
     if any(hint in name for hint in LOWER_IS_BETTER_METRIC_SUBSTRINGS):
         return True

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 _UNRESOLVED = object()
 _core_looks_lower_is_better = _UNRESOLVED
+_last_core_heuristic_warning = None
 
 AUTOFL_CONFIG_SCHEMA_VERSION = "nvflare.autofl.config.v1"
 IMPORTER_VERSION = "nvflare-autofl-job-importer/v1"
@@ -1235,17 +1236,20 @@ def _resolve_stop_condition_mode(
 def _resolve_core_heuristic():
     """Load and cache the core heuristic, retrying after transient import failures."""
 
-    global _core_looks_lower_is_better
+    global _core_looks_lower_is_better, _last_core_heuristic_warning
 
     if _core_looks_lower_is_better is _UNRESOLVED:
         try:
             from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better
         except Exception as e:
-            logger.warning(
-                "Unable to load the NVFlare core metric heuristic (%s); using the local fallback and retrying "
-                "on the next check",
-                type(e).__name__,
-            )
+            warning = (type(e).__name__, str(e))
+            if warning != _last_core_heuristic_warning:
+                logger.warning(
+                    "Unable to load the NVFlare core metric heuristic (%s: %s); using the local fallback and "
+                    "retrying on the next check",
+                    *warning,
+                )
+                _last_core_heuristic_warning = warning
             return None
         else:
             _core_looks_lower_is_better = _looks_lower_is_better

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -39,6 +40,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 _UNRESOLVED = object()
 _core_looks_lower_is_better = _UNRESOLVED
@@ -1230,13 +1233,20 @@ def _resolve_stop_condition_mode(
 
 
 def _resolve_core_heuristic():
+    """Load and cache the core heuristic, retrying after transient import failures."""
+
     global _core_looks_lower_is_better
 
     if _core_looks_lower_is_better is _UNRESOLVED:
         try:
             from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better
-        except Exception:  # Core initialization failures must preserve the standalone fallback.
-            _core_looks_lower_is_better = None
+        except Exception as e:
+            logger.warning(
+                "Unable to load the NVFlare core metric heuristic (%s); using the local fallback and retrying "
+                "on the next check",
+                type(e).__name__,
+            )
+            return None
         else:
             _core_looks_lower_is_better = _looks_lower_is_better
     return _core_looks_lower_is_better

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -50,6 +50,14 @@ dump_autofl_yaml = job_importer.dump_autofl_yaml
 import_job_to_autofl_config = job_importer.import_job_to_autofl_config
 
 
+def test_load_importer_removes_temporary_runner_module(monkeypatch):
+    monkeypatch.delitem(sys.modules, IMPORTER_MODULE_NAME, raising=False)
+
+    _load_importer()
+
+    assert IMPORTER_MODULE_NAME not in sys.modules
+
+
 def test_load_importer_restores_cached_runner_module(monkeypatch):
     cached_module = object()
     monkeypatch.setitem(sys.modules, IMPORTER_MODULE_NAME, cached_module)
@@ -1280,6 +1288,13 @@ def test_core_lower_is_better_metric_heuristic_is_resolved_and_cached(monkeypatc
     assert calls == ["val_loss", "val_loss"]
 
 
+@pytest.mark.parametrize("metric", ["dice", "neg_loss"])
+def test_lower_is_better_dispatcher_uses_fallback_for_false_metrics(monkeypatch, metric):
+    monkeypatch.setattr(job_importer, "_core_looks_lower_is_better", None)
+
+    assert job_importer.likely_lower_is_better_metric(metric) is False
+
+
 def test_fallback_lower_is_better_metric_hints_match_nvflare_core():
     assert set(job_importer.LOWER_IS_BETTER_METRIC_SUBSTRINGS) == set(ims._LOWER_IS_BETTER_SUBSTRING_HINTS)
     assert job_importer.LOWER_IS_BETTER_METRIC_TOKENS == ims._LOWER_IS_BETTER_TOKEN_HINTS
@@ -1304,10 +1319,13 @@ def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(
     config = isolated_importer.import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
 
     assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
+    assert caplog.records == []
     with caplog.at_level("WARNING", logger=isolated_importer.__name__):
         assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
+        assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
     assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
-    assert import_error.__name__ in caplog.text
+    assert len(caplog.records) == 1
+    assert f"{import_error.__name__}: NVFlare is unavailable in the agent environment" in caplog.text
     assert "retrying on the next check" in caplog.text
     assert config["import"]["support"]["status"] == "supported"
 
@@ -1338,8 +1356,12 @@ def test_core_heuristic_resolution_retries_after_transient_import_failure(monkey
     assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
     assert isolated_importer.likely_lower_is_better_metric("val_loss") is False
     assert isolated_importer._core_looks_lower_is_better is core_heuristic
+    assert len(caplog.records) == 1
+    assert "RuntimeError: transient NVFlare initialization failure" in caplog.text
+    assert isolated_importer.likely_lower_is_better_metric("val_loss") is False
     assert import_attempts == 2
-    assert core_calls == ["val_loss"]
+    assert len(caplog.records) == 1
+    assert core_calls == ["val_loss", "val_loss"]
 
 
 def test_train_script_outside_workspace_is_not_admitted_to_trust_contract(tmp_path):

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -22,14 +22,24 @@ import yaml
 
 from nvflare.app_common.widgets import intime_model_selector as ims
 
+IMPORTER_MODULE_NAME = "nvflare_autofl_skill_job_importer"
+_MISSING_MODULE = object()
+
 
 def _load_importer():
     repo_root = Path(__file__).parents[3]
     importer_path = repo_root / "skills" / "nvflare-autofl" / "scripts" / "job_importer.py"
-    spec = importlib.util.spec_from_file_location("nvflare_autofl_skill_job_importer", importer_path)
+    spec = importlib.util.spec_from_file_location(IMPORTER_MODULE_NAME, importer_path)
     module = importlib.util.module_from_spec(spec)
+    previous_module = sys.modules.get(spec.name, _MISSING_MODULE)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_module is _MISSING_MODULE:
+            sys.modules.pop(spec.name, None)
+        else:
+            sys.modules[spec.name] = previous_module
     return module
 
 
@@ -38,6 +48,37 @@ AUTOFL_CONFIG_SCHEMA_VERSION = job_importer.AUTOFL_CONFIG_SCHEMA_VERSION
 DeterministicJobImporter = job_importer.DeterministicJobImporter
 dump_autofl_yaml = job_importer.dump_autofl_yaml
 import_job_to_autofl_config = job_importer.import_job_to_autofl_config
+
+
+def test_load_importer_restores_cached_runner_module(monkeypatch):
+    cached_module = object()
+    monkeypatch.setitem(sys.modules, IMPORTER_MODULE_NAME, cached_module)
+
+    loaded_importer = _load_importer()
+
+    assert loaded_importer is not cached_module
+    assert sys.modules[IMPORTER_MODULE_NAME] is cached_module
+
+
+def test_load_importer_restores_cached_runner_module_when_execution_fails(monkeypatch):
+    cached_module = object()
+    original_spec_from_file_location = importlib.util.spec_from_file_location
+
+    def failing_spec_from_file_location(*args, **kwargs):
+        spec = original_spec_from_file_location(*args, **kwargs)
+
+        def fail_execution(_module):
+            raise RuntimeError("importer execution failed")
+
+        spec.loader.exec_module = fail_execution
+        return spec
+
+    monkeypatch.setitem(sys.modules, IMPORTER_MODULE_NAME, cached_module)
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", failing_spec_from_file_location)
+
+    with pytest.raises(RuntimeError, match="importer execution failed"):
+        _load_importer()
+    assert sys.modules[IMPORTER_MODULE_NAME] is cached_module
 
 
 def _objective(
@@ -1197,10 +1238,46 @@ def main():
         "energy",
     ],
 )
-def test_lower_is_better_metric_heuristic_matches_nvflare_core(metric, monkeypatch):
-    assert job_importer.likely_lower_is_better_metric(metric) is ims._looks_lower_is_better(metric)
-    monkeypatch.setattr(job_importer, "_core_looks_lower_is_better", None)
-    assert job_importer.likely_lower_is_better_metric(metric) is ims._looks_lower_is_better(metric)
+def test_lower_is_better_metric_heuristic_matches_nvflare_core(metric):
+    assert job_importer._fallback_looks_lower_is_better(metric) is ims._looks_lower_is_better(metric)
+
+
+def test_lower_is_better_metric_fallback_matches_core_across_token_boundaries():
+    metrics = {"mse2", "2mse", "neg_mse2", "negative_mse2"}
+    for token in ims._LOWER_IS_BETTER_TOKEN_HINTS:
+        metrics.update(
+            {
+                token,
+                f"val_{token}",
+                f"val-{token}",
+                f"{token}.score",
+                f"{token}2",
+                f"2{token}",
+                f"{token}_2",
+                f"2_{token}",
+                f"neg_{token}",
+                f"negative_{token}",
+            }
+        )
+
+    for metric in metrics:
+        assert job_importer._fallback_looks_lower_is_better(metric) is ims._looks_lower_is_better(metric), metric
+
+
+def test_core_lower_is_better_metric_heuristic_is_resolved_and_cached(monkeypatch):
+    calls = []
+
+    def core_heuristic(metric):
+        calls.append(metric)
+        return False
+
+    monkeypatch.setattr(ims, "_looks_lower_is_better", core_heuristic)
+    monkeypatch.setattr(job_importer, "_core_looks_lower_is_better", job_importer._UNRESOLVED)
+
+    assert job_importer.likely_lower_is_better_metric("val_loss") is False
+    assert job_importer._core_looks_lower_is_better is core_heuristic
+    assert job_importer.likely_lower_is_better_metric("val_loss") is False
+    assert calls == ["val_loss", "val_loss"]
 
 
 def test_fallback_lower_is_better_metric_hints_match_nvflare_core():
@@ -1210,7 +1287,9 @@ def test_fallback_lower_is_better_metric_hints_match_nvflare_core():
 
 
 @pytest.mark.parametrize("import_error", [ImportError, RuntimeError])
-def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(tmp_path, monkeypatch, import_error):
+def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(
+    tmp_path, monkeypatch, caplog, import_error
+):
     original_import = builtins.__import__
 
     def isolated_import(name, globals=None, locals=None, fromlist=(), level=0):
@@ -1225,9 +1304,42 @@ def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(tmp
     config = isolated_importer.import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
 
     assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
-    assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
-    assert isolated_importer._core_looks_lower_is_better is None
+    with caplog.at_level("WARNING", logger=isolated_importer.__name__):
+        assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
+    assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
+    assert import_error.__name__ in caplog.text
+    assert "retrying on the next check" in caplog.text
     assert config["import"]["support"]["status"] == "supported"
+
+
+def test_core_heuristic_resolution_retries_after_transient_import_failure(monkeypatch, caplog):
+    original_import = builtins.__import__
+    import_attempts = 0
+    core_calls = []
+
+    def core_heuristic(metric):
+        core_calls.append(metric)
+        return False
+
+    def flaky_import(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal import_attempts
+        if name == "nvflare.app_common.widgets.intime_model_selector":
+            import_attempts += 1
+            if import_attempts == 1:
+                raise RuntimeError("transient NVFlare initialization failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(ims, "_looks_lower_is_better", core_heuristic)
+    monkeypatch.setattr(builtins, "__import__", flaky_import)
+    isolated_importer = _load_importer()
+
+    with caplog.at_level("WARNING", logger=isolated_importer.__name__):
+        assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
+    assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
+    assert isolated_importer.likely_lower_is_better_metric("val_loss") is False
+    assert isolated_importer._core_looks_lower_is_better is core_heuristic
+    assert import_attempts == 2
+    assert core_calls == ["val_loss"]
 
 
 def test_train_script_outside_workspace_is_not_admitted_to_trust_contract(tmp_path):

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from nvflare.app_common.widgets.intime_model_selector import _looks_lower_is_better
+from nvflare.app_common.widgets import intime_model_selector as ims
 
 
 def _load_importer():
@@ -1198,17 +1198,24 @@ def main():
     ],
 )
 def test_lower_is_better_metric_heuristic_matches_nvflare_core(metric, monkeypatch):
-    assert job_importer.likely_lower_is_better_metric(metric) is _looks_lower_is_better(metric)
+    assert job_importer.likely_lower_is_better_metric(metric) is ims._looks_lower_is_better(metric)
     monkeypatch.setattr(job_importer, "_core_looks_lower_is_better", None)
-    assert job_importer.likely_lower_is_better_metric(metric) is _looks_lower_is_better(metric)
+    assert job_importer.likely_lower_is_better_metric(metric) is ims._looks_lower_is_better(metric)
 
 
-def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(tmp_path, monkeypatch):
+def test_fallback_lower_is_better_metric_hints_match_nvflare_core():
+    assert set(job_importer.LOWER_IS_BETTER_METRIC_SUBSTRINGS) == set(ims._LOWER_IS_BETTER_SUBSTRING_HINTS)
+    assert job_importer.LOWER_IS_BETTER_METRIC_TOKENS == ims._LOWER_IS_BETTER_TOKEN_HINTS
+    assert job_importer.ALREADY_NEGATED_METRIC_TOKEN == ims._ALREADY_NEGATED_TOKEN
+
+
+@pytest.mark.parametrize("import_error", [ImportError, RuntimeError])
+def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(tmp_path, monkeypatch, import_error):
     original_import = builtins.__import__
 
     def isolated_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "nvflare.app_common.widgets.intime_model_selector":
-            raise ImportError("NVFlare is unavailable in the agent environment")
+            raise import_error("NVFlare is unavailable in the agent environment")
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", isolated_import)
@@ -1217,6 +1224,8 @@ def test_importer_loads_and_imports_job_without_nvflare_in_agent_environment(tmp
 
     config = isolated_importer.import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
 
+    assert isolated_importer._core_looks_lower_is_better is isolated_importer._UNRESOLVED
+    assert isolated_importer.likely_lower_is_better_metric("val_loss") is True
     assert isolated_importer._core_looks_lower_is_better is None
     assert config["import"]["support"]["status"] == "supported"
 


### PR DESCRIPTION
## Summary

- resolve NVFlare's lower-is-better metric helper only when the importer needs metric-direction inference
- cache successful core resolution while falling back and retrying after failed imports
- log the exception detail once per distinct resolution failure instead of repeating an identical warning on every metric check
- preserve or remove the temporary runner module entry correctly while isolated tests load fresh importer instances
- make core dispatch, lazy resolution, retry caching, warning behavior, and fallback parity independently falsifiable

## Why

The Auto-FL runner loads `job_importer.py` on multiple lifecycle paths—including initialization and job CLI inspection—even when metric-direction inference is not needed. Its former module-level NVFlare import pulled in the core package whenever the importer was loaded, adding avoidable startup work and making the standalone importer vulnerable to unrelated transitive import failures.

Keeping resolution lazy preserves the importer's standalone behavior while returning identical heuristic results when NVFlare is available. A transient core initialization failure no longer pins the process permanently to the fallback. When core resolution is unavailable, the importer retains standalone behavior, reports the concrete failure without log spam from repeated checks, and retries later.

## Validation

- `pytest tests/unit_test/tool/autofl_skill_job_importer_test.py -q` — 78 passed
- importer followed by runner suite under Python 3.12 — 287 passed, 2 skipped
- reviewed `[^a-z0-9]+` → `[^a-z]+` mutant diverges on `mse2`, covered by the boundary corpus
- regression assertions cover false fallback results, eager resolution, successful-resolution caching, temporary `sys.modules` cleanup, and warning count
- fresh-process importer probe loaded 0 NVFlare modules
- `./runtest.sh --skip-install -s` — Black, isort, flake8, and agent-skill lint passed on the rebased head
- deterministic `skillevaluator quality-check skills/nvflare-autofl -r cli` — 98.2/100 (A), passed
- `git diff --check` passed

## Design notes

- Runtime delegation to the installed core heuristic is deliberate: with NVFlare present in the driver environment, the direction check should predict the judgment of the core that will actually run, including under version skew. The vendored fallback serves NVFlare-absent agent environments and is pinned to core by the parity and token-boundary tests.
- The resolution-failure warning fires for plain NVFlare absence as well; this is intentional observability that the direction check ran on the standalone fallback. Consecutive identical failures are deduplicated, so each distinct failure surfaces once per process.

## Follow-ups

- Extract the hardened `sys.modules` snapshot/restore loader into `tests/unit_test/tool/conftest.py` and reuse it for the sibling skill-script test loaders.
- Refresh the skill signature (`skill.oms.sig`) on this branch before merge; the pinned digest for `scripts/job_importer.py` predates these changes.
