### PR TITLE
Report active client process exit failures

### DIFF
--- a/nvflare/private/fed/client/client_executor.py
+++ b/nvflare/private/fed/client/client_executor.py
@@ -46,6 +46,8 @@ REPORTABLE_JOB_FAILURES = {
     JobReturnCode.ABORTED: "aborted",
 }
 
+_ABORT_REQUESTED_KEY = "_abort_requested"
+
 
 class _PendingJobHandle(JobHandleSpec):
     """Hold an abort request until a launcher returns the real job handle."""
@@ -301,6 +303,7 @@ class JobExecutor(ClientExecutor):
             self.run_processes[job_id] = {
                 RunProcessKey.JOB_HANDLE: pending_handle,
                 RunProcessKey.STATUS: ClientStatus.STARTING,
+                _ABORT_REQUESTED_KEY: False,
             }
         try:
             job_handle = job_launcher.launch_job(job_meta, fl_ctx)
@@ -493,6 +496,8 @@ class JobExecutor(ClientExecutor):
         while retry >= 0:
             with self.lock:
                 process = self.run_processes.get(job_id)
+                if process:
+                    process[_ABORT_REQUESTED_KEY] = True
                 process_status = (
                     process.get(RunProcessKey.STATUS, ClientStatus.NOT_STARTED) if process else ClientStatus.NOT_STARTED
                 )
@@ -624,9 +629,18 @@ class JobExecutor(ClientExecutor):
 
             return_code = get_return_code(job_handle, job_id, workspace, self.logger)
 
-            process_status = self.run_processes.get(job_id, {}).get(RunProcessKey.STATUS)
-            if return_code == JobReturnCode.EXECUTION_ERROR and process_status == ClientStatus.STARTING:
-                return_code = ProcessExitCode.INFRASTRUCTURE_ERROR
+            with self.lock:
+                process = self.run_processes.get(job_id, {})
+                process_status = process.get(RunProcessKey.STATUS)
+                abort_requested = process.get(_ABORT_REQUESTED_KEY, False)
+            # A generic RC 1 is actionable only while a checked-in worker is still active.
+            # STARTING remains an infrastructure failure, while STOPPED teardown noise and
+            # launcher UNKNOWN retain their existing non-reportable behavior.
+            if return_code == JobReturnCode.EXECUTION_ERROR and not abort_requested:
+                if process_status == ClientStatus.STARTING:
+                    return_code = ProcessExitCode.INFRASTRUCTURE_ERROR
+                elif process_status == ClientStatus.STARTED:
+                    return_code = ProcessExitCode.EXCEPTION
 
             self.logger.info(f"run ({job_id}): child worker process finished with RC {return_code}")
 

--- a/tests/unit_test/private/fed/client/client_executor_test.py
+++ b/tests/unit_test/private/fed/client/client_executor_test.py
@@ -30,7 +30,12 @@ from nvflare.fuel.f3.cellnet.core_cell import FQCN
 from nvflare.fuel.f3.cellnet.defs import ReturnCode
 from nvflare.private.defs import CellChannel, CellChannelTopic, JobFailureMsgKey
 from nvflare.private.fed.client.client_engine import ClientEngine
-from nvflare.private.fed.client.client_executor import REPORTABLE_JOB_FAILURES, JobExecutor, _PendingJobHandle
+from nvflare.private.fed.client.client_executor import (
+    _ABORT_REQUESTED_KEY,
+    REPORTABLE_JOB_FAILURES,
+    JobExecutor,
+    _PendingJobHandle,
+)
 from nvflare.private.fed.client.client_status import ClientStatus
 from nvflare.private.fed.client.communicator import Communicator
 
@@ -60,6 +65,7 @@ def test_abort_app_terminates_starting_job_without_worker_command():
 
     job_handle.terminate.assert_called_once_with()
     client.cell.fire_and_forget.assert_not_called()
+    assert job_executor.run_processes["job-1"][_ABORT_REQUESTED_KEY]
 
 
 @pytest.mark.parametrize("heartbeat_cleanup", [False, True], ids=["admin_abort", "server_cleanup"])
