### PR TITLE
[2.8] Restrict remote log configuration and local listeners

### DIFF
--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -82,6 +82,7 @@ class ConnectorManager:
         self.adhoc_allowed = comm_configurator.allow_adhoc_connections(_Defaults.ALLOW_ADHOC_CONNECTIONS)
         self.adhoc_scheme = comm_configurator.get_adhoc_connection_scheme(_Defaults.SCHEME_FOR_ADHOC_CONNECTIONS)
         self.adhoc_resources = {}
+        internal_host_configured = False
 
         # load config if any
         comm_config = comm_configurator.get_config()
@@ -90,15 +91,16 @@ class ConnectorManager:
             if int_conf:
                 self.int_scheme = int_conf.get(_KEY_SCHEME)
                 self.int_resources = int_conf.get(_KEY_RESOURCES)
+                internal_host_configured = DriverParams.HOST.value in self.int_resources
 
             adhoc_conf = self._validate_conn_config(comm_config, _KEY_ADHOC)
             if adhoc_conf:
                 self.adhoc_scheme = adhoc_conf.get(_KEY_SCHEME)
                 self.adhoc_resources = adhoc_conf.get(_KEY_RESOURCES)
 
-        if internal_listener_host:
+        if internal_listener_host and not internal_host_configured:
             self.int_resources[DriverParams.HOST.value] = internal_listener_host
-            self.int_resources[DriverParams.LISTEN_HOST.value] = internal_listener_host
+            self.int_resources.setdefault(DriverParams.LISTEN_HOST.value, internal_listener_host)
 
         # default conn sec
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY)

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -59,7 +59,13 @@ class ConnectorManager:
     Manages creation of connectors
     """
 
-    def __init__(self, communicator: Communicator, secure: bool, comm_configurator: CommConfigurator):
+    def __init__(
+        self,
+        communicator: Communicator,
+        secure: bool,
+        comm_configurator: CommConfigurator,
+        internal_listener_host: str = None,
+    ):
         self._name = self.__class__.__name__
         self.logger = get_obj_logger(self)
 
@@ -89,6 +95,10 @@ class ConnectorManager:
             if adhoc_conf:
                 self.adhoc_scheme = adhoc_conf.get(_KEY_SCHEME)
                 self.adhoc_resources = adhoc_conf.get(_KEY_RESOURCES)
+
+        if internal_listener_host:
+            self.int_resources[DriverParams.HOST.value] = internal_listener_host
+            self.int_resources[DriverParams.LISTEN_HOST.value] = internal_listener_host
 
         # default conn sec
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY)

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -288,6 +288,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         bulk_check_interval=0.5,
         bulk_process_interval=0.5,
         max_bulk_size=100,
+        internal_listener_host: str = None,
     ):
         """
 
@@ -300,6 +301,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             create_internal_listener: whether to create an internal listener for child cells
             parent_url: url for connecting to parent cell
             parent_resources: extra resources for making connection to parent
+            internal_listener_host: host for the internal listener to advertise and bind to
 
         FQCN is the names of all ancestor, concatenated with dots.
 
@@ -407,7 +409,10 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
         self.endpoint = ep
         self.connector_manager = ConnectorManager(
-            communicator=self.communicator, secure=secure, comm_configurator=comm_configurator
+            communicator=self.communicator,
+            secure=secure,
+            comm_configurator=comm_configurator,
+            internal_listener_host=internal_listener_host,
         )
 
         self.communicator.register_message_receiver(app_id=self.APP_ID, receiver=self)

--- a/nvflare/fuel/f3/drivers/driver_params.py
+++ b/nvflare/fuel/f3/drivers/driver_params.py
@@ -37,6 +37,7 @@ class DriverParams(str, Enum):
     CUSTOM_CA_CERT = "custom_ca_cert"
     SECURE = "secure"
     PORTS = "ports"
+    LISTEN_HOST = "listen_host"
     SOCKET = "socket"
     LOCAL_ADDR = "local_addr"
     PEER_ADDR = "peer_addr"

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -272,7 +272,7 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
 
     Args:
         scheme: The transport scheme
-        resources: The resource restrictions like port ranges
+        resources: Resource restrictions. "host" is advertised; "listen_host" limits the bind address.
 
     Returns:
         a tuple with connecting and listening URL
