### PR TITLE
[2.7] Restrict remote log configuration and local listeners

### DIFF
--- a/docs/user_guide/admin_guide/configurations/logging_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/logging_configuration.rst
@@ -300,7 +300,7 @@ Modifying Logging Configurations
 
 Log Config Argument
 ===================
-We provide a log config argument (``-l`` or ``log_config`` in simulator mode, and ``config`` in the dynamic logging admin commands for POC and production mode).
+We provide a log config argument (``-l`` or ``log_config``) in simulator mode.
 This argument can be any of the following:
 
 - log configuration json file (``/path/to/my_log_config.json``, ``my_log_config.json``)
@@ -311,7 +311,6 @@ This argument can be any of the following:
     - ``verbose``: debug level logs with detailed log attributes
 
 - log level name or number (``debug``, ``info``, ``warning``, ``error``, ``critical``, ``30``)
-- For admin commands only: read the current log configuration file log_config.json from the workspace (``reload``)
 
 
 Simulator log configuration

--- a/docs/user_guide/admin_guide/configurations/logging_configuration.rst
+++ b/docs/user_guide/admin_guide/configurations/logging_configuration.rst
@@ -380,9 +380,8 @@ Note these command effects will last until reconfiguration or as long as the cor
 However these commands do not overwrite the log configuration file in the workspace- the log configuration file can be reloaded using "reload".
 
 - **target**: ``server``, ``client <clients>...``, or ``all``
-- **config**: the log config argument can be any of the following (For more details, refer to :ref:`Log Config Argument <log_config_argument>` above):
+- **config**: the remote log config argument can only be one of the following:
 
-    - path to a json log configuration file (``/path/to/my_log_config.json``)
     - predefined log mode (``concise``, ``full``, ``verbose``)
     - log level name or number (``debug``, ``info``, ``warning``, ``error``, ``critical``, ``30``)
     - read the current log configuration file log_config.json from the workspace (``reload``)

--- a/docs/user_guide/admin_guide/deployment/operation.rst
+++ b/docs/user_guide/admin_guide/deployment/operation.rst
@@ -30,7 +30,7 @@ commands shown as examples of how they may be run with a description.
     ,``check_status client clientname``,"The name, token, and status of the specified client with *clientname* are displayed."
     submit_job,``submit_job job_folder_name``,Submits the job to the server.
     list_jobs,``list_jobs``,Lists the jobs on the server. (Options: [-n name_prefix] [-d] [job_id_prefix])
-    configure_job_log,``configure_job_log job_id server config``,"Configure the job log on the server. (*config* can be a path to a json config file, a levelname/levelnumber, or 'reload')"
+    configure_job_log,``configure_job_log job_id server config``,"Configure the job log on the server. (*config* can be a built-in log mode, a levelname/levelnumber, or 'reload')"
     ,``configure_job_log job_id client <client-name>... config``,Configure the job log on the target client(s).
     abort_job,``abort_job job_id``,Aborts the job of the specified job_id if it is running or dispatched
     clone_job,``clone_job job_id``,Creates a copy of the specified job with a new job_id
@@ -49,7 +49,7 @@ commands shown as examples of how they may be run with a description.
     ,``ls clientname -SR``,List files in workspace root directory (-S: sort by file size; -R: list subdirectories recursively)
     pwd,``pwd server``,Print the name of workspace root directory
     ,``pwd clientname``,Print the name of workspace root directory
-    configure_site_log,``configure_job_log server config``,"Configure the site log on the server. (*config* can be a path to a json config file, a levelname/levelnumber, or 'reload')"
+    configure_site_log,``configure_job_log server config``,"Configure the site log on the server. (*config* can be a built-in log mode, a levelname/levelnumber, or 'reload')"
     ,``configure_site_log client <client-name>... config``,Configure the site log on the target client(s).
     sys_info,``sys_info server``,Get system information
     ,``sys_info client *clientname*``,Get system information. Individual clients can be shutdown by specifying *clientname*.

--- a/examples/tutorials/logging.ipynb
+++ b/examples/tutorials/logging.ipynb
@@ -316,7 +316,6 @@
         "- **target**: server, client <clients>..., or all\n",
         "- **config**: log configuration\n",
         "    - log mode (concise, full, verbose)\n",
-        "    - path to a json log configuration file (/path/to/my_log_config.json)\n",
         "    - log level name/number (debug, INFO, 30)\n",
         "    - read the current log configuration file (reload)\n",
         "\n",
