### PR TITLE
Fix watchdog PID tracking

### DIFF
--- a/nvflare/lighter/templates/master_template.yml
+++ b/nvflare/lighter/templates/master_template.yml
@@ -665,7 +665,7 @@ sub_start_sh: |
   restart_count=0
 
   start_python() {
-    python3 -u -m nvflare.private.fed.app.{~~type~~}.{~~app_name~~} -m "$WORKSPACE" -s fed_{~~type~~}.json --set secure_train=true {~~cln_uid~~} org={~~org_name~~} config_folder={~~config_folder~~}
+    exec python3 -u -m nvflare.private.fed.app.{~~type~~}.{~~app_name~~} -m "$WORKSPACE" -s fed_{~~type~~}.json --set secure_train=true {~~cln_uid~~} org={~~org_name~~} config_folder={~~config_folder~~}
   }
 
   start_fl() {
@@ -680,8 +680,9 @@ sub_start_sh: |
       exit
     fi
     lst=$SECONDS
-    (start_python 2>&1 & echo $! >&3 ) 3>"$WORKSPACE/pid.fl"
-    pid=`cat "$WORKSPACE/pid.fl"`
+    start_python 2>&1 &
+    pid=$!
+    printf '%s\n' "$pid" > "$WORKSPACE/pid.fl"
     echo "new pid ${pid}"
   }
 
@@ -697,7 +698,8 @@ sub_start_sh: |
       echo "Process already terminated"
       return
     fi
-    kill -9 $pid
+    kill -9 "$pid"
+    wait "$pid" 2> /dev/null
     rm -f "$WORKSPACE/pid.fl" "$WORKSPACE/shutdown.fl" "$WORKSPACE/restart.fl" 2> /dev/null 1>&2
   }
 

--- a/tests/unit_test/lighter/static_file_builder_test.py
+++ b/tests/unit_test/lighter/static_file_builder_test.py
@@ -280,6 +280,16 @@ class TestStaticFileBuilder:
         assert sub_start.index(verify_cmd) < sub_start.index('mkdir -p "$WORKSPACE/transfer"')
         assert 'touch "$WORKSPACE/shutdown.fl"' in stop_fl
 
+    def test_master_template_sub_start_tracks_python_pid(self):
+        """The watchdog must record and reap the FL Python process, not a Bash wrapper."""
+        sub_start = _load_master_template()["sub_start_sh"]
+
+        assert "exec python3 -u -m nvflare.private.fed.app." in sub_start
+        assert "  start_python 2>&1 &\n  pid=$!\n" in sub_start
+        assert 'printf \'%s\\n\' "$pid" > "$WORKSPACE/pid.fl"' in sub_start
+        assert "(start_python 2>&1 & echo $! >&3 )" not in sub_start
+        assert 'wait "$pid" 2> /dev/null' in sub_start
+
     def test_master_template_class_allow_list_is_exact(self):
         """The provisioned allow list must match the curated component list exactly."""
         template = _load_master_template()


### PR DESCRIPTION
## Summary

- launch the watchdog-managed FL application with `exec` so the recorded PID belongs to the Python process
- capture and persist the background PID directly, then reap the process after forced termination
- add a regression test for the generated startup script's PID tracking behavior

## Testing

- `.venv/bin/python -m pytest -q tests/unit_test/lighter/static_file_builder_test.py` (22 passed)
- `./runtest.sh -s`
