### PR TITLE
Avoid per-stream error context scans

### DIFF
--- a/nvflare/fuel/f3/streaming/byte_streamer.py
+++ b/nvflare/fuel/f3/streaming/byte_streamer.py
@@ -14,6 +14,7 @@
 import logging
 import threading
 import time
+from collections import OrderedDict
 from concurrent.futures import TimeoutError, as_completed
 from dataclasses import dataclass
 from typing import Callable, Optional
@@ -727,7 +728,8 @@ class TxTask(StreamTaskSpec):
 class ByteStreamer:
 
     tx_task_map = {}
-    error_context_map = {}
+    # Contexts all have the same TTL, so insertion order is expiry order.
+    error_context_map = OrderedDict()
     map_lock = threading.Lock()
 
     sent_stream_counter_pool = StatsPoolManager.add_counter_pool(
@@ -796,7 +798,7 @@ class ByteStreamer:
     def _retain_error_context(cls, task: TxTask):
         now = time.monotonic()
         cls._purge_error_contexts(now)
-        cls.error_context_map[task.sid] = _TxTaskContext(
+        context = _TxTaskContext(
             cell=task.cell,
             target=task.target,
             channel=task.channel,
@@ -804,13 +806,18 @@ class ByteStreamer:
             req_id=(task.headers or {}).get(StreamHeaderKey.STREAM_REQ_ID),
             expires_at=now + STREAM_ERROR_CONTEXT_TTL,
         )
+        cls.error_context_map.pop(task.sid, None)
+        cls.error_context_map[task.sid] = context
         while len(cls.error_context_map) > MAX_STREAM_ERROR_CONTEXTS:
-            cls.error_context_map.pop(next(iter(cls.error_context_map)))
+            cls.error_context_map.popitem(last=False)
 
     @classmethod
     def _purge_error_contexts(cls, now: float):
-        expired = [sid for sid, context in cls.error_context_map.items() if context.expires_at <= now]
-        for sid in expired:
+        while cls.error_context_map:
+            sid = next(iter(cls.error_context_map))
+            context = cls.error_context_map[sid]
+            if context.expires_at > now:
+                break
             cls.error_context_map.pop(sid, None)
 
     @staticmethod

--- a/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
+++ b/tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py
@@ -14,6 +14,8 @@
 
 import threading
 import time
+from collections import OrderedDict
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -62,6 +64,28 @@ class OversizedReadStream(Stream):
 
     def read(self, size):
         return b"x" * (size + 1)
+
+
+def test_error_context_expiry_cleanup_uses_queue_without_scanning_context_map(monkeypatch):
+    class NoScanDict(OrderedDict):
+        def items(self):
+            raise AssertionError("expiration cleanup must not scan every retained context")
+
+    now = [0.0]
+    monkeypatch.setattr(byte_streamer_module.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(ByteStreamer, "error_context_map", NoScanDict())
+
+    def task(sid):
+        return SimpleNamespace(sid=sid, cell=MagicMock(), target="receiver", channel="ch", topic="tp", headers={})
+
+    ByteStreamer._retain_error_context(task(1))
+    now[0] = byte_streamer_module.STREAM_ERROR_CONTEXT_TTL - 1
+    ByteStreamer._retain_error_context(task(2))
+    assert set(ByteStreamer.error_context_map) == {1, 2}
+
+    now[0] = byte_streamer_module.STREAM_ERROR_CONTEXT_TTL
+    ByteStreamer._retain_error_context(task(3))
+    assert set(ByteStreamer.error_context_map) == {2, 3}
 
 
 class TestByteStreamerAckWatchdog:


### PR DESCRIPTION
## Summary

- replace full-map expiration scans with an insertion-ordered expiry queue
- keep retained stream-error contexts bounded while reducing contention on the shared stream map lock
- add regression coverage for expiry cleanup without scanning all retained contexts

## Validation

- `/Users/zhihongz/venv/3.12/bin/python -m pytest tests/unit_test/fuel/f3/streaming/byte_streamer_ack_watchdog_test.py tests/unit_test/fuel/f3/cellnet/cell_blob_size_test.py -v`
- Scoped Black, isort, flake8, and `git diff --check`