### PR TITLE
Advertise protocol and NVFlare versions during registration

### DIFF
--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -139,6 +139,7 @@ class AppFolderConstants:
 
 
 ERROR_MSG_PREFIX = "NVFLARE_ERROR"
+FEDERATION_PROTOCOL_VERSION = 1
 
 
 class CellMessageHeaderKeys:
@@ -155,6 +156,7 @@ class CellMessageHeaderKeys:
     JOB_IDS = "job_ids"
     MESSAGE = "message"
     ABORT_JOBS = "abort_jobs"
+    FEDERATION_PROTOCOL_VERSION = "federation_protocol_version"
 
 
 class ClientRegMsgKey:

--- a/nvflare/private/defs.py
+++ b/nvflare/private/defs.py
@@ -157,6 +157,7 @@ class CellMessageHeaderKeys:
     MESSAGE = "message"
     ABORT_JOBS = "abort_jobs"
     FEDERATION_PROTOCOL_VERSION = "federation_protocol_version"
+    NVFLARE_VERSION = "nvflare_version"
 
 
 class ClientRegMsgKey:

--- a/nvflare/private/fed/authenticator.py
+++ b/nvflare/private/fed/authenticator.py
@@ -32,6 +32,7 @@ from nvflare.fuel.f3.cellnet.fqcn import FQCN
 from nvflare.fuel.f3.message import Message
 from nvflare.fuel.f3.message import Message as CellMessage
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.private import defs as private_defs
 from nvflare.private.defs import CellChannel, CellChannelTopic, CellMessageHeaderKeys, ClientRegMsgKey, new_cell_message
 from nvflare.private.fed.utils.identity_utils import (
     IdentityAsserter,
@@ -247,6 +248,7 @@ class Authenticator:
             CellMessageHeaderKeys.CLIENT_TYPE: self.client_type,
             CellMessageHeaderKeys.CLIENT_IP: local_ip,
             CellMessageHeaderKeys.PROJECT_NAME: self.project_name,
+            CellMessageHeaderKeys.FEDERATION_PROTOCOL_VERSION: private_defs.FEDERATION_PROTOCOL_VERSION,
         }
         login_message = new_cell_message(headers, shareable)
 

--- a/nvflare/private/fed/authenticator.py
+++ b/nvflare/private/fed/authenticator.py
@@ -19,6 +19,7 @@ from typing import Callable, Optional
 
 from cryptography.x509.oid import ExtendedKeyUsageOID
 
+import nvflare
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.fl_exception import FLCommunicationError
 from nvflare.apis.shareable import Shareable
@@ -249,6 +250,7 @@ class Authenticator:
             CellMessageHeaderKeys.CLIENT_IP: local_ip,
             CellMessageHeaderKeys.PROJECT_NAME: self.project_name,
             CellMessageHeaderKeys.FEDERATION_PROTOCOL_VERSION: private_defs.FEDERATION_PROTOCOL_VERSION,
+            CellMessageHeaderKeys.NVFLARE_VERSION: nvflare.__version__,
         }
         login_message = new_cell_message(headers, shareable)
 

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -59,6 +59,7 @@ from nvflare.fuel.f3.mpm import MainProcessMonitor as mpm
 from nvflare.fuel.sec.authn import add_authentication_headers
 from nvflare.fuel.utils.config_service import ConfigService
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.private import defs as private_defs
 from nvflare.private.defs import (
     CellChannel,
     CellChannelTopic,
@@ -855,6 +856,7 @@ class FederatedServer(BaseServer):
                         CellMessageHeaderKeys.TOKEN: client.token,
                         CellMessageHeaderKeys.TOKEN_SIGNATURE: token_signature,
                         CellMessageHeaderKeys.SSID: self.server_state.ssid,
+                        CellMessageHeaderKeys.FEDERATION_PROTOCOL_VERSION: private_defs.FEDERATION_PROTOCOL_VERSION,
                     }
 
                     # Add CC info if present

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 from threading import Lock
 from typing import Dict, List, Optional
 
+import nvflare
 from nvflare.apis.client import Client
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_component import FLComponent
@@ -857,6 +858,7 @@ class FederatedServer(BaseServer):
                         CellMessageHeaderKeys.TOKEN_SIGNATURE: token_signature,
                         CellMessageHeaderKeys.SSID: self.server_state.ssid,
                         CellMessageHeaderKeys.FEDERATION_PROTOCOL_VERSION: private_defs.FEDERATION_PROTOCOL_VERSION,
+                        CellMessageHeaderKeys.NVFLARE_VERSION: nvflare.__version__,
                     }
 
                     # Add CC info if present


### PR DESCRIPTION
## Summary
- define federation protocol version 1
- advertise the protocol and NVFlare release versions in the client registration request
- advertise the protocol and NVFlare release versions in the successful server registration response
- leave compatibility enforcement unchanged in 2.9

## Rationale
This seeds additive registration fields so a future release can detect protocol compatibility in both directions and report the peer software release in mismatch diagnostics. Existing peers continue to ignore the extra fields, so this does not change 2.9 admission behavior.

## Testing
- ./runtest.sh -s
- python -m pytest -q tests/unit_test/private/fed/authenticator_test.py tests/unit_test/private/fed/server/fed_server_test.py (66 passed)