### PR TITLE
[Auto-FL] Fail closed on splatted job kwargs

### DIFF
--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -136,7 +136,9 @@ Compatibility and Migration Notes
   metric, direction, or fixed training budget. Rewrite the call with
   keyword-only arguments, no splats, and the constructor's applicable
   safety-critical keywords spelled out before initializing. ``SimEnv`` calls
-  must expose ``num_clients`` explicitly when using a keyword splat. A declared
+  pin a positive explicit ``num_clients``; when it is zero or omitted, they
+  must expose a non-empty static ``clients`` list whose length is pinned.
+  Dynamic or splatted client-count sources fail closed. A declared
   alternate-metric bridge cannot override an unresolved native job metric.
 - In external-process Client API mode, losing a trainer after its lazy result
   envelope has been accepted now fails the run as ``EXECUTION_EXCEPTION`` even

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -131,7 +131,10 @@ Compatibility and Migration Notes
   ``key_metric`` with ``key_metric_mode``, or declare the alternate metric
   bridge, before initializing a campaign. Experimental legacy minimization
   campaigns without direction provenance must be re-initialized in a fresh
-  workspace.
+  workspace. Job constructor calls that pass ``**kwargs`` now also fail closed
+  when the splat could hide ``key_metric``, ``key_metric_mode``,
+  ``model_selector``, or ``stop_cond``; spell out the safety-critical keywords
+  in the call before initializing.
 - In external-process Client API mode, losing a trainer after its lazy result
   envelope has been accepted now fails the run as ``EXECUTION_EXCEPTION`` even
   if a controller's ``min_responses`` threshold could otherwise tolerate a

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -131,10 +131,13 @@ Compatibility and Migration Notes
   ``key_metric`` with ``key_metric_mode``, or declare the alternate metric
   bridge, before initializing a campaign. Experimental legacy minimization
   campaigns without direction provenance must be re-initialized in a fresh
-  workspace. Job constructor calls that pass ``**kwargs`` now also fail closed
-  when the splat could hide ``key_metric``, ``key_metric_mode``,
-  ``model_selector``, or ``stop_cond``; spell out the safety-critical keywords
-  in the call before initializing.
+  workspace. Job constructor calls that pass positional arguments, ``*args``,
+  or ``**kwargs`` now also fail closed when dynamic arguments could hide the
+  metric, direction, or fixed training budget. Rewrite the call with
+  keyword-only arguments, no splats, and the constructor's applicable
+  safety-critical keywords spelled out before initializing. ``SimEnv`` calls
+  must expose ``num_clients`` explicitly when using a keyword splat. A declared
+  alternate-metric bridge cannot override an unresolved native job metric.
 - In external-process Client API mode, losing a trainer after its lazy result
   envelope has been accepted now fails the run as ``EXECUTION_EXCEPTION`` even
   if a controller's ``min_responses`` threshold could otherwise tolerate a

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -26,6 +26,13 @@ importer preserves that native direction separately as `job_key_metric_mode`
 so candidate validation can detect changes hidden by an alternate metric
 bridge. A custom `model_selector` makes direction unresolved because it
 supersedes `key_metric_mode` and its behavior cannot be imported statically.
+A job constructor that passes `**kwargs` also leaves `key_metric` unresolved
+unless that keyword is explicit in the call. Its direction remains unresolved
+unless `key_metric_mode`, `model_selector`, and `stop_cond` are all explicit,
+because any omitted value may be supplied by the splat. Rewrite the call to
+spell out these safety-critical keywords before initializing. A mutation-schema
+bridge may declare the direction of a differing requested metric, but the job
+key metric's own direction can only be declared explicitly in `job.py`.
 
 For a new campaign, import and admission complete in memory before the runner
 creates campaign files or acquires the workspace lock. An obvious

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -32,8 +32,10 @@ fixed training budget. A keyword splat leaves direction and budget unresolved
 even when some safety-critical keywords are also explicit, because the accepted
 direction controls differ between constructors. Rewrite the call with
 keyword-only arguments, no splats, and the applicable `key_metric`, direction,
-and budget keywords written directly before initializing. A `SimEnv` keyword
-splat must expose `num_clients` explicitly; positional `SimEnv` arguments are
+and budget keywords written directly before initializing. A `SimEnv` call pins
+a positive explicit `num_clients`; when `num_clients` is zero or omitted, the
+importer requires a non-empty static `clients` list and pins its length. A
+dynamic or splatted client-count source and positional `SimEnv` arguments are
 unresolved. A mutation-schema
 bridge may declare the direction of a differing requested metric, but it cannot
 resolve the job key metric's own identity or direction.

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -26,13 +26,17 @@ importer preserves that native direction separately as `job_key_metric_mode`
 so candidate validation can detect changes hidden by an alternate metric
 bridge. A custom `model_selector` makes direction unresolved because it
 supersedes `key_metric_mode` and its behavior cannot be imported statically.
-A job constructor that passes `**kwargs` also leaves `key_metric` unresolved
-unless that keyword is explicit in the call. Its direction remains unresolved
-unless `key_metric_mode`, `model_selector`, and `stop_cond` are all explicit,
-because any omitted value may be supplied by the splat. Rewrite the call to
-spell out these safety-critical keywords before initializing. A mutation-schema
-bridge may declare the direction of a differing requested metric, but the job
-key metric's own direction can only be declared explicitly in `job.py`.
+Supported job constructors must use keyword-only arguments and must not pass
+`*args` or `**kwargs`. Positional arguments can hide the metric, direction, and
+fixed training budget. A keyword splat leaves direction and budget unresolved
+even when some safety-critical keywords are also explicit, because the accepted
+direction controls differ between constructors. Rewrite the call with
+keyword-only arguments, no splats, and the applicable `key_metric`, direction,
+and budget keywords written directly before initializing. A `SimEnv` keyword
+splat must expose `num_clients` explicitly; positional `SimEnv` arguments are
+unresolved. A mutation-schema
+bridge may declare the direction of a differing requested metric, but it cannot
+resolve the job key metric's own identity or direction.
 
 For a new campaign, import and admission complete in memory before the runner
 creates campaign files or acquires the workspace lock. An obvious

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -135,6 +135,8 @@ class CallInfo:
     function_name: Optional[str] = None
     branch_conditions: Tuple[Tuple[ast.AST, bool], ...] = ()
     has_keyword_splat: bool = False