@@ -284,12 +284,15 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     if not host:
         host = "localhost"
 
+    listening_host = resources.get(DriverParams.LISTEN_HOST.value) if resources else None
+    if not listening_host:
+        listening_host = "0"
+
     port = get_open_tcp_port(resources)
     if not port:
         raise CommError(CommError.BAD_CONFIG, "Can't find an open port in the specified range")
 
-    # Always listen on all interfaces
-    listening_url = f"{scheme}://0:{port}"
+    listening_url = f"{scheme}://{listening_host}:{port}"
     connect_url = f"{scheme}://{host}:{port}"
 
     return connect_url, listening_url

--- a/nvflare/fuel/flare_api/api_spec.py
+++ b/nvflare/fuel/flare_api/api_spec.py
@@ -332,7 +332,7 @@ class SessionSpec(ABC):
 
         Args:
             job_id: ID of the running job
-            config: log level, log mode, file path, or dictConfig payload
+            config: log level or built-in log mode
             target: ``all``, ``server``, or a client site name
 
         Returns: None

--- a/nvflare/fuel/flare_api/flare_api.py
+++ b/nvflare/fuel/flare_api/flare_api.py
@@ -1475,7 +1475,7 @@ class Session(SessionSpec):
 
         Args:
             job_id (str): ID of the job (must be RUNNING)
-            config: str (level or LogMode), dict (dictConfig), or file path
+            config: str log level or built-in LogMode
             target (str): "all", "server", or a client site name. Any value
                 other than "all" or "server" is sent through the client-targeted
                 admin command path.

--- a/nvflare/private/fed/client/admin_commands.py
+++ b/nvflare/private/fed/client/admin_commands.py
@@ -17,7 +17,7 @@
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_site_log_config
 from nvflare.private.fed.client.client_status import get_status_message
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
@@ -272,8 +272,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -171,14 +171,16 @@ class BaseServer(ABC):
         if len(parts) != 2:
             raise RuntimeError(f"bad service target: {target}")
 
+        listening_host = "127.0.0.1" if parts[0].rstrip(".").lower() == "localhost" else None
         fl_port = int(parts[1])
 
         # get admin port
         admin_port = int(grpc_args.get("admin_port", fl_port))
 
-        root_url = [f"{scheme}://0:{fl_port}"]
+        url_host = listening_host or "0"
+        root_url = [f"{scheme}://{url_host}:{fl_port}"]
         if admin_port != fl_port:
-            root_url.append(f"{scheme}://0:{admin_port}")
+            root_url.append(f"{scheme}://{url_host}:{admin_port}")
 
         my_fqcn = FQCN.ROOT_SERVER
         self.cell = Cell(
@@ -188,6 +190,7 @@ class BaseServer(ABC):
             credentials=credentials,
             create_internal_listener=True,
             parent_url=parent_url,
+            internal_listener_host=listening_host,
         )
 
         self.cell.start()

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -68,6 +68,8 @@ from nvflare.fuel.hci.server.binary_transfer import BinaryTransfer
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.fuel.utils.argument_utils import SafeArgumentParser
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.private.admin_defs import MsgHeader
+from nvflare.private.admin_defs import ReturnCode as AdminReturnCode
 from nvflare.private.defs import RequestHeader, TrainingTopic
 from nvflare.private.fed.server.admin import new_message
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
@@ -396,6 +398,28 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             message.set_header(RequestHeader.JOB_ID, str(job_id))
             replies = self.send_request_to_clients(conn, message)
             self.process_replies_to_table(conn, replies)
+
+            client_errors = []
+            client_replies = replies or []
+            received_tokens = {client_reply.client_token for client_reply in client_replies}
+            expected_clients = conn.get_prop(self.TARGET_CLIENTS, {}) or {}
+            for client_token, client_name in expected_clients.items():
+                if client_token not in received_tokens:
+                    client_errors.append(f"{client_name or client_token}: no reply")
+
+            for client_reply in client_replies:
+                client_name = client_reply.client_name or client_reply.client_token or "client"
+                if client_reply.reply is None:
+                    client_errors.append(f"{client_name}: no reply")
+                    continue
+
+                return_code = client_reply.reply.get_header(MsgHeader.RETURN_CODE, AdminReturnCode.OK)
+                if return_code != AdminReturnCode.OK:
+                    detail = client_reply.reply.body or f"return code {return_code}"
+                    client_errors.append(f"{client_name}: {detail}")
+
+            if client_errors:
+                conn.update_meta(make_meta(MetaStatusValue.ERROR, info="\n".join(client_errors)))
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -407,9 +407,7 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                 or client_reply.reply.get_header(MsgHeader.RETURN_CODE, AdminReturnCode.OK) != AdminReturnCode.OK
                 for client_reply in client_replies
             ):