@@ -359,8 +358,7 @@
       "source": [
         "- ``configure_job_log <job_id> server debug``\n",
         "- ``configure_job_log <job_id> client site-1 debug``\n",
-        "- ``configure_job_log <job_id> all info``\n",
-        "- ``configure_job_log <job_id> all <path>/<to>/custom_log_config.json``"
+        "- ``configure_job_log <job_id> all info``"
       ]
     },
     {

--- a/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.7_logging/logging.ipynb
+++ b/examples/tutorials/self-paced-training/part-1_federated_learning_introduction/chapter-1_running_federated_learning_applications/01.7_logging/logging.ipynb
@@ -86,7 +86,6 @@
     "configure_job_log <job_id> server debug\n",
     "configure_job_log <job_id> client site-1 debug\n",
     "configure_job_log <job_id> all info\n",
-    "configure_job_log <job_id> all <path>/<to>/custom_log_config.json\n",
     "```\n",
     "\n",
     "The ```configure_site_log``` is the FLARE Console command used to configure the site log configuration.  \n",

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -59,7 +59,13 @@ class ConnectorManager:
     Manages creation of connectors
     """
 
-    def __init__(self, communicator: Communicator, secure: bool, comm_configurator: CommConfigurator):
+    def __init__(
+        self,
+        communicator: Communicator,
+        secure: bool,
+        comm_configurator: CommConfigurator,
+        internal_listener_host: str = None,
+    ):
         self._name = self.__class__.__name__
         self.logger = get_obj_logger(self)
 
@@ -76,6 +82,7 @@ class ConnectorManager:
         self.adhoc_allowed = comm_configurator.allow_adhoc_connections(_Defaults.ALLOW_ADHOC_CONNECTIONS)
         self.adhoc_scheme = comm_configurator.get_adhoc_connection_scheme(_Defaults.SCHEME_FOR_ADHOC_CONNECTIONS)
         self.adhoc_resources = {}
+        internal_host_configured = False
 
         # load config if any
         comm_config = comm_configurator.get_config()
@@ -84,11 +91,16 @@ class ConnectorManager:
             if int_conf:
                 self.int_scheme = int_conf.get(_KEY_SCHEME)
                 self.int_resources = int_conf.get(_KEY_RESOURCES)
+                internal_host_configured = DriverParams.HOST.value in self.int_resources
 
             adhoc_conf = self._validate_conn_config(comm_config, _KEY_ADHOC)
             if adhoc_conf:
                 self.adhoc_scheme = adhoc_conf.get(_KEY_SCHEME)
                 self.adhoc_resources = adhoc_conf.get(_KEY_RESOURCES)
+
+        if internal_listener_host and not internal_host_configured:
+            self.int_resources[DriverParams.HOST.value] = internal_listener_host
+            self.int_resources.setdefault(DriverParams.LISTEN_HOST.value, internal_listener_host)
 
         # default conn sec
         conn_sec = self.int_resources.get(DriverParams.CONNECTION_SECURITY)

--- a/nvflare/fuel/f3/cellnet/connector_manager.py
+++ b/nvflare/fuel/f3/cellnet/connector_manager.py
@@ -99,6 +99,7 @@ class ConnectorManager:
                 self.adhoc_resources = adhoc_conf.get(_KEY_RESOURCES)
 
         if internal_listener_host and not internal_host_configured:
+            self.int_resources = dict(self.int_resources)
             self.int_resources[DriverParams.HOST.value] = internal_listener_host
             self.int_resources.setdefault(DriverParams.LISTEN_HOST.value, internal_listener_host)
 

--- a/nvflare/fuel/f3/cellnet/core_cell.py
+++ b/nvflare/fuel/f3/cellnet/core_cell.py
@@ -288,6 +288,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
         bulk_check_interval=0.5,
         bulk_process_interval=0.5,
         max_bulk_size=100,
+        internal_listener_host: str = None,
     ):
         """
 
@@ -300,6 +301,7 @@ class CoreCell(MessageReceiver, EndpointMonitor):
             create_internal_listener: whether to create an internal listener for child cells
             parent_url: url for connecting to parent cell
             parent_resources: extra resources for making connection to parent
+            internal_listener_host: host for the internal listener to advertise and bind to
 
         FQCN is the names of all ancestor, concatenated with dots.
 
@@ -407,7 +409,10 @@ class CoreCell(MessageReceiver, EndpointMonitor):
 
         self.endpoint = ep
         self.connector_manager = ConnectorManager(
-            communicator=self.communicator, secure=secure, comm_configurator=comm_configurator
+            communicator=self.communicator,
+            secure=secure,
+            comm_configurator=comm_configurator,
+            internal_listener_host=internal_listener_host,
         )
 
         self.communicator.register_message_receiver(app_id=self.APP_ID, receiver=self)

--- a/nvflare/fuel/f3/drivers/driver_params.py
+++ b/nvflare/fuel/f3/drivers/driver_params.py
@@ -37,6 +37,7 @@ class DriverParams(str, Enum):
     CUSTOM_CA_CERT = "custom_ca_cert"
     SECURE = "secure"
     PORTS = "ports"
+    LISTEN_HOST = "listen_host"
     SOCKET = "socket"
     LOCAL_ADDR = "local_addr"
     PEER_ADDR = "peer_addr"

--- a/nvflare/fuel/f3/drivers/net_utils.py
+++ b/nvflare/fuel/f3/drivers/net_utils.py
@@ -272,7 +272,7 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
 
     Args:
         scheme: The transport scheme
-        resources: The resource restrictions like port ranges
+        resources: Resource restrictions. "host" is advertised; "listen_host" limits the bind address.
 
     Returns:
         a tuple with connecting and listening URL
@@ -284,12 +284,15 @@ def get_tcp_urls(scheme: str, resources: dict) -> (str, str):
     if not host:
         host = "localhost"
 
+    listening_host = resources.get(DriverParams.LISTEN_HOST.value) if resources else None
+    if not listening_host:
+        listening_host = "0"
+
     port = get_open_tcp_port(resources)
     if not port:
         raise CommError(CommError.BAD_CONFIG, "Can't find an open port in the specified range")
 
-    # Always listen on all interfaces
-    listening_url = f"{scheme}://0:{port}"
+    listening_url = f"{scheme}://{listening_host}:{port}"
     connect_url = f"{scheme}://{host}:{port}"
 
     return connect_url, listening_url

--- a/nvflare/fuel/utils/log_utils.py
+++ b/nvflare/fuel/utils/log_utils.py
@@ -342,21 +342,22 @@ def apply_log_config(dict_config, dir_path: str = "", file_prefix: str = ""):
     logging.captureWarnings(True)  # route Python warnings through logging so they reach file handlers
 
 
-def dynamic_log_config(config: Union[dict, str], dir_path: str, reload_path: str):
+def dynamic_log_config(config: Union[dict, str], dir_path: str, reload_path: str, allow_file_config: bool = True):
     # Dynamically configure log given a config (dict, filepath, LogMode, or level), apply the config to the proper locations.
 
     if isinstance(config, dict):
         apply_log_config(config, dir_path)
     elif isinstance(config, str):
         # Handle pre-defined LogModes
-        if config == LogMode.RELOAD:
+        reload_config = config == LogMode.RELOAD
+        if reload_config:
             config = reload_path
         elif log_config := logmode_config_dict.get(config):
             apply_log_config(copy.deepcopy(log_config), dir_path)
             return
 
         # Read config file
-        if os.path.isfile(config):
+        if (allow_file_config or reload_config) and os.path.isfile(config):
             with open(config, "r") as f:
                 dict_config = json.load(f)
 

--- a/nvflare/fuel/utils/log_utils.py
+++ b/nvflare/fuel/utils/log_utils.py
@@ -398,7 +398,7 @@ def validate_site_log_config(config) -> str:
         return config
 
     level = int(config) if config.isdigit() else getattr(logging, config.upper(), None)
-    if level is None or not (0 <= level <= 50):
+    if not isinstance(level, int) or not (0 <= level <= 50):
         raise ValueError("configure_site_log only supports log levels and built-in log modes")
 
     return config

--- a/nvflare/fuel/utils/log_utils.py
+++ b/nvflare/fuel/utils/log_utils.py
@@ -378,6 +378,31 @@ def dynamic_log_config(config: Union[dict, str], dir_path: str, reload_path: str
         )
 
 
+def validate_site_log_config(config) -> str:
+    """Validate site-wide log configuration input.
+
+    Site-wide log reconfiguration is intentionally narrower than general
+    dictConfig support: only simple log levels and built-in log modes are
+    allowed on this admin command path.
+    """
+
+    if not isinstance(config, str):
+        raise ValueError("configure_site_log only supports log levels and built-in log modes")
+
+    config = config.strip()
+    if not config:
+        raise ValueError("configure_site_log only supports log levels and built-in log modes")
+
+    if config == LogMode.RELOAD or config in logmode_config_dict:
+        return config
+
+    level = int(config) if config.isdigit() else getattr(logging, config.upper(), None)
+    if level is None or not (0 <= level <= 50):
+        raise ValueError("configure_site_log only supports log levels and built-in log modes")
+
+    return config
+
+
 def add_log_file_handler(log_file_name):
     root_logger = logging.getLogger()
     main_handler = root_logger.handlers[0]

--- a/nvflare/private/fed/client/admin_commands.py
+++ b/nvflare/private/fed/client/admin_commands.py
@@ -17,7 +17,7 @@
 from nvflare.apis.fl_constant import AdminCommandNames, FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_site_log_config
 from nvflare.private.fed.client.client_status import get_status_message
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import InfoCollector
@@ -272,8 +272,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/private/fed/client/admin_commands.py
+++ b/nvflare/private/fed/client/admin_commands.py
@@ -277,6 +277,7 @@ class ConfigureJobLogCommand(CommandProcessor):
                 config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
+                allow_file_config=False,
             )
         except Exception as e:
             return secure_format_exception(e)