@@ -611,15 +617,20 @@ def test_wait_child_process_preserves_launcher_infrastructure_error_over_rc_file
 
 
 @pytest.mark.parametrize(
-    ("return_code", "process_status", "expected_code"),
+    ("return_code", "process_status", "abort_requested", "expected_code"),
     [
-        (JobReturnCode.SUCCESS, ClientStatus.STARTING, JobReturnCode.SUCCESS),
-        (JobReturnCode.UNKNOWN, ClientStatus.STARTING, JobReturnCode.UNKNOWN),
-        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTED, JobReturnCode.EXECUTION_ERROR),
-        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTING, ProcessExitCode.INFRASTRUCTURE_ERROR),
+        (JobReturnCode.SUCCESS, ClientStatus.STARTING, False, JobReturnCode.SUCCESS),
+        (JobReturnCode.UNKNOWN, ClientStatus.STARTING, False, JobReturnCode.UNKNOWN),
+        (JobReturnCode.UNKNOWN, ClientStatus.STARTED, False, JobReturnCode.UNKNOWN),
+        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTING, False, ProcessExitCode.INFRASTRUCTURE_ERROR),
+        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTED, False, ProcessExitCode.EXCEPTION),
+        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STOPPED, False, JobReturnCode.EXECUTION_ERROR),
+        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTING, True, JobReturnCode.EXECUTION_ERROR),
+        (JobReturnCode.EXECUTION_ERROR, ClientStatus.STARTED, True, JobReturnCode.EXECUTION_ERROR),
+        (JobReturnCode.ABORTED, ClientStatus.STARTED, False, JobReturnCode.ABORTED),
     ],
 )
-def test_wait_child_process_reports_terminal_return_code(return_code, process_status, expected_code):
+def test_wait_child_process_reports_terminal_return_code(return_code, process_status, abort_requested, expected_code):
     client = MagicMock()
     client.client_name = "site-1"
     client.send_request_before_shutdown.return_value.get_header.return_value = ReturnCode.OK
@@ -630,6 +641,7 @@ def test_wait_child_process_reports_terminal_return_code(return_code, process_st
         "job-1": {
             RunProcessKey.JOB_HANDLE: job_handle,
             RunProcessKey.STATUS: process_status,
+            _ABORT_REQUESTED_KEY: abort_requested,
         }
     }
 
@@ -651,6 +663,7 @@ def test_wait_child_process_reports_terminal_return_code(return_code, process_st
     client.send_request_before_shutdown.assert_called_once()
     payload = client.send_request_before_shutdown.call_args.kwargs["request"].payload
     assert payload[JobFailureMsgKey.CODE] == expected_code
+    assert payload[JobFailureMsgKey.REASON] == REPORTABLE_JOB_FAILURES.get(expected_code)
     assert "job-1" not in job_executor.run_processes
     engine.fire_event.assert_called_once_with(EventType.JOB_COMPLETED, fl_ctx)
 


### PR DESCRIPTION
## Summary

- classify generic client-worker exit code `1` as `ProcessExitCode.EXCEPTION` only when the worker previously checked in as `STARTED` and no parent-side abort was requested
- preserve the existing `STARTING + 1` infrastructure-failure classification
- leave post-`STOPPED` teardown errors, launcher `UNKNOWN`, and explicit abort paths unchanged

## Why

An in-process Client API trainer runs inside the client job worker. If it terminates the process unexpectedly with exit code `1`, the client parent observes a generic `JobReturnCode.EXECUTION_ERROR` while the worker is still recorded as `STARTED`.

Since #4595, that generic code is not an authoritative server-side failure. Both affected clients can disappear without failing the server job, leaving it `RUNNING` until an external timeout or dead-client fallback intervenes.

This patch restores bounded failure only at the active-worker boundary. It does not make all generic launcher errors reportable:

| Parent observation | Effective outcome |
| --- | --- |
| `STARTING + EXECUTION_ERROR`, no abort | `INFRASTRUCTURE_ERROR` (existing behavior) |
| `STARTED + EXECUTION_ERROR`, no abort | `EXCEPTION` |
| `STOPPED + EXECUTION_ERROR` | unchanged, non-reportable teardown result |
| explicit parent abort + `EXECUTION_ERROR` | unchanged, not promoted to an application exception |
| launcher `UNKNOWN` | unchanged |
| canonical process failure or `ABORTED` | unchanged |

## Scope

The change is intentionally parent-side and limited to the reported regression. It does not change `ClientRunner`, worker shutdown, process-RC markers, workspace publication or extraction, Client API backends, job launchers, or server failure mapping.

Client status notifications remain best effort. If a completed worker loses its `STOPPED` notification and later exits with code `1`, the parent can still observe stale `STARTED` state. A reliable completion handshake is a separate lifecycle problem; this patch chooses bounded failure for an apparently active worker rather than broadening the 2.9 fix into a new completion protocol.

## Testing

- exact two-client in-process reproduction: job reached `FINISHED:EXECUTION_EXCEPTION` in 11.9 seconds instead of timing out
- focused client/server regression suite: `146 passed`
- full style check: `./runtest.sh -s --skip-install`
- `git diff --check`