-                conn.update_meta(
-                    make_meta(MetaStatusValue.ERROR, info="one or more clients failed to configure job logging")
-                )
+                conn.append_error("one or more clients failed to configure job logging")
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -399,27 +399,17 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             replies = self.send_request_to_clients(conn, message)
             self.process_replies_to_table(conn, replies)
 
-            client_errors = []
             client_replies = replies or []
+            expected_tokens = set((conn.get_prop(self.TARGET_CLIENTS, {}) or {}).keys())
             received_tokens = {client_reply.client_token for client_reply in client_replies}
-            expected_clients = conn.get_prop(self.TARGET_CLIENTS, {}) or {}
-            for client_token, client_name in expected_clients.items():
-                if client_token not in received_tokens:
-                    client_errors.append(f"{client_name or client_token}: no reply")
-
-            for client_reply in client_replies:
-                client_name = client_reply.client_name or client_reply.client_token or "client"
-                if client_reply.reply is None:
-                    client_errors.append(f"{client_name}: no reply")
-                    continue
-
-                return_code = client_reply.reply.get_header(MsgHeader.RETURN_CODE, AdminReturnCode.OK)
-                if return_code != AdminReturnCode.OK:
-                    detail = client_reply.reply.body or f"return code {return_code}"
-                    client_errors.append(f"{client_name}: {detail}")
-
-            if client_errors:
-                conn.update_meta(make_meta(MetaStatusValue.ERROR, info="\n".join(client_errors)))
+            if not expected_tokens.issubset(received_tokens) or any(
+                client_reply.reply is None
+                or client_reply.reply.get_header(MsgHeader.RETURN_CODE, AdminReturnCode.OK) != AdminReturnCode.OK
+                for client_reply in client_replies
+            ):
+                conn.update_meta(
+                    make_meta(MetaStatusValue.ERROR, info="one or more clients failed to configure job logging")
+                )
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -29,7 +29,7 @@ from nvflare.apis.fl_constant import (
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
-from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger
+from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger, validate_site_log_config
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.security.logging import secure_format_exception, secure_format_traceback
 from nvflare.widgets.widget import WidgetID
@@ -453,8 +453,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ app_opt =
     %(MONITORING)s
     %(K8S)s
     pytorch_lightning
-    xgboost
+    xgboost<3.4
     bitsandbytes
 app_opt_mac =
     %(PT)s

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+from nvflare.fuel.f3.cellnet.connector_manager import ConnectorManager
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+
+
+def test_internal_listener_host_overrides_default_resources():
+    comm_configurator = MagicMock()
+    comm_configurator.get_config.return_value = None
+
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+        internal_listener_host="127.0.0.1",
+    )
+
+    assert manager.int_resources[DriverParams.HOST.value] == "127.0.0.1"
+    assert manager.int_resources[DriverParams.LISTEN_HOST.value] == "127.0.0.1"

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
@@ -31,3 +31,20 @@ def test_internal_listener_host_overrides_default_resources():
 
     assert manager.int_resources[DriverParams.HOST.value] == "127.0.0.1"
     assert manager.int_resources[DriverParams.LISTEN_HOST.value] == "127.0.0.1"
+
+
+def test_internal_listener_host_does_not_override_configured_host():
+    comm_configurator = MagicMock()
+    comm_configurator.get_config.return_value = {
+        "internal": {"scheme": "tcp", "resources": {DriverParams.HOST.value: "10.0.0.5"}}
+    }
+
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+        internal_listener_host="127.0.0.1",
+    )
+
+    assert manager.int_resources[DriverParams.HOST.value] == "10.0.0.5"
+    assert DriverParams.LISTEN_HOST.value not in manager.int_resources

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -43,11 +43,11 @@ class TestNetUtils:
     @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
     def test_tcp_listener_uses_explicit_listening_host(self, _):
         resources = {
-            DriverParams.HOST.value: "127.0.0.1",
+            DriverParams.HOST.value: "server.example",
             DriverParams.LISTEN_HOST.value: "127.0.0.1",
         }
 
-        assert get_tcp_urls("tcp", resources) == ("tcp://127.0.0.1:1234", "tcp://127.0.0.1:1234")
+        assert get_tcp_urls("tcp", resources) == ("tcp://server.example:1234", "tcp://127.0.0.1:1234")
 
     @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
     def test_tcp_listener_default_remains_wildcard(self, _):

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import patch
+
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
-from nvflare.fuel.f3.drivers.net_utils import encode_url, parse_url
+from nvflare.fuel.f3.drivers.net_utils import encode_url, get_tcp_urls, parse_url
 
 
 class TestNetUtils:
@@ -37,3 +39,19 @@ class TestNetUtils:
         assert int(params.get(DriverParams.PORT)) == 8002
         assert params.get("a") == "123"
         assert params.get("b") == "test"
+
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_uses_explicit_listening_host(self, _):
+        resources = {
+            DriverParams.HOST.value: "127.0.0.1",
+            DriverParams.LISTEN_HOST.value: "127.0.0.1",
+        }
+
+        assert get_tcp_urls("tcp", resources) == ("tcp://127.0.0.1:1234", "tcp://127.0.0.1:1234")
+
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_default_remains_wildcard(self, _):
+        assert get_tcp_urls("tcp", {DriverParams.HOST.value: "server.example"}) == (
+            "tcp://server.example:1234",
+            "tcp://0:1234",
+        )

--- a/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
+++ b/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import ipaddress
 import os
 import shutil
 import tempfile
@@ -80,8 +79,6 @@ class TestSimulatorDeploy(unittest.TestCase):
         assert isinstance(server, SimulatorServer)
         assert isinstance(server.engine.run_manager, RunManager)
         listening_host = "127.0.0.1"
-        listen_ip = ipaddress.ip_address(listening_host)
-        assert listen_ip.version == 4 and listen_ip.is_loopback
         fl_port = server_config["service"]["target"].rsplit(":", 1)[1]
         admin_port = server_config["admin_port"]
         cell_args = mock_cell.call_args.kwargs

--- a/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
+++ b/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import ipaddress
 import os
 import shutil
 import tempfile
@@ -67,17 +68,28 @@ class TestSimulatorDeploy(unittest.TestCase):
     @patch("nvflare.private.fed.server.admin.FedAdminServer.start")
     @patch("nvflare.private.fed.simulator.simulator_server.SimulatorServer._register_cellnet_cbs")
     @patch("nvflare.private.fed.server.fed_server.Cell")
-    def test_create_server(self, mock_admin, mock_simulator_server, mock_cell):
+    def test_create_server(self, mock_cell, mock_register_cbs, mock_admin_start):
         workspace = tempfile.mkdtemp()
         os.mkdir(os.path.join(workspace, "local"))
         os.mkdir(os.path.join(workspace, "startup"))
         parser = self._create_parser()
         args = parser.parse_args(["job_folder", "-w" + workspace, "-n 2", "-t 1"])
         args.config_folder = "config"
-        _, server = self.deployer.create_fl_server(args)
+        server_config, server = self.deployer.create_fl_server(args)
 
         assert isinstance(server, SimulatorServer)
         assert isinstance(server.engine.run_manager, RunManager)