--- a/nvflare/private/fed/client/sys_cmd.py
+++ b/nvflare/private/fed/client/sys_cmd.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from nvflare.apis.fl_constant import FLContextKey, SystemComponents
 from nvflare.apis.fl_context import FLContext
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_site_log_config
 from nvflare.private.admin_defs import Message, error_reply, ok_reply
 from nvflare.private.defs import SysCommandTopic
 from nvflare.private.fed.client.admin import RequestProcessor
@@ -93,8 +93,9 @@ class ConfigureSiteLogProcessor(RequestProcessor):
         workspace = fl_ctx.get_prop(FLContextKey.WORKSPACE_OBJECT)
 
         try:
+            config = validate_site_log_config(req.body)
             dynamic_log_config(
-                config=req.body, dir_path=workspace.get_root_dir(), reload_path=workspace.get_log_config_file_path()
+                config=config, dir_path=workspace.get_root_dir(), reload_path=workspace.get_log_config_file_path()
             )
         except Exception as e:
             return error_reply(secure_format_exception(e))

--- a/nvflare/private/fed/client/sys_cmd.py
+++ b/nvflare/private/fed/client/sys_cmd.py
@@ -95,7 +95,10 @@ class ConfigureSiteLogProcessor(RequestProcessor):
         try:
             config = validate_site_log_config(req.body)
             dynamic_log_config(
-                config=config, dir_path=workspace.get_root_dir(), reload_path=workspace.get_log_config_file_path()
+                config=config,
+                dir_path=workspace.get_root_dir(),
+                reload_path=workspace.get_log_config_file_path(),
+                allow_file_config=False,
             )
         except Exception as e:
             return error_reply(secure_format_exception(e))

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -89,6 +89,8 @@ from .server_status import ServerStatus
 
 
 class BaseServer(ABC):