+    has_positional_args: bool = False
+    has_positional_splat: bool = False
 
 
 class JobImportError(ValueError):
@@ -411,6 +413,18 @@ class DeterministicJobImporter:
         parser_args: Dict[str, ArgSpec],
         source_text: str,
     ) -> Tuple[str, str, Optional[Dict[str, str]]]:
+        if job_call and job_call.has_positional_args:
+            return (
+                "accuracy",
+                "default",
+                _unresolved(
+                    "objective.metric",
+                    _positional_call_reason(
+                        job_call,
+                        "key_metric may be supplied positionally; use keyword-only constructor arguments",
+                    ),
+                ),
+            )
         if job_call and job_call.has_keyword_splat and "key_metric" not in job_call.keywords:
             return (
                 "accuracy",
@@ -444,15 +458,27 @@ class DeterministicJobImporter:
         if not job_call:
             return "max", "unresolved", _unresolved("objective.mode", "job metric direction is unknown")
 
-        direction_keywords = {"key_metric_mode", "model_selector", "stop_cond"}
-        if job_call.has_keyword_splat and not direction_keywords.issubset(job_call.keywords):
+        if job_call.has_positional_args:
             return (
                 "max",
                 "unresolved",
                 _unresolved(
                     "objective.mode",
-                    "job call passes **kwargs; key_metric_mode, model_selector, or stop_cond may be supplied "
-                    "dynamically; write all three direction-relevant keywords explicitly in the job call",
+                    _positional_call_reason(
+                        job_call,
+                        "direction-relevant values may be supplied positionally; use keyword-only constructor arguments",
+                    ),
+                ),
+            )
+
+        if job_call.has_keyword_splat:
+            return (
+                "max",
+                "unresolved",
+                _unresolved(
+                    "objective.mode",
+                    "job call passes **kwargs; direction-relevant values may be supplied dynamically; "
+                    "remove **kwargs and write the applicable direction keyword explicitly in the job call",
                 ),
             )
 
@@ -537,12 +563,53 @@ class DeterministicJobImporter:
                 else:
                     fixed_training_budget["num_clients"] = resolved.value
 
-        if env_call and env_call.name == "SimEnv" and "num_clients" in env_call.keywords:
-            resolved = _resolve_value(env_call.keywords["num_clients"], env_call.assignments, parser_args, source_text)
-            if resolved.unresolved:
-                unresolved.append(_unresolved("budget.fixed_training_budget.num_clients", resolved.source))
-            else:
-                fixed_training_budget["num_clients"] = resolved.value
+            if job_call.has_positional_args:
+                unresolved.append(
+                    _unresolved(
+                        "budget.fixed_training_budget",
+                        _positional_call_reason(
+                            job_call,
+                            "fixed training budget values may be supplied positionally; "
+                            "use keyword-only constructor arguments",
+                        ),
+                    )
+                )
+            if job_call.has_keyword_splat:
+                unresolved.append(
+                    _unresolved(
+                        "budget.fixed_training_budget",
+                        "job call passes **kwargs; fixed training budget values may be supplied dynamically; "
+                        "remove **kwargs and write the applicable budget keywords explicitly in the job call",
+                    )
+                )
+
+        if env_call and env_call.name == "SimEnv":
+            if "num_clients" in env_call.keywords:
+                resolved = _resolve_value(
+                    env_call.keywords["num_clients"], env_call.assignments, parser_args, source_text
+                )
+                if resolved.unresolved:
+                    unresolved.append(_unresolved("budget.fixed_training_budget.num_clients", resolved.source))
+                else:
+                    fixed_training_budget["num_clients"] = resolved.value
+            elif env_call.has_keyword_splat:
+                unresolved.append(
+                    _unresolved(
+                        "budget.fixed_training_budget.num_clients",
+                        "SimEnv call passes **kwargs; num_clients may be supplied dynamically; "
+                        "write num_clients explicitly in the SimEnv call",
+                    )
+                )
+            if env_call.has_positional_args:
+                unresolved.append(
+                    _unresolved(
+                        "budget.fixed_training_budget.num_clients",
+                        _positional_call_reason(
+                            env_call,
+                            "num_clients may be supplied positionally; use keyword-only SimEnv arguments",
+                        ),
+                    )
+                )
 
         if fixed_training_budget:
             budget["fixed_training_budget"] = fixed_training_budget
@@ -807,6 +874,8 @@ class _ImportIndex(ast.NodeVisitor):
                 function_name=self._function_stack[-1] if self._function_stack else None,
                 branch_conditions=tuple(self._branch_conditions),
                 has_keyword_splat=any(keyword.arg is None for keyword in node.keywords),
+                has_positional_args=bool(node.args),
+                has_positional_splat=any(isinstance(arg, ast.Starred) for arg in node.args),
             )
             if is_environment:
                 self.env_calls.append(call_info)
@@ -1479,3 +1548,8 @@ def _overall_confidence(unresolved: List[Dict[str, str]], job_call: Optional[Cal
 
 def _unresolved(field: str, reason: str) -> Dict[str, str]:
     return {"field": field, "reason": reason}
+
+
+def _positional_call_reason(call_info: CallInfo, detail: str) -> str:
+    argument_kind = "*args" if call_info.has_positional_splat else "positional arguments"
+    return f"{call_info.name} call passes {argument_kind}; {detail}"

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -584,29 +584,18 @@ class DeterministicJobImporter:
                 )
 
         if env_call and env_call.name == "SimEnv":
-            if "num_clients" in env_call.keywords:
-                resolved = _resolve_value(
-                    env_call.keywords["num_clients"], env_call.assignments, parser_args, source_text
-                )
-                if resolved.unresolved:
-                    unresolved.append(_unresolved("budget.fixed_training_budget.num_clients", resolved.source))
-                else:
-                    fixed_training_budget["num_clients"] = resolved.value
-            elif env_call.has_keyword_splat:
-                unresolved.append(
-                    _unresolved(
-                        "budget.fixed_training_budget.num_clients",
-                        "SimEnv call passes **kwargs; num_clients may be supplied dynamically; "
-                        "write num_clients explicitly in the SimEnv call",
-                    )
-                )
+            resolved = _resolve_sim_env_num_clients(env_call, parser_args, source_text)
+            if resolved.unresolved:
+                unresolved.append(_unresolved("budget.fixed_training_budget.num_clients", resolved.source))
+            else:
+                fixed_training_budget["num_clients"] = resolved.value
             if env_call.has_positional_args:
                 unresolved.append(
                     _unresolved(
                         "budget.fixed_training_budget.num_clients",
                         _positional_call_reason(
                             env_call,
-                            "num_clients may be supplied positionally; use keyword-only SimEnv arguments",
+                            "the client count may be supplied positionally; use keyword-only SimEnv arguments",
                         ),
                     )
                 )
@@ -628,12 +617,9 @@ class DeterministicJobImporter:
         environment: Dict[str, Any] = {"requested": requested, "profiles": {}, "simulator_env_passthrough": []}
         if env_call and env_call.name == "SimEnv":
             sim_profile: Dict[str, Any] = {}
-            if "num_clients" in env_call.keywords:
-                resolved = _resolve_value(
-                    env_call.keywords["num_clients"], env_call.assignments, parser_args, source_text
-                )
-                if not resolved.unresolved:
-                    sim_profile["num_clients"] = resolved.value
+            resolved = _resolve_sim_env_num_clients(env_call, parser_args, source_text)
+            if not resolved.unresolved:
+                sim_profile["num_clients"] = resolved.value
             environment["profiles"]["sim"] = sim_profile
         return environment
 
@@ -1282,6 +1268,48 @@ def _resolve_value(
             )
 
     return ResolvedValue(_source_segment(source_text, node) or type(node).__name__, "expression", "low", True)
+
+
+def _resolve_sim_env_num_clients(
+    env_call: CallInfo,
+    parser_args: Dict[str, ArgSpec],
+    source_text: str,
+) -> ResolvedValue:
+    """Resolve the effective client count using ``SimEnv`` runtime semantics."""
+
+    num_clients_node = env_call.keywords.get("num_clients")
+    if num_clients_node is not None:
+        num_clients = _resolve_value(num_clients_node, env_call.assignments, parser_args, source_text)
+        if num_clients.unresolved:
+            return ResolvedValue(None, f"num_clients is dynamic: {num_clients.source}", "low", True)
+        if isinstance(num_clients.value, bool) or not isinstance(num_clients.value, int):
+            return ResolvedValue(None, "num_clients must resolve to an integer", "low", True)
+        if num_clients.value > 0:
+            return num_clients
+
+    clients_node = env_call.keywords.get("clients")
+    if clients_node is not None:
+        clients = _resolve_value(clients_node, env_call.assignments, parser_args, source_text)
+        if clients.unresolved:
+            return ResolvedValue(None, f"clients is dynamic: {clients.source}", "low", True)
+        if not isinstance(clients.value, list) or not clients.value:
+            return ResolvedValue(None, "clients must resolve to a non-empty static list", "low", True)
+        return ResolvedValue(len(clients.value), f"len(clients):{clients.source}")
+
+    if env_call.has_keyword_splat:
+        return ResolvedValue(
+            None,
+            "SimEnv call passes **kwargs; num_clients or clients may be supplied dynamically; "
+            "write a positive num_clients or a non-empty static clients list explicitly in the SimEnv call",
+            "low",
+            True,
+        )
+    return ResolvedValue(
+        None,
+        "SimEnv client count is unresolved; write a positive num_clients or a non-empty static clients list",
+        "low",
+        True,
+    )
 
 
 def _resolve_arg_default(name: str, arg_spec: ArgSpec) -> ResolvedValue:

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -134,6 +134,7 @@ class CallInfo:
     source: str
     function_name: Optional[str] = None
     branch_conditions: Tuple[Tuple[ast.AST, bool], ...] = ()
+    has_keyword_splat: bool = False
 
 
 class JobImportError(ValueError):
@@ -410,6 +411,16 @@ class DeterministicJobImporter:
         parser_args: Dict[str, ArgSpec],
         source_text: str,
     ) -> Tuple[str, str, Optional[Dict[str, str]]]:
+        if job_call and job_call.has_keyword_splat and "key_metric" not in job_call.keywords:
+            return (
+                "accuracy",
+                "default",
+                _unresolved(
+                    "objective.metric",
+                    "job call passes **kwargs; key_metric may be supplied dynamically; "
+                    "write key_metric explicitly in the job call",
+                ),
+            )
         if job_call and "key_metric" in job_call.keywords:
             resolved = _resolve_value(job_call.keywords["key_metric"], job_call.assignments, parser_args, source_text)
             if isinstance(resolved.value, str) and not resolved.unresolved:
@@ -432,6 +443,18 @@ class DeterministicJobImporter:
     ) -> Tuple[str, str, Optional[Dict[str, str]]]:
         if not job_call:
             return "max", "unresolved", _unresolved("objective.mode", "job metric direction is unknown")
+
+        direction_keywords = {"key_metric_mode", "model_selector", "stop_cond"}
+        if job_call.has_keyword_splat and not direction_keywords.issubset(job_call.keywords):
+            return (
+                "max",
+                "unresolved",
+                _unresolved(
+                    "objective.mode",
+                    "job call passes **kwargs; key_metric_mode, model_selector, or stop_cond may be supplied "
+                    "dynamically; write all three direction-relevant keywords explicitly in the job call",
+                ),
+            )
 
         model_selector = job_call.keywords.get("model_selector")
         if model_selector is not None:
@@ -783,6 +806,7 @@ class _ImportIndex(ast.NodeVisitor):
                 source=_source_segment(self.source_text, node),
                 function_name=self._function_stack[-1] if self._function_stack else None,
                 branch_conditions=tuple(self._branch_conditions),
+                has_keyword_splat=any(keyword.arg is None for keyword in node.keywords),
             )
             if is_environment:
                 self.env_calls.append(call_info)

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -124,13 +124,21 @@ class ResolvedValue:
 
 
 @dataclass(frozen=True)
+class AssignmentInfo:
+    """Assignment value with the branch conditions required to reach it."""
+
+    value: ast.AST
+    branch_conditions: Tuple[Tuple[ast.AST, bool], ...] = ()
+
+
+@dataclass(frozen=True)
 class CallInfo:
     """Supported call found in ``job.py`` with source-local resolution context."""
 
     name: str
     full_name: str
     keywords: Dict[str, ast.AST]
-    assignments: Dict[str, ast.AST]
+    assignments: Dict[str, Tuple[AssignmentInfo, ...]]
     source: str
     function_name: Optional[str] = None
     branch_conditions: Tuple[Tuple[ast.AST, bool], ...] = ()
@@ -217,7 +225,7 @@ class DeterministicJobImporter:
 
         parser_args, reachable_functions = _reachable_parser_args(tree, index, job_args or [])
         job_call = index.first_job_call(reachable_functions, parser_args)
-        env_call = index.first_env_call(reachable_functions)
+        env_call = index.first_env_call(reachable_functions, parser_args)
         train_script = self._resolve_train_script(
             source_path, job_call, index, parser_args, source_text, reachable_functions
         )
@@ -739,8 +747,8 @@ class _ImportIndex(ast.NodeVisitor):
         self.source_text = source_text
         self.imports: Dict[str, str] = {}
         self.parser_arg_definitions: Dict[str, List[ArgSpec]] = {}
-        self.module_assignments: Dict[str, ast.AST] = {}
-        self._local_assignments_stack: List[Dict[str, ast.AST]] = []
+        self.module_assignments: Dict[str, List[AssignmentInfo]] = {}
+        self._local_assignments_stack: List[Dict[str, List[AssignmentInfo]]] = []
         self._function_stack: List[str] = []
         self._branch_conditions: List[Tuple[ast.AST, bool]] = []
         self._argparse_parser_names: Set[Tuple[Optional[str], str]] = set()
@@ -763,8 +771,12 @@ class _ImportIndex(ast.NodeVisitor):
     ) -> Optional[CallInfo]:
         return _first_reachable_call(self.job_calls, reachable_functions, parser_args)
 
-    def first_env_call(self, reachable_functions: Optional[Set[str]] = None) -> Optional[CallInfo]:
-        return _first_reachable_call(self.env_calls, reachable_functions)
+    def first_env_call(
+        self,
+        reachable_functions: Optional[Set[str]] = None,
+        parser_args: Optional[Dict[str, ArgSpec]] = None,
+    ) -> Optional[CallInfo]:
+        return _first_reachable_call(self.env_calls, reachable_functions, parser_args)
 
     def first_unsupported_job_call(self) -> Optional[CallInfo]:
         return self.unsupported_job_calls[0] if self.unsupported_job_calls else None
@@ -808,13 +820,13 @@ class _ImportIndex(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> None:
         for target in node.targets:
             if isinstance(target, ast.Name):
-                self._current_assignments()[target.id] = node.value
+                self._record_assignment(target.id, node.value)
                 self._track_argparse_assignment(target.id, node.value)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if isinstance(node.target, ast.Name) and node.value:
-            self._current_assignments()[node.target.id] = node.value
+            self._record_assignment(node.target.id, node.value)
             self._track_argparse_assignment(node.target.id, node.value)
         self.generic_visit(node)
 
@@ -823,7 +835,7 @@ class _ImportIndex(ast.NodeVisitor):
             # The result depends on runtime state. Preserve the expression so
             # downstream resolution marks the value as unresolved instead of
             # reusing an earlier static assignment.
-            self._current_assignments()[node.target.id] = node
+            self._record_assignment(node.target.id, node)
         self.generic_visit(node)
 
     def visit_If(self, node: ast.If) -> None:
@@ -904,15 +916,19 @@ class _ImportIndex(ast.NodeVisitor):
             return call_name
         return f"{imported}.{remainder}" if separator else imported
 
-    def _current_assignments(self) -> Dict[str, ast.AST]:
+    def _current_assignments(self) -> Dict[str, List[AssignmentInfo]]:
         if self._local_assignments_stack:
             return self._local_assignments_stack[-1]
         return self.module_assignments
 
-    def _resolution_assignments(self) -> Dict[str, ast.AST]:
-        assignments = dict(self.module_assignments)
+    def _record_assignment(self, name: str, value: ast.AST) -> None:
+        assignment = AssignmentInfo(value=value, branch_conditions=tuple(self._branch_conditions))
+        self._current_assignments().setdefault(name, []).append(assignment)
+
+    def _resolution_assignments(self) -> Dict[str, Tuple[AssignmentInfo, ...]]:
+        assignments = {name: tuple(history) for name, history in self.module_assignments.items()}
         if self._local_assignments_stack:
-            assignments.update(self._local_assignments_stack[-1])
+            assignments.update({name: tuple(history) for name, history in self._local_assignments_stack[-1].items()})
         return assignments
 
 
@@ -934,11 +950,20 @@ def _first_reachable_call(
 
 
 def _matches_static_branch_conditions(call: CallInfo, arg_values: Dict[str, Any]) -> bool:
-    for condition, expected in call.branch_conditions:
+    return _static_branch_conditions_match(call.branch_conditions, arg_values) is not False
+
+
+def _static_branch_conditions_match(
+    branch_conditions: Sequence[Tuple[ast.AST, bool]], arg_values: Dict[str, Any]
+) -> Optional[bool]:
+    unknown = False
+    for condition, expected in branch_conditions:
         value = _static_condition_value(condition, arg_values)
-        if value is not None and value != expected:
+        if value is None:
+            unknown = True
+        elif value != expected:
             return False
-    return True
+    return None if unknown else True
 
 
 def _arg_spec_signature(spec: ArgSpec) -> Tuple[Any, ...]:
@@ -1119,6 +1144,9 @@ def _static_condition_value(node: ast.AST, arg_values: Dict[str, Any]) -> Option
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
         value = _static_condition_value(node.operand, arg_values)
         return None if value is None else not value
+    known, value = _static_condition_operand(node, arg_values)
+    if known:
+        return bool(value)
     return None
 
 
@@ -1223,7 +1251,7 @@ def _name_from_flags(flags: Iterable[str]) -> Optional[str]:
 
 def _resolve_value(
     node: ast.AST,
-    assignments: Dict[str, ast.AST],
+    assignments: Dict[str, Tuple[AssignmentInfo, ...]],
     parser_args: Dict[str, ArgSpec],
     source_text: str,
     seen: Optional[set[str]] = None,
@@ -1245,7 +1273,10 @@ def _resolve_value(
         if node.id in parser_args:
             return _resolve_arg_default(node.id, parser_args[node.id])
         if node.id in assignments:
-            return _resolve_value(assignments[node.id], assignments, parser_args, source_text, seen | {node.id})
+            assignment, issue = _select_assignment(node.id, assignments[node.id], parser_args)
+            if issue:
+                return ResolvedValue(None, issue, "low", True)
+            return _resolve_value(assignment, assignments, parser_args, source_text, seen | {node.id})
         return ResolvedValue(node.id, f"name:{node.id}", "low", True)
 
     if isinstance(node, ast.Call):
@@ -1268,6 +1299,22 @@ def _resolve_value(
             )
 
     return ResolvedValue(_source_segment(source_text, node) or type(node).__name__, "expression", "low", True)
+
+
+def _select_assignment(
+    name: str,
+    history: Sequence[AssignmentInfo],
+    parser_args: Dict[str, ArgSpec],
+) -> Tuple[Optional[ast.AST], Optional[str]]:
+    arg_values = {key: spec.default for key, spec in parser_args.items() if not spec.default_unresolved}
+    for assignment in reversed(history):
+        branch_match = _static_branch_conditions_match(assignment.branch_conditions, arg_values)
+        if branch_match is False:
+            continue
+        if branch_match is None:
+            return None, f"conditional assignment for {name} cannot be resolved from job arguments"
+        return assignment.value, None
+    return None, f"no reachable assignment for {name}"
 
 
 def _resolve_sim_env_num_clients(
@@ -1372,7 +1419,7 @@ def _fallback_looks_lower_is_better(metric: str) -> bool:
 def _resolve_path_call(
     node: ast.Call,
     call_name: str,
-    assignments: Dict[str, ast.AST],
+    assignments: Dict[str, Tuple[AssignmentInfo, ...]],
     parser_args: Dict[str, ArgSpec],
     source_text: str,
 ) -> Optional[ResolvedValue]:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -3238,7 +3238,9 @@ def campaign_admission_errors(config: Dict[str, Any], schema: Optional[Dict[str,
         critical_issues: Dict[str, List[str]] = {}
         for item in unresolved:
             field = item.get("field", "") if isinstance(item, dict) else ""
-            if field in {"objective.metric", "objective.mode"} or field.startswith("budget.fixed_training_budget"):
+            if field in {"objective.metric", "objective.job_key_metric", "objective.mode"} or field.startswith(
+                "budget.fixed_training_budget"
+            ):
                 reasons = critical_issues.setdefault(field, [])
                 reason = item.get("reason", "") if isinstance(item, dict) else ""
                 if reason:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -3235,13 +3235,20 @@ def campaign_admission_errors(config: Dict[str, Any], schema: Optional[Dict[str,
         errors.append("fixed comparison budget is unresolved")
     unresolved = config.get("unresolved", [])
     if isinstance(unresolved, list):
-        critical_fields = []
+        critical_issues: Dict[str, List[str]] = {}
         for item in unresolved:
             field = item.get("field", "") if isinstance(item, dict) else ""
             if field in {"objective.metric", "objective.mode"} or field.startswith("budget.fixed_training_budget"):
-                critical_fields.append(field)
-        if critical_fields:
-            errors.append(f"safety-critical fields are unresolved: {', '.join(sorted(set(critical_fields)))}")
+                reasons = critical_issues.setdefault(field, [])
+                reason = item.get("reason", "") if isinstance(item, dict) else ""
+                if reason:
+                    reasons.append(reason)
+        if critical_issues:
+            details = []
+            for field, reasons in sorted(critical_issues.items()):
+                unique_reasons = sorted(set(reasons))
+                details.append(f"{field} ({'; '.join(unique_reasons)})" if unique_reasons else field)
+            errors.append(f"safety-critical fields are unresolved: {', '.join(details)}")
     objective = objective_contract(config, None)
     schema = schema or {}
     if not mutation_schema_declares_metric_bridge(config, schema):

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -333,6 +333,103 @@ runner = ScriptRunner(script="train.py")
     assert config["objective"]["mode_contract_source"] == "job:key_metric_mode"
 
 
+def test_import_marks_splatted_key_metric_unresolved(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+import argparse
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--key_metric", default="val_loss")
+args = parser.parse_args()
+tuning = {"key_metric": args.key_metric}
+recipe = FedAvgRecipe(
+    name="splatted-metric", min_clients=2, num_rounds=1, train_script="client.py", **tuning
+)
+recipe.execute(SimEnv(num_clients=2))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert config["objective"]["metric"] == "accuracy"
+    assert config["objective"]["metric_contract_source"] == "default"
+    assert any(
+        item["field"] == "objective.metric" and "job call passes **kwargs" in item["reason"]
+        for item in config["unresolved"]
+    )
+
+
+def test_import_marks_splatted_direction_keywords_unresolved_with_explicit_metric(tmp_path):
+    tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_common.executors.script_runner import ScriptRunner
+from nvflare.job_config.base_fed_job import BaseFedJob
+from nvflare.widgets.widget import Widget
+
+
+class CustomSelector(Widget):
+    pass
+
+
+extra = {"model_selector": CustomSelector(), "key_metric_mode": "min"}
+job = BaseFedJob(name="splatted-direction", min_clients=2, key_metric="brier", **extra)
+runner = ScriptRunner(script="train.py")
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert config["objective"]["metric"] == "brier"
+    assert config["objective"]["metric_contract_source"] == "literal"
+    assert config["objective"]["mode"] == "max"
+    assert config["objective"]["mode_contract_source"] == "unresolved"
+    assert any(
+        item["field"] == "objective.mode" and "job call passes **kwargs" in item["reason"]
+        for item in config["unresolved"]
+    )
+    assert not any(item["field"] == "objective.metric" for item in config["unresolved"])
+
+
+def test_import_resolves_explicit_direction_keywords_despite_unrelated_splat(tmp_path):
+    tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_common.executors.script_runner import ScriptRunner
+from nvflare.job_config.base_fed_job import BaseFedJob
+
+
+other = {"description": "unrelated"}
+job = BaseFedJob(
+    name="explicit-direction",
+    min_clients=2,
+    key_metric="loss",
+    key_metric_mode="min",
+    model_selector=None,
+    stop_cond=None,
+    **other,
+)
+runner = ScriptRunner(script="train.py")
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert config["objective"]["mode"] == "min"
+    assert config["objective"]["mode_contract_source"] == "job:key_metric_mode"
+    assert not any(item["field"] == "objective.mode" for item in config["unresolved"])
+
+
 def test_import_marks_malformed_stop_condition_unresolved(tmp_path):
     job_path = _write_recipe_job(tmp_path)
     source = job_path.read_text(encoding="utf-8").replace(

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -549,6 +549,107 @@ recipe.execute(SimEnv({sim_env_args}))
     assert not any(item["field"] == "budget.fixed_training_budget.num_clients" for item in config["unresolved"])
 
 
+def test_import_selects_conditional_sim_env_from_job_args(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+import argparse
+
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--environment", choices=["small", "large"], default="small")
+args = parser.parse_args()
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=2, num_rounds=1, train_script="client.py")
+if args.environment == "small":
+    recipe.execute(SimEnv(num_clients=2))
+else:
+    recipe.execute(SimEnv(num_clients=5))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    default_config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+    large_config = import_job_to_autofl_config(
+        str(job_path), workspace_root=str(tmp_path), job_args=["--environment", "large"]
+    )
+
+    assert default_config["budget"]["fixed_training_budget"]["num_clients"] == 2
+    assert default_config["environment"]["profiles"]["sim"]["num_clients"] == 2
+    assert large_config["budget"]["fixed_training_budget"]["num_clients"] == 5
+    assert large_config["environment"]["profiles"]["sim"]["num_clients"] == 5
+
+
+@pytest.mark.parametrize(("job_args", "expected_num_clients"), [([], 1), (["--use-two-clients"], 2)])
+def test_import_resolves_sim_env_clients_from_selected_assignment_branch(tmp_path, job_args, expected_num_clients):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+import argparse
+
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--use-two-clients", action="store_true")
+args = parser.parse_args()
+
+clients = ["site-1"]
+if args.use_two_clients:
+    clients = ["site-1", "site-2"]
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=1, num_rounds=1, train_script="client.py")
+recipe.execute(SimEnv(clients=clients))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path), job_args=job_args)
+
+    assert config["budget"]["fixed_training_budget"]["num_clients"] == expected_num_clients
+    assert config["environment"]["profiles"]["sim"]["num_clients"] == expected_num_clients
+
+
+def test_import_rejects_sim_env_clients_from_unknown_assignment_branch(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+def use_two_clients():
+    return False
+
+
+clients = ["site-1"]
+if use_two_clients():
+    clients = ["site-1", "site-2"]
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=1, num_rounds=1, train_script="client.py")
+recipe.execute(SimEnv(clients=clients))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert "num_clients" not in config["budget"]["fixed_training_budget"]
+    assert "num_clients" not in config["environment"]["profiles"]["sim"]
+    assert any(
+        item["field"] == "budget.fixed_training_budget.num_clients"
+        and "conditional assignment for clients" in item["reason"]
+        for item in config["unresolved"]
+    )
+
+
 def test_import_rejects_zero_sim_env_client_count_with_splatted_clients(tmp_path):
     tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
     job_path = tmp_path / "job.py"

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -399,7 +399,7 @@ runner = ScriptRunner(script="train.py")
     assert not any(item["field"] == "objective.metric" for item in config["unresolved"])
 
 
-def test_import_resolves_explicit_direction_keywords_despite_unrelated_splat(tmp_path):
+def test_import_rejects_direction_contract_when_job_call_has_keyword_splat(tmp_path):
     tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
     job_path = tmp_path / "job.py"
     job_path.write_text(
@@ -408,14 +408,13 @@ from nvflare.app_common.executors.script_runner import ScriptRunner
 from nvflare.job_config.base_fed_job import BaseFedJob
 
 
-other = {"description": "unrelated"}
+other = {"analytics_receiver": None}
 job = BaseFedJob(
     name="explicit-direction",
     min_clients=2,
     key_metric="loss",
     key_metric_mode="min",
     model_selector=None,
-    stop_cond=None,
     **other,
 )
 runner = ScriptRunner(script="train.py")
@@ -425,9 +424,100 @@ runner = ScriptRunner(script="train.py")
 
     config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
 
-    assert config["objective"]["mode"] == "min"
-    assert config["objective"]["mode_contract_source"] == "job:key_metric_mode"
-    assert not any(item["field"] == "objective.mode" for item in config["unresolved"])
+    assert config["objective"]["mode"] == "max"
+    assert config["objective"]["mode_contract_source"] == "unresolved"
+    assert any(
+        item["field"] == "objective.mode" and "remove **kwargs" in item["reason"] for item in config["unresolved"]
+    )
+
+
+@pytest.mark.parametrize(
+    "constructor_args",
+    [
+        '"positional", 2, None, "loss", "min"',
+        "*job_args",
+    ],
+)
+def test_import_marks_positional_job_arguments_unresolved(tmp_path, constructor_args):
+    tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        f"""
+from nvflare.app_common.executors.script_runner import ScriptRunner
+from nvflare.job_config.base_fed_job import BaseFedJob
+
+
+job_args = ("positional", 2, None, "loss", "min")
+job = BaseFedJob({constructor_args})
+runner = ScriptRunner(script="train.py")
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    unresolved_fields = {item["field"] for item in config["unresolved"]}
+    assert {"objective.metric", "objective.mode", "budget.fixed_training_budget"} <= unresolved_fields
+    positional_reasons = " ".join(item["reason"] for item in config["unresolved"])
+    expected_argument_kind = "*args" if constructor_args.startswith("*") else "positional arguments"
+    assert expected_argument_kind in positional_reasons
+
+
+def test_import_marks_splatted_job_budget_unresolved(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+budget = {"num_rounds": 3}
+recipe = FedAvgRecipe(
+    name="splatted-budget",
+    min_clients=2,
+    train_script="client.py",
+    key_metric="accuracy",
+    key_metric_mode="max",
+    **budget,
+)
+recipe.execute(SimEnv(num_clients=2))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert "num_rounds" not in config["budget"]["fixed_training_budget"]
+    assert any(
+        item["field"] == "budget.fixed_training_budget" and "job call passes **kwargs" in item["reason"]
+        for item in config["unresolved"]
+    )
+
+
+def test_import_marks_splatted_sim_env_client_budget_unresolved(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=2, num_rounds=1, train_script="client.py")
+sim_budget = {"num_clients": 3}
+recipe.execute(SimEnv(**sim_budget))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert "num_clients" not in config["budget"]["fixed_training_budget"]
+    assert any(
+        item["field"] == "budget.fixed_training_budget.num_clients" and "SimEnv call passes **kwargs" in item["reason"]
+        for item in config["unresolved"]
+    )
 
 
 def test_import_marks_malformed_stop_condition_unresolved(tmp_path):

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -520,6 +520,89 @@ recipe.execute(SimEnv(**sim_budget))
     )
 
 
+@pytest.mark.parametrize(
+    "sim_env_args",
+    [
+        'clients=["site-1", "site-2", "site-3"]',
+        'num_clients=0, clients=["site-1", "site-2", "site-3"]',
+    ],
+)
+def test_import_resolves_sim_env_client_budget_from_static_clients(tmp_path, sim_env_args):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        f"""
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=2, num_rounds=1, train_script="client.py")
+recipe.execute(SimEnv({sim_env_args}))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert config["budget"]["fixed_training_budget"]["num_clients"] == 3
+    assert config["environment"]["profiles"]["sim"]["num_clients"] == 3
+    assert not any(item["field"] == "budget.fixed_training_budget.num_clients" for item in config["unresolved"])
+
+
+def test_import_rejects_zero_sim_env_client_count_with_splatted_clients(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=2, num_rounds=1, train_script="client.py")
+sim_args = {"clients": ["site-1", "site-2"]}
+recipe.execute(SimEnv(num_clients=0, **sim_args))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert "num_clients" not in config["budget"]["fixed_training_budget"]
+    assert "num_clients" not in config["environment"]["profiles"]["sim"]
+    assert any(
+        item["field"] == "budget.fixed_training_budget.num_clients" and "SimEnv call passes **kwargs" in item["reason"]
+        for item in config["unresolved"]
+    )
+
+
+def test_import_rejects_dynamic_sim_env_clients(tmp_path):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job_path = tmp_path / "job.py"
+    job_path.write_text(
+        """
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+def get_clients():
+    return ["site-1", "site-2"]
+
+
+recipe = FedAvgRecipe(name="sim-budget", min_clients=2, num_rounds=1, train_script="client.py")
+recipe.execute(SimEnv(clients=get_clients()))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = import_job_to_autofl_config(str(job_path), workspace_root=str(tmp_path))
+
+    assert "num_clients" not in config["budget"]["fixed_training_budget"]
+    assert any(
+        item["field"] == "budget.fixed_training_budget.num_clients" and "clients is dynamic" in item["reason"]
+        for item in config["unresolved"]
+    )
+
+
 def test_import_marks_malformed_stop_condition_unresolved(tmp_path):
     job_path = _write_recipe_job(tmp_path)
     source = job_path.read_text(encoding="utf-8").replace(

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -3826,6 +3826,14 @@ def test_import_job_config_forwards_job_args_without_direction_plumbing(tmp_path
             },
             "objective.metric",
         ),
+        (
+            {
+                "import": {"support": {"status": "supported"}},
+                "budget": {"fixed_training_budget": {"num_rounds": 1}},
+                "unresolved": [{"field": "objective.job_key_metric", "reason": "dynamic job metric"}],
+            },
+            "objective.job_key_metric",
+        ),
     ],
 )
 def test_campaign_admission_rejects_unresolved_safety_contract(config, expected):
@@ -3893,6 +3901,49 @@ recipe.execute(SimEnv(num_clients=2))
     assert not tmp_path.joinpath("autofl_runs").exists()
 
 
+def test_initialize_rejects_splatted_metric_even_with_declared_bridge_and_explicit_direction(tmp_path, capsys):
+    tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
+    job = tmp_path / "job.py"
+    job.write_text(
+        """
+from nvflare.app_common.executors.script_runner import ScriptRunner
+from nvflare.job_config.base_fed_job import BaseFedJob
+
+
+metric = {"key_metric": "accuracy"}
+job = BaseFedJob(
+    name="splatted-bridge",
+    min_clients=2,
+    key_metric_mode="max",
+    model_selector=None,
+    **metric,
+)
+runner = ScriptRunner(script="train.py")
+""".lstrip(),
+        encoding="utf-8",
+    )
+    tmp_path.joinpath("mutation_schema.yaml").write_text(
+        """
+objective:
+  requested_metric: f1
+  optimization_metric: f1
+  mode: max
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runner = _load_runner()
+
+    assert runner.main(["initialize", str(job), "--metric", "f1"]) == 2
+
+    error = capsys.readouterr().err
+    assert "objective.metric" in error
+    assert "objective.mode" in error
+    assert "job call passes **kwargs" in error
+    assert not tmp_path.joinpath(".nvflare").exists()
+    assert not tmp_path.joinpath("autofl.yaml").exists()
+    assert not tmp_path.joinpath("autofl_runs").exists()
+
+
 def _write_dynamic_metric_job(workspace):
     workspace.mkdir()
     workspace.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
@@ -3945,7 +3996,7 @@ def test_initialize_rejects_explicit_metric_matching_unresolved_job_metric_place
     assert not workspace.joinpath(".nvflare").exists()
 
 
-def test_initialize_admits_explicit_metric_bridge_for_unresolved_job_metric(tmp_path, monkeypatch):
+def test_initialize_rejects_explicit_metric_bridge_for_unresolved_job_metric(tmp_path, capsys):
     runner = _load_runner()
     workspace = tmp_path / "explicit-bridged"
     job = _write_dynamic_metric_job(workspace)
@@ -3958,13 +4009,11 @@ objective:
 """.lstrip(),
         encoding="utf-8",
     )
-    _mock_successful_baseline(runner, monkeypatch)
 
-    assert runner.main(["initialize", str(job), "--metric", "accuracy"]) == 0
+    assert runner.main(["initialize", str(job), "--metric", "accuracy"]) == 2
 
-    config = runner.read_yaml(workspace / "autofl.yaml")
-    assert config["objective"]["mode"] == "max"
-    assert config["objective"]["mode_contract_source"] == "mutation_schema"
+    assert "objective.job_key_metric" in capsys.readouterr().err
+    assert not workspace.joinpath(".nvflare").exists()
 
 
 def test_initialize_rejects_unresolved_job_metric_without_user_metric(tmp_path, capsys):

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -3859,6 +3859,40 @@ def test_initialize_rejects_implicit_max_loss_without_writing_campaign_files(tmp
     assert not tmp_path.joinpath("autofl_runs").exists()
 
 
+def test_initialize_rejects_splatted_job_contract_without_writing_campaign_files(tmp_path, capsys):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job = tmp_path / "job.py"
+    job.write_text(
+        """
+import argparse
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--key_metric", default="val_loss")
+args = parser.parse_args()
+tuning = {"key_metric": args.key_metric, "key_metric_mode": "min"}
+recipe = FedAvgRecipe(
+    name="splatted-contract", min_clients=2, num_rounds=1, train_script="client.py", **tuning
+)
+recipe.execute(SimEnv(num_clients=2))
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runner = _load_runner()
+
+    assert runner.main(["initialize", str(job)]) == 2
+
+    error = capsys.readouterr().err
+    assert "objective.metric" in error
+    assert "objective.mode" in error
+    assert "job call passes **kwargs" in error
+    assert not tmp_path.joinpath(".nvflare").exists()
+    assert not tmp_path.joinpath("autofl.yaml").exists()
+    assert not tmp_path.joinpath("autofl_runs").exists()
+
+
 def _write_dynamic_metric_job(workspace):
     workspace.mkdir()
     workspace.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -3901,6 +3901,40 @@ recipe.execute(SimEnv(num_clients=2))
     assert not tmp_path.joinpath("autofl_runs").exists()
 
 
+@pytest.mark.parametrize(
+    "sim_env_setup",
+    [
+        'sim_args = {"clients": ["site-1", "site-2"]}\nrecipe.execute(SimEnv(num_clients=0, **sim_args))',
+        'def get_clients():\n    return ["site-1", "site-2"]\n\n\nrecipe.execute(SimEnv(clients=get_clients()))',
+    ],
+)
+def test_initialize_rejects_unresolved_sim_env_clients_without_writing_campaign_files(tmp_path, capsys, sim_env_setup):
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    job = tmp_path / "job.py"
+    job.write_text(
+        f"""
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+recipe = FedAvgRecipe(
+    name="sim-clients", min_clients=2, num_rounds=1, train_script="client.py", key_metric_mode="max"
+)
+{sim_env_setup}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runner = _load_runner()
+
+    assert runner.main(["initialize", str(job)]) == 2
+
+    error = capsys.readouterr().err
+    assert "budget.fixed_training_budget.num_clients" in error
+    assert not tmp_path.joinpath(".nvflare").exists()
+    assert not tmp_path.joinpath("autofl.yaml").exists()
+    assert not tmp_path.joinpath("autofl_runs").exists()
+
+
 def test_initialize_rejects_splatted_metric_even_with_declared_bridge_and_explicit_direction(tmp_path, capsys):
     tmp_path.joinpath("train.py").write_text("print('train')\n", encoding="utf-8")
     job = tmp_path / "job.py"


### PR DESCRIPTION
Follow-up to #5169.

### Description

The Auto-FL AST importer previously discarded dynamic constructor arguments on Recipe, FedJob, and SimEnv calls. Positional arguments, `*args`, or `**kwargs` could therefore hide the native metric, direction controls, or fixed training budget while the importer trusted NVFlare defaults.

This change:

- records positional arguments, `*args`, and `**kwargs` on supported constructor calls;
- keeps an unresolved native job metric safety-critical even when a requested metric has a declared bridge;
- rejects job keyword splats for direction instead of requiring the unsatisfiable combination of `key_metric_mode`, `model_selector`, and `stop_cond`;
- resolves the effective `SimEnv` client count from a positive explicit `num_clients` or the length of a non-empty static `clients` list, and rejects dynamic or splatted client-count sources;
- requires supported job constructors to use keyword-only arguments without splats and gives constructor-valid remediation;
- includes unresolved reasons in the admission error before any campaign artifacts are written; and
- documents the tightened import contract and 2.9 compatibility behavior.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running ./runtest.sh.
- [ ] In-line docstrings updated.
- [x] Documentation updated.

### Validation

- Auto-FL helper suites on latest upstream/main (including PR #5182): 453 passed, 2 skipped.
- Scoped Black, isort, flake8, and git diff --check passed.
- Documentation build succeeded with ./build_doc.sh --html --skip-api; existing repository-wide warnings only.

The top-level ./runtest.sh -s wrapper was attempted but its dependency bootstrap stopped before style checks because uv selected an externally managed Homebrew Python. The equivalent scoped style checks passed directly.