+        listening_host = "127.0.0.1"
+        listen_ip = ipaddress.ip_address(listening_host)
+        assert listen_ip.version == 4 and listen_ip.is_loopback
+        fl_port = server_config["service"]["target"].rsplit(":", 1)[1]
+        admin_port = server_config["admin_port"]
+        cell_args = mock_cell.call_args.kwargs
+        assert cell_args["root_url"] == [
+            f"tcp://{listening_host}:{fl_port}",
+            f"tcp://{listening_host}:{admin_port}",
+        ]
+        assert cell_args["internal_listener_host"] == listening_host
 
         server.cell.stop()
         server.close()

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nvflare.fuel.utils.log_utils import LogMode
+from nvflare.private.fed.client.admin_commands import ConfigureJobLogCommand as ClientConfigureJobLogCommand
+from nvflare.private.fed.server.server_commands import ConfigureJobLogCommand as ServerConfigureJobLogCommand
+
+COMMANDS = [
+    (ServerConfigureJobLogCommand, "nvflare.private.fed.server.server_commands.dynamic_log_config"),
+    (ClientConfigureJobLogCommand, "nvflare.private.fed.client.admin_commands.dynamic_log_config"),
+]
+
+
+def _log_command_context(tmp_path):
+    workspace = MagicMock()
+    workspace.get_run_dir.return_value = str(tmp_path / "run")
+    workspace.get_log_config_file_path.return_value = str(tmp_path / "log_config.json")
+    engine = MagicMock()
+    engine.get_workspace.return_value = workspace
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = engine
+    fl_ctx.get_job_id.return_value = "job-1"
+    return fl_ctx
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+@pytest.mark.parametrize("config", ["DEBUG", "20", LogMode.MSG_ONLY, LogMode.RELOAD])
+def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_path, config):
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert error is None
+    dynamic.assert_called_once_with(
+        config=config,
+        dir_path=str(tmp_path / "run"),
+        reload_path=str(tmp_path / "log_config.json"),
+    )
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+def test_remote_job_log_rejects_inline_json(tmp_path, command_class, dynamic_path):
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process('{"version": 1}', _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+def test_remote_job_log_rejects_existing_file_path(tmp_path, command_class, dynamic_path):
+    config_path = tmp_path / "attacker-log-config.json"
+    config_path.write_text('{"version": 1}', encoding="utf-8")
+
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(str(config_path), _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+
+
+@pytest.mark.parametrize("command_class", [ServerConfigureJobLogCommand, ClientConfigureJobLogCommand])
+def test_remote_job_log_rejects_dict_config_factory_before_execution(tmp_path, command_class):
+    factory_calls = []
+
+    def harmless_factory():
+        factory_calls.append(True)
+        return logging.NullHandler()
+
+    config = {
+        "version": 1,
+        "handlers": {"factory": {"()": harmless_factory}},
+        "root": {"level": "INFO", "handlers": ["factory"]},
+    }
+
+    error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    assert factory_calls == []

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -54,41 +54,30 @@ def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_p
 
 
 @pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
-def test_remote_job_log_rejects_inline_json(tmp_path, command_class, dynamic_path):
-    with patch(dynamic_path) as dynamic:
-        error = command_class().process('{"version": 1}', _log_command_context(tmp_path))
-
-    assert "only supports log levels and built-in log modes" in error
-    dynamic.assert_not_called()
-
-
-@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
-def test_remote_job_log_rejects_existing_file_path(tmp_path, command_class, dynamic_path):
-    config_path = tmp_path / "attacker-log-config.json"
-    config_path.write_text('{"version": 1}', encoding="utf-8")
-
-    with patch(dynamic_path) as dynamic:
-        error = command_class().process(str(config_path), _log_command_context(tmp_path))
-
-    assert "only supports log levels and built-in log modes" in error
-    dynamic.assert_not_called()
-
-
-@pytest.mark.parametrize("command_class", [ServerConfigureJobLogCommand, ClientConfigureJobLogCommand])
-def test_remote_job_log_rejects_dict_config_factory_before_execution(tmp_path, command_class):
+@pytest.mark.parametrize("config_type", ["inline-json", "file-path", "dict-factory"])
+def test_remote_job_log_rejects_unsafe_config(tmp_path, command_class, dynamic_path, config_type):
     factory_calls = []
 
     def harmless_factory():
         factory_calls.append(True)
         return logging.NullHandler()
 
-    config = {
-        "version": 1,
-        "handlers": {"factory": {"()": harmless_factory}},
-        "root": {"level": "INFO", "handlers": ["factory"]},
-    }
+    if config_type == "inline-json":
+        config = '{"version": 1}'
+    elif config_type == "file-path":
+        config_path = tmp_path / "attacker-log-config.json"
+        config_path.write_text('{"version": 1}', encoding="utf-8")
+        config = str(config_path)
+    else:
+        config = {
+            "version": 1,
+            "handlers": {"factory": {"()": harmless_factory}},
+            "root": {"level": "INFO", "handlers": ["factory"]},
+        }
 
-    error = command_class().process(config, _log_command_context(tmp_path))
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(config, _log_command_context(tmp_path))
 
     assert "only supports log levels and built-in log modes" in error
-    assert factory_calls == []
+    dynamic.assert_not_called()
+    assert not factory_calls

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -26,11 +26,32 @@ from nvflare.fuel.f3.cellnet.defs import MessageHeaderKey
 from nvflare.fuel.f3.cellnet.defs import ReturnCode as F3ReturnCode
 from nvflare.private.defs import CellMessageHeaderKeys, ClientRegMsgKey, JobFailureMsgKey, new_cell_message
 from nvflare.private.fed.authenticator import MISSING_CLIENT_FQCN
-from nvflare.private.fed.server.fed_server import FederatedServer
+from nvflare.private.fed.server.fed_server import BaseServer, FederatedServer
 from nvflare.private.fed.server.server_state import DEFAULT_SERVICE_SESSION_ID, HotState
 
 
 class TestFederatedServer:
+    def test_production_listener_bindings_remain_wildcard_by_default(self):
+        server = object.__new__(FederatedServer)
+
+        with (
+            patch("nvflare.private.fed.server.fed_server.Cell") as cell_cls,
+            patch("nvflare.private.fed.server.fed_server.mpm.add_cleanup_cb"),
+            patch("nvflare.private.fed.server.fed_server.threading.Thread"),
+        ):
+            BaseServer.deploy(
+                server,
+                args=MagicMock(),
+                grpc_args={
+                    "service": {"target": "server.example:8002", "scheme": "tcp"},
+                    "admin_port": 8003,
+                },
+            )
+
+        cell_args = cell_cls.call_args.kwargs
+        assert cell_args["root_url"] == ["tcp://0:8002", "tcp://0:8003"]
+        assert cell_args["internal_listener_host"] is None
+
     def test_resolve_client_fqcn_for_auth_fails_closed_for_registered_client_with_missing_fqcn(self):
         server = object.__new__(FederatedServer)
         client = MagicMock()

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -104,7 +104,6 @@ class _MockConnection:
         self.successes = []
         self.dicts = []
         self.tables = []
-        self.meta = {}
 
     def get_prop(self, key, default=None):
         return self._props.get(key, default)
@@ -128,9 +127,6 @@ class _MockConnection:
         table = _MockTable(headers=headers, name=name)
         self.tables.append(table)
         return table
-
-    def update_meta(self, meta):
-        self.meta.update(meta)
 
 
 class _MockTable:
@@ -1668,7 +1664,7 @@ def test_configure_job_log_all_targets_server_and_clients(tmp_path, monkeypatch)
     engine.configure_job_log.assert_called_once_with("job-1", "DEBUG")
     assert processed == [client_replies]
     assert any("successfully configured server job job-1 log" in msg for msg, _meta in conn.strings)
-    assert not conn.meta
+    assert not conn.errors
 
 
 def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypatch):
@@ -1706,7 +1702,7 @@ def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypat
 
     engine.configure_job_log.assert_not_called()
     assert len(processed) == 1
-    assert not conn.meta
+    assert not conn.errors
 
 
 def _reply_with_return_code(return_code, body):
@@ -1747,10 +1743,7 @@ def test_configure_job_log_client_failure_sets_error_meta(tmp_path, monkeypatch,
     args = ["configure_job_log", "job-1", "client", *target_clients.values(), "DEBUG"]
     module.configure_job_log(conn, args)
 
-    assert conn.meta == {
-        MetaKey.STATUS: MetaStatusValue.ERROR,
-        MetaKey.INFO: "one or more clients failed to configure job logging",
-    }
+    assert conn.errors == [("one or more clients failed to configure job logging", None)]
 
 
 def test_authorize_job_id_hides_jobs_from_other_studies(monkeypatch):

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1716,68 +1716,40 @@ def _reply_with_return_code(return_code, body):
 
 
 @pytest.mark.parametrize(
-    "reply, expected_info",
+    ("target_clients", "client_replies"),
     [
-        (error_reply("log configuration refused"), "log configuration refused"),
-        (_reply_with_return_code("timeout", "request timed out"), "request timed out"),
-        (None, "no reply"),
+        (
+            {"token-a": "site-a"},
+            [ClientReply("token-a", "site-a", None, error_reply("log configuration refused"))],
+        ),
+        (
+            {"token-a": "site-a"},
+            [ClientReply("token-a", "site-a", None, _reply_with_return_code("timeout", "request timed out"))],
+        ),
+        ({"token-a": "site-a"}, [ClientReply("token-a", "site-a", None, None)]),
+        ({"token-a": "site-a"}, []),
+        (
+            {"token-a": "site-a", "token-b": "site-b"},
+            [ClientReply("token-a", "site-a", None, ok_reply())],
+        ),
     ],
+    ids=["rejected", "timeout", "empty-reply", "no-responses", "partial-responses"],
 )
-def test_configure_job_log_client_failure_sets_error_meta(tmp_path, monkeypatch, reply, expected_info):
+def test_configure_job_log_client_failure_sets_error_meta(tmp_path, monkeypatch, target_clients, client_replies):
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
     workspace = _FakeWorkspace(tmp_path)
     engine = _FakeServerEngine(workspace)
     engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
-    conn = _MockConnection(app_ctx=engine)
+    conn = _MockConnection(app_ctx=engine, props={JobCommandModule.TARGET_CLIENTS: target_clients})
     module = JobCommandModule()
-    client_reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=reply)
-    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [client_reply])
+    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: client_replies)
 
-    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "DEBUG"])
-
-    assert conn.meta[MetaKey.STATUS] == MetaStatusValue.ERROR
-    assert "site-a" in conn.meta[MetaKey.INFO]
-    assert expected_info in conn.meta[MetaKey.INFO]
-
-
-def test_configure_job_log_no_client_responses_sets_error_meta(tmp_path, monkeypatch):
-    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
-    workspace = _FakeWorkspace(tmp_path)
-    engine = _FakeServerEngine(workspace)
-    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
-    conn = _MockConnection(
-        app_ctx=engine,
-        props={JobCommandModule.TARGET_CLIENTS: {"token-a": "site-a"}},
-    )
-    module = JobCommandModule()
-    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [])
-
-    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "DEBUG"])
+    args = ["configure_job_log", "job-1", "client", *target_clients.values(), "DEBUG"]
+    module.configure_job_log(conn, args)
 
     assert conn.meta == {
         MetaKey.STATUS: MetaStatusValue.ERROR,
-        MetaKey.INFO: "site-a: no reply",
-    }
-
-
-def test_configure_job_log_partial_client_responses_set_error_meta(tmp_path, monkeypatch):
-    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
-    workspace = _FakeWorkspace(tmp_path)
-    engine = _FakeServerEngine(workspace)
-    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
-    conn = _MockConnection(
-        app_ctx=engine,
-        props={JobCommandModule.TARGET_CLIENTS: {"token-a": "site-a", "token-b": "site-b"}},
-    )
-    module = JobCommandModule()
-    client_reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())
-    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [client_reply])
-
-    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "site-b", "DEBUG"])
-
-    assert conn.meta == {
-        MetaKey.STATUS: MetaStatusValue.ERROR,
-        MetaKey.INFO: "site-b: no reply",
+        MetaKey.INFO: "one or more clients failed to configure job logging",
     }
 
 

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -36,6 +36,7 @@ from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
 from nvflare.fuel.hci.server.authz import PreAuthzReturnCode
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.lighter.tool_consts import NVFLARE_SUBMITTER_CRT_FILE
+from nvflare.private.admin_defs import MsgHeader, error_reply, ok_reply
 from nvflare.private.fed.server import cmd_utils as cmd_utils_module
 from nvflare.private.fed.server import job_cmds as job_cmds_module
 from nvflare.private.fed.server.job_cmds import (
@@ -43,6 +44,7 @@ from nvflare.private.fed.server.job_cmds import (
     _create_get_job_log_cmd_parser,
     _create_list_job_cmd_parser,
 )
+from nvflare.private.fed.server.message_send import ClientReply
 
 TEST_CASES = [
     (
@@ -102,6 +104,7 @@ class _MockConnection:
         self.successes = []
         self.dicts = []
         self.tables = []
+        self.meta = {}
 
     def get_prop(self, key, default=None):
         return self._props.get(key, default)
@@ -125,6 +128,9 @@ class _MockConnection:
         table = _MockTable(headers=headers, name=name)
         self.tables.append(table)
         return table
+
+    def update_meta(self, meta):
+        self.meta.update(meta)
 
 
 class _MockTable:
@@ -1652,7 +1658,7 @@ def test_configure_job_log_all_targets_server_and_clients(tmp_path, monkeypatch)
     engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
     conn = _MockConnection(app_ctx=engine)
     module = JobCommandModule()
-    client_replies = [object()]
+    client_replies = [ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())]
     monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: client_replies)
     processed = []
     monkeypatch.setattr(module, "process_replies_to_table", lambda conn, replies: processed.append(replies))
@@ -1662,6 +1668,7 @@ def test_configure_job_log_all_targets_server_and_clients(tmp_path, monkeypatch)
     engine.configure_job_log.assert_called_once_with("job-1", "DEBUG")
     assert processed == [client_replies]
     assert any("successfully configured server job job-1 log" in msg for msg, _meta in conn.strings)
+    assert not conn.meta
 
 
 def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypatch):
@@ -1689,7 +1696,7 @@ def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypat
     def _send_request_to_clients(conn, message):
         assert conn.get_prop(JobCommandModule.TARGET_CLIENT_TOKENS) == ["token-a"]
         assert conn.get_prop(JobCommandModule.TARGET_CLIENT_NAMES) == ["site-a"]
-        return [object()]
+        return [ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())]
 
     processed = []
     monkeypatch.setattr(module, "send_request_to_clients", _send_request_to_clients)
@@ -1699,6 +1706,79 @@ def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypat
 
     engine.configure_job_log.assert_not_called()
     assert len(processed) == 1
+    assert not conn.meta
+
+
+def _reply_with_return_code(return_code, body):
+    reply = ok_reply(body=body)
+    reply.set_header(MsgHeader.RETURN_CODE, return_code)
+    return reply
+
+
+@pytest.mark.parametrize(
+    "reply, expected_info",
+    [
+        (error_reply("log configuration refused"), "log configuration refused"),
+        (_reply_with_return_code("timeout", "request timed out"), "request timed out"),
+        (None, "no reply"),
+    ],
+)
+def test_configure_job_log_client_failure_sets_error_meta(tmp_path, monkeypatch, reply, expected_info):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
+    conn = _MockConnection(app_ctx=engine)
+    module = JobCommandModule()
+    client_reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=reply)
+    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [client_reply])
+
+    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "DEBUG"])
+
+    assert conn.meta[MetaKey.STATUS] == MetaStatusValue.ERROR
+    assert "site-a" in conn.meta[MetaKey.INFO]
+    assert expected_info in conn.meta[MetaKey.INFO]
+
+
+def test_configure_job_log_no_client_responses_sets_error_meta(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={JobCommandModule.TARGET_CLIENTS: {"token-a": "site-a"}},
+    )
+    module = JobCommandModule()
+    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [])
+
+    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "DEBUG"])
+
+    assert conn.meta == {
+        MetaKey.STATUS: MetaStatusValue.ERROR,
+        MetaKey.INFO: "site-a: no reply",
+    }
+
+
+def test_configure_job_log_partial_client_responses_set_error_meta(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={JobCommandModule.TARGET_CLIENTS: {"token-a": "site-a", "token-b": "site-b"}},
+    )
+    module = JobCommandModule()
+    client_reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())
+    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: [client_reply])
+
+    module.configure_job_log(conn, ["configure_job_log", "job-1", "client", "site-a", "site-b", "DEBUG"])
+
+    assert conn.meta == {
+        MetaKey.STATUS: MetaStatusValue.ERROR,
+        MetaKey.INFO: "site-b: no reply",
+    }
 
 
 def test_authorize_job_id_hides_jobs_from_other_studies(monkeypatch):


### PR DESCRIPTION
## Summary

- restrict remote job log configuration to log levels and built-in log modes
- bind SimEnv/PocEnv FL, admin, and internal listeners to IPv4 loopback
- preserve wildcard listener defaults for non-localhost production deployments
- combine the 2.8 backports of #5120 and #5122

## Testing

- targeted unit tests: 42 passed
- project style checks: ./runtest.sh -s