+    LISTENING_HOST = None
+
     def __init__(
         self,
         project_name=None,
@@ -178,7 +180,7 @@ class BaseServer(ABC):
         if len(parts) != 2:
             raise RuntimeError(f"bad service target: {target}")
 
-        listening_host = "127.0.0.1" if parts[0].rstrip(".").lower() == "localhost" else None
+        listening_host = self.LISTENING_HOST
         fl_port = int(parts[1])
 
         # get admin port

--- a/nvflare/private/fed/server/fed_server.py
+++ b/nvflare/private/fed/server/fed_server.py
@@ -178,14 +178,16 @@ class BaseServer(ABC):
         if len(parts) != 2:
             raise RuntimeError(f"bad service target: {target}")
 
+        listening_host = "127.0.0.1" if parts[0].rstrip(".").lower() == "localhost" else None
         fl_port = int(parts[1])
 
         # get admin port
         admin_port = int(grpc_args.get("admin_port", fl_port))
 
-        root_url = [f"{scheme}://0:{fl_port}"]
+        url_host = listening_host or "0"
+        root_url = [f"{scheme}://{url_host}:{fl_port}"]
         if admin_port != fl_port:
-            root_url.append(f"{scheme}://0:{admin_port}")
+            root_url.append(f"{scheme}://{url_host}:{admin_port}")
 
         my_fqcn = FQCN.ROOT_SERVER
         self.cell = Cell(
@@ -195,6 +197,7 @@ class BaseServer(ABC):
             credentials=credentials,
             create_internal_listener=True,
             parent_url=parent_url,
+            internal_listener_host=listening_host,
         )
 
         self.cell.start()

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -456,6 +456,7 @@ class ConfigureJobLogCommand(CommandProcessor):
                 config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
+                allow_file_config=False,
             )
         except Exception as e:
             return secure_format_exception(e)

--- a/nvflare/private/fed/server/server_commands.py
+++ b/nvflare/private/fed/server/server_commands.py
@@ -29,7 +29,7 @@ from nvflare.apis.fl_constant import (
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable, make_reply
 from nvflare.apis.utils.fl_context_utils import gen_new_peer_ctx
-from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger
+from nvflare.fuel.utils.log_utils import dynamic_log_config, get_obj_logger, validate_site_log_config
 from nvflare.private.defs import SpecialTaskName, TaskConstant
 from nvflare.security.logging import secure_format_exception, secure_format_traceback
 from nvflare.widgets.widget import WidgetID
@@ -451,8 +451,9 @@ class ConfigureJobLogCommand(CommandProcessor):
         engine = fl_ctx.get_engine()
         workspace = engine.get_workspace()
         try:
+            config = validate_site_log_config(data)
             dynamic_log_config(
-                config=data,
+                config=config,
                 dir_path=workspace.get_run_dir(fl_ctx.get_job_id()),
                 reload_path=workspace.get_log_config_file_path(),
             )

--- a/nvflare/private/fed/server/sys_cmd.py
+++ b/nvflare/private/fed/server/sys_cmd.py
@@ -153,7 +153,10 @@ class SystemCommandModule(CommandModule, CommandUtil):
             workspace = engine.get_workspace()
             try:
                 dynamic_log_config(
-                    config=config, dir_path=workspace.get_root_dir(), reload_path=workspace.get_log_config_file_path()
+                    config=config,
+                    dir_path=workspace.get_root_dir(),
+                    reload_path=workspace.get_log_config_file_path(),
+                    allow_file_config=False,
                 )
             except Exception as e:
                 conn.append_error(

--- a/nvflare/private/fed/server/sys_cmd.py
+++ b/nvflare/private/fed/server/sys_cmd.py
@@ -21,7 +21,7 @@ from nvflare.fuel.hci.conn import Connection
 from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue, make_meta
 from nvflare.fuel.hci.reg import CommandModule, CommandModuleSpec, CommandSpec
 from nvflare.fuel.hci.server.authz import PreAuthzReturnCode
-from nvflare.fuel.utils.log_utils import dynamic_log_config
+from nvflare.fuel.utils.log_utils import dynamic_log_config, validate_site_log_config
 from nvflare.private.admin_defs import MsgHeader, ReturnCode
 from nvflare.private.defs import SysCommandTopic
 from nvflare.private.fed.server.admin import new_message
@@ -139,7 +139,11 @@ class SystemCommandModule(CommandModule, CommandUtil):
             return
 
         target_type = args[1]
-        config = args[-1]
+        try:
+            config = validate_site_log_config(args[-1])
+        except ValueError as e:
+            conn.append_error(str(e), meta=make_meta(MetaStatusValue.SYNTAX_ERROR, info=str(e)))
+            return
 
         if target_type in [self.TARGET_TYPE_SERVER, self.TARGET_TYPE_ALL]:
             engine = conn.app_ctx

--- a/nvflare/private/fed/simulator/simulator_server.py
+++ b/nvflare/private/fed/simulator/simulator_server.py
@@ -94,6 +94,8 @@ class SimulatorIdentityAsserter(IdentityAsserter):
 
 
 class SimulatorServer(FederatedServer):
+    LISTENING_HOST = "127.0.0.1"
+
     def __init__(
         self,
         project_name=None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ app_opt =
     %(TRACKING)s
     %(MONITORING)s
     pytorch_lightning
-    xgboost
+    xgboost<3.4
     bitsandbytes
 app_opt_mac =
     %(PT)s

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
@@ -48,3 +48,24 @@ def test_internal_listener_host_does_not_override_configured_host():
 
     assert manager.int_resources[DriverParams.HOST.value] == "10.0.0.5"
     assert DriverParams.LISTEN_HOST.value not in manager.int_resources
+
+
+def test_internal_listener_host_does_not_mutate_shared_resources():
+    resources = {}
+    comm_configurator = MagicMock()
+    comm_configurator.get_config.return_value = {"internal": {"scheme": "tcp", "resources": resources}}
+
+    ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+        internal_listener_host="127.0.0.1",
+    )
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+    )
+
+    assert DriverParams.HOST.value not in resources
+    assert DriverParams.LISTEN_HOST.value not in manager.int_resources

--- a/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
+++ b/tests/unit_test/fuel/f3/cellnet/connector_manager_test.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+from nvflare.fuel.f3.cellnet.connector_manager import ConnectorManager
+from nvflare.fuel.f3.drivers.driver_params import DriverParams
+
+
+def test_internal_listener_host_overrides_default_resources():
+    comm_configurator = MagicMock()
+    comm_configurator.get_config.return_value = None
+
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+        internal_listener_host="127.0.0.1",
+    )
+
+    assert manager.int_resources[DriverParams.HOST.value] == "127.0.0.1"
+    assert manager.int_resources[DriverParams.LISTEN_HOST.value] == "127.0.0.1"
+
+
+def test_internal_listener_host_does_not_override_configured_host():
+    comm_configurator = MagicMock()
+    comm_configurator.get_config.return_value = {
+        "internal": {"scheme": "tcp", "resources": {DriverParams.HOST.value: "10.0.0.5"}}
+    }
+
+    manager = ConnectorManager(
+        communicator=MagicMock(),
+        secure=False,
+        comm_configurator=comm_configurator,
+        internal_listener_host="127.0.0.1",
+    )
+
+    assert manager.int_resources[DriverParams.HOST.value] == "10.0.0.5"
+    assert DriverParams.LISTEN_HOST.value not in manager.int_resources

--- a/tests/unit_test/fuel/f3/drivers/net_utils_test.py
+++ b/tests/unit_test/fuel/f3/drivers/net_utils_test.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import patch
+
 from nvflare.fuel.f3.drivers.driver_params import DriverParams
-from nvflare.fuel.f3.drivers.net_utils import encode_url, parse_url
+from nvflare.fuel.f3.drivers.net_utils import encode_url, get_tcp_urls, parse_url
 
 
 class TestNetUtils:
@@ -37,3 +39,19 @@ class TestNetUtils:
         assert int(params.get(DriverParams.PORT)) == 8002
         assert params.get("a") == "123"
         assert params.get("b") == "test"
+
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_uses_explicit_listening_host(self, _):
+        resources = {
+            DriverParams.HOST.value: "server.example",
+            DriverParams.LISTEN_HOST.value: "127.0.0.1",
+        }
+
+        assert get_tcp_urls("tcp", resources) == ("tcp://server.example:1234", "tcp://127.0.0.1:1234")
+
+    @patch("nvflare.fuel.f3.drivers.net_utils.get_open_tcp_port", return_value=1234)
+    def test_tcp_listener_default_remains_wildcard(self, _):
+        assert get_tcp_urls("tcp", {DriverParams.HOST.value: "server.example"}) == (
+            "tcp://server.example:1234",
+            "tcp://0:1234",
+        )

--- a/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
+++ b/tests/unit_test/private/fed/app/deployer/simulator_deployer_test.py
@@ -67,17 +67,26 @@ class TestSimulatorDeploy(unittest.TestCase):
     @patch("nvflare.private.fed.server.admin.FedAdminServer.start")
     @patch("nvflare.private.fed.simulator.simulator_server.SimulatorServer._register_cellnet_cbs")
     @patch("nvflare.private.fed.server.fed_server.Cell")
-    def test_create_server(self, mock_admin, mock_simulator_server, mock_cell):
+    def test_create_server(self, mock_cell, mock_register_cbs, mock_admin_start):
         workspace = tempfile.mkdtemp()
         os.mkdir(os.path.join(workspace, "local"))
         os.mkdir(os.path.join(workspace, "startup"))
         parser = self._create_parser()
         args = parser.parse_args(["job_folder", "-w" + workspace, "-n 2", "-t 1"])
         args.config_folder = "config"
-        _, server = self.deployer.create_fl_server(args)
+        server_config, server = self.deployer.create_fl_server(args)
 
         assert isinstance(server, SimulatorServer)
         assert isinstance(server.engine.run_manager, RunManager)
+        listening_host = "127.0.0.1"
+        fl_port = server_config["service"]["target"].rsplit(":", 1)[1]
+        admin_port = server_config["admin_port"]
+        cell_args = mock_cell.call_args.kwargs
+        assert cell_args["root_url"] == [
+            f"tcp://{listening_host}:{fl_port}",
+            f"tcp://{listening_host}:{admin_port}",
+        ]
+        assert cell_args["internal_listener_host"] == listening_host
 
         server.cell.stop()
         server.close()

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nvflare.fuel.utils.log_utils import LogMode
+from nvflare.private.admin_defs import Message, MsgHeader, ReturnCode
+from nvflare.private.defs import SysCommandTopic
+from nvflare.private.fed.client.admin_commands import ConfigureJobLogCommand as ClientConfigureJobLogCommand
+from nvflare.private.fed.client.sys_cmd import ConfigureSiteLogProcessor
+from nvflare.private.fed.server.server_commands import ConfigureJobLogCommand as ServerConfigureJobLogCommand
+from nvflare.private.fed.server.sys_cmd import SystemCommandModule
+
+COMMANDS = [
+    (ServerConfigureJobLogCommand, "nvflare.private.fed.server.server_commands.dynamic_log_config"),
+    (ClientConfigureJobLogCommand, "nvflare.private.fed.client.admin_commands.dynamic_log_config"),
+]
+
+SAFE_CONFIGS = ["DEBUG", "20", LogMode.CONCISE, LogMode.RELOAD]
+
+
+def _log_command_context(tmp_path):
+    workspace = MagicMock()
+    workspace.get_run_dir.return_value = str(tmp_path / "run")
+    workspace.get_log_config_file_path.return_value = str(tmp_path / "log_config.json")
+    engine = MagicMock()
+    engine.get_workspace.return_value = workspace
+    fl_ctx = MagicMock()
+    fl_ctx.get_engine.return_value = engine
+    fl_ctx.get_job_id.return_value = "job-1"
+    return fl_ctx
+
+
+def _site_log_context(tmp_path):
+    workspace = MagicMock()
+    workspace.get_root_dir.return_value = str(tmp_path)
+    workspace.get_log_config_file_path.return_value = str(tmp_path / "log_config.json")
+    fl_ctx = MagicMock()
+    fl_ctx.get_identity_name.return_value = "site-1"
+    fl_ctx.get_prop.return_value = workspace
+    engine = MagicMock()
+    engine.new_context.return_value = fl_ctx
+    return engine
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+@pytest.mark.parametrize("config", SAFE_CONFIGS)
+def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_path, config):
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert error is None
+    dynamic.assert_called_once_with(
+        config=config,
+        dir_path=str(tmp_path / "run"),
+        reload_path=str(tmp_path / "log_config.json"),
+    )
+
+
+@pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
+@pytest.mark.parametrize("config_type", ["inline-json", "file-path", "dict-factory"])
+def test_remote_job_log_rejects_unsafe_config(tmp_path, command_class, dynamic_path, config_type):
+    factory_calls = []
+
+    def harmless_factory():
+        factory_calls.append(True)
+        return logging.NullHandler()
+
+    if config_type == "inline-json":
+        config = '{"version": 1}'
+    elif config_type == "file-path":
+        config_path = tmp_path / "attacker-log-config.json"
+        config_path.write_text('{"version": 1}', encoding="utf-8")
+        config = str(config_path)
+    else:
+        config = {
+            "version": 1,
+            "handlers": {"factory": {"()": harmless_factory}},
+            "root": {"level": "INFO", "handlers": ["factory"]},
+        }
+
+    with patch(dynamic_path) as dynamic:
+        error = command_class().process(config, _log_command_context(tmp_path))
+
+    assert "only supports log levels and built-in log modes" in error
+    dynamic.assert_not_called()
+    assert not factory_calls
+
+
+@pytest.mark.parametrize("config", SAFE_CONFIGS)
+def test_server_site_log_accepts_safe_controls(config):
+    conn = MagicMock()
+    message = MagicMock()
+    command = SystemCommandModule()
+    command.send_request_to_clients = MagicMock(return_value=[])
+    command.process_replies_to_table = MagicMock()
+
+    with patch("nvflare.private.fed.server.sys_cmd.new_message", return_value=message) as new_message:
+        command.configure_site_log(conn, ["configure_site_log", "client", config])
+
+    new_message.assert_called_once_with(conn, topic=SysCommandTopic.CONFIGURE_SITE_LOG, body=config, require_authz=True)
+
+
+def test_server_site_log_rejects_existing_file_path(tmp_path):
+    config_path = tmp_path / "attacker-log-config.json"
+    config_path.write_text('{"version": 1}', encoding="utf-8")
+    conn = MagicMock()
+
+    with (
+        patch("nvflare.private.fed.server.sys_cmd.dynamic_log_config") as dynamic,
+        patch("nvflare.private.fed.server.sys_cmd.new_message") as new_message,
+    ):
+        SystemCommandModule().configure_site_log(conn, ["configure_site_log", "all", str(config_path)])
+
+    assert "only supports log levels and built-in log modes" in conn.append_error.call_args.args[0]
+    dynamic.assert_not_called()
+    new_message.assert_not_called()
+
+
+@pytest.mark.parametrize("config", SAFE_CONFIGS)
+def test_client_site_log_accepts_safe_controls(tmp_path, config):
+    request = Message(topic=SysCommandTopic.CONFIGURE_SITE_LOG, body=config)
+
+    with patch("nvflare.private.fed.client.sys_cmd.dynamic_log_config") as dynamic:
+        reply = ConfigureSiteLogProcessor().process(request, _site_log_context(tmp_path))
+
+    assert reply.get_header(MsgHeader.RETURN_CODE) == ReturnCode.OK
+    dynamic.assert_called_once_with(
+        config=config,
+        dir_path=str(tmp_path),
+        reload_path=str(tmp_path / "log_config.json"),
+    )
+
+
+def test_client_site_log_rejects_existing_file_path(tmp_path):
+    config_path = tmp_path / "attacker-log-config.json"
+    config_path.write_text('{"version": 1}', encoding="utf-8")
+    request = Message(topic=SysCommandTopic.CONFIGURE_SITE_LOG, body=str(config_path))
+
+    with patch("nvflare.private.fed.client.sys_cmd.dynamic_log_config") as dynamic:
+        reply = ConfigureSiteLogProcessor().process(request, _site_log_context(tmp_path))
+
+    assert reply.get_header(MsgHeader.RETURN_CODE) == ReturnCode.ERROR
+    assert "only supports log levels and built-in log modes" in reply.body
+    dynamic.assert_not_called()

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -17,12 +17,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nvflare.fuel.utils.log_utils import LogMode
+from nvflare.fuel.utils.log_utils import LogMode, dynamic_log_config
 from nvflare.private.admin_defs import Message, MsgHeader, ReturnCode
 from nvflare.private.defs import SysCommandTopic
 from nvflare.private.fed.client.admin_commands import ConfigureJobLogCommand as ClientConfigureJobLogCommand
 from nvflare.private.fed.client.sys_cmd import ConfigureSiteLogProcessor
 from nvflare.private.fed.server.server_commands import ConfigureJobLogCommand as ServerConfigureJobLogCommand
+from nvflare.private.fed.server.server_engine import ServerEngine
 from nvflare.private.fed.server.sys_cmd import SystemCommandModule
 
 COMMANDS = [
@@ -57,6 +58,28 @@ def _site_log_context(tmp_path):
     return engine
 
 
+def test_remote_log_level_does_not_load_same_named_file(tmp_path, monkeypatch):
+    (tmp_path / "DEBUG").write_text('{"version": 1}', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    root_logger = MagicMock()
+    root_logger.hasHandlers.return_value = True
+
+    with patch("nvflare.fuel.utils.log_utils.logging.getLogger", return_value=root_logger):
+        dynamic_log_config("DEBUG", str(tmp_path), "unused", allow_file_config=False)
+
+    root_logger.setLevel.assert_called_once_with(logging.DEBUG)
+
+
+def test_remote_reload_still_loads_workspace_config(tmp_path):
+    reload_path = tmp_path / "log_config.json"
+    reload_path.write_text('{"version": 1}', encoding="utf-8")
+
+    with patch("nvflare.fuel.utils.log_utils.apply_log_config") as apply_config:
+        dynamic_log_config(LogMode.RELOAD, str(tmp_path), str(reload_path), allow_file_config=False)
+
+    apply_config.assert_called_once_with({"version": 1}, str(tmp_path))
+
+
 @pytest.mark.parametrize(("command_class", "dynamic_path"), COMMANDS)
 @pytest.mark.parametrize("config", SAFE_CONFIGS)
 def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_path, config):
@@ -68,6 +91,7 @@ def test_remote_job_log_accepts_safe_controls(tmp_path, command_class, dynamic_p
         config=config,
         dir_path=str(tmp_path / "run"),
         reload_path=str(tmp_path / "log_config.json"),
+        allow_file_config=False,
     )
 
 
@@ -102,17 +126,30 @@ def test_remote_job_log_rejects_unsafe_config(tmp_path, command_class, dynamic_p
 
 
 @pytest.mark.parametrize("config", SAFE_CONFIGS)
-def test_server_site_log_accepts_safe_controls(config):
+def test_server_site_log_accepts_safe_controls(tmp_path, config):
     conn = MagicMock()
+    conn.app_ctx = MagicMock(spec=ServerEngine)
+    workspace = conn.app_ctx.get_workspace.return_value
+    workspace.get_root_dir.return_value = str(tmp_path)
+    workspace.get_log_config_file_path.return_value = str(tmp_path / "log_config.json")
     message = MagicMock()
     command = SystemCommandModule()
     command.send_request_to_clients = MagicMock(return_value=[])
     command.process_replies_to_table = MagicMock()
 
-    with patch("nvflare.private.fed.server.sys_cmd.new_message", return_value=message) as new_message:
-        command.configure_site_log(conn, ["configure_site_log", "client", config])
+    with (
+        patch("nvflare.private.fed.server.sys_cmd.dynamic_log_config") as dynamic,
+        patch("nvflare.private.fed.server.sys_cmd.new_message", return_value=message) as new_message,
+    ):
+        command.configure_site_log(conn, ["configure_site_log", "all", config])
 
     new_message.assert_called_once_with(conn, topic=SysCommandTopic.CONFIGURE_SITE_LOG, body=config, require_authz=True)
+    dynamic.assert_called_once_with(
+        config=config,
+        dir_path=str(tmp_path),
+        reload_path=str(tmp_path / "log_config.json"),
+        allow_file_config=False,
+    )
 
 
 def test_server_site_log_rejects_existing_file_path(tmp_path):
@@ -143,6 +180,7 @@ def test_client_site_log_accepts_safe_controls(tmp_path, config):
         config=config,
         dir_path=str(tmp_path),
         reload_path=str(tmp_path / "log_config.json"),
+        allow_file_config=False,
     )
 
 

--- a/tests/unit_test/private/fed/configure_job_log_security_test.py
+++ b/tests/unit_test/private/fed/configure_job_log_security_test.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
 from nvflare.fuel.utils.log_utils import LogMode, dynamic_log_config
 from nvflare.private.admin_defs import Message, MsgHeader, ReturnCode
 from nvflare.private.defs import SysCommandTopic
@@ -166,6 +167,15 @@ def test_server_site_log_rejects_existing_file_path(tmp_path):
     assert "only supports log levels and built-in log modes" in conn.append_error.call_args.args[0]
     dynamic.assert_not_called()
     new_message.assert_not_called()
+
+
+def test_server_site_log_rejects_non_level_logging_attribute():
+    conn = MagicMock()
+
+    SystemCommandModule().configure_site_log(conn, ["configure_site_log", "all", "basic_format"])
+
+    assert "only supports log levels and built-in log modes" in conn.append_error.call_args.args[0]
+    assert conn.append_error.call_args.kwargs["meta"][MetaKey.STATUS] == MetaStatusValue.SYNTAX_ERROR
 
 
 @pytest.mark.parametrize("config", SAFE_CONFIGS)

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -24,7 +24,7 @@ from nvflare.private.fed.server.server_state import ColdState, HotState
 
 
 class TestFederatedServer:
-    def test_production_listener_bindings_remain_wildcard_by_default(self):
+    def test_production_localhost_listener_bindings_remain_wildcard(self):
         server = object.__new__(FederatedServer)
 
         with (
@@ -36,7 +36,7 @@ class TestFederatedServer:
                 server,
                 args=MagicMock(),
                 grpc_args={
-                    "service": {"target": "server.example:8002", "scheme": "tcp"},
+                    "service": {"target": "localhost:8002", "scheme": "tcp"},
                     "admin_port": 8003,
                 },
             )

--- a/tests/unit_test/private/fed/server/fed_server_test.py
+++ b/tests/unit_test/private/fed/server/fed_server_test.py
@@ -19,11 +19,32 @@ import pytest
 from nvflare.apis.fl_constant import RunProcessKey
 from nvflare.apis.shareable import Shareable
 from nvflare.private.defs import CellMessageHeaderKeys, new_cell_message
-from nvflare.private.fed.server.fed_server import FederatedServer
+from nvflare.private.fed.server.fed_server import BaseServer, FederatedServer
 from nvflare.private.fed.server.server_state import ColdState, HotState
 
 
 class TestFederatedServer:
+    def test_production_listener_bindings_remain_wildcard_by_default(self):
+        server = object.__new__(FederatedServer)
+
+        with (
+            patch("nvflare.private.fed.server.fed_server.Cell") as cell_cls,
+            patch("nvflare.private.fed.server.fed_server.mpm.add_cleanup_cb"),
+            patch("nvflare.private.fed.server.fed_server.threading.Thread"),
+        ):
+            BaseServer.deploy(
+                server,
+                args=MagicMock(),
+                grpc_args={
+                    "service": {"target": "server.example:8002", "scheme": "tcp"},
+                    "admin_port": 8003,
+                },
+            )
+
+        cell_args = cell_cls.call_args.kwargs
+        assert cell_args["root_url"] == ["tcp://0:8002", "tcp://0:8003"]
+        assert cell_args["internal_listener_host"] is None
+
     @pytest.mark.parametrize("server_state, expected", [(HotState(), ["extra_job"]), (ColdState(), [])])
     def test_heart_beat_abort_jobs(self, server_state, expected):
         with patch("nvflare.private.fed.server.fed_server.ServerEngine"):


### PR DESCRIPTION
## Summary

- restrict remote job and site log configuration to log levels and built-in log modes
- bind FL, admin, and internal listeners to IPv4 loopback for literal `localhost` deployments
- preserve configured internal hosts and wildcard listener defaults for non-local production targets

## Testing

- targeted unit tests: `40 passed`
- broader backport unit suites: `697 passed`
- project style checks: `./runtest.sh -s`