### PR TITLE
[2.7] Surface client job log configuration failures

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -328,7 +328,8 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     client_errors.append(f"{client_name}: {detail}")
 
             if client_errors:
-                conn.update_meta(make_meta(MetaStatusValue.ERROR, info="\n".join(client_errors)))
+                error_info = "\n".join(client_errors)
+                conn.append_error(error_info, make_meta(MetaStatusValue.ERROR, info=error_info))
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -33,6 +33,8 @@ from nvflare.fuel.hci.server.binary_transfer import BinaryTransfer
 from nvflare.fuel.hci.server.constants import ConnProps
 from nvflare.fuel.utils.argument_utils import SafeArgumentParser
 from nvflare.fuel.utils.log_utils import get_obj_logger
+from nvflare.private.admin_defs import MsgHeader
+from nvflare.private.admin_defs import ReturnCode as AdminReturnCode
 from nvflare.private.defs import RequestHeader, TrainingTopic
 from nvflare.private.fed.server.admin import new_message
 from nvflare.private.fed.server.job_meta_validator import JobMetaValidator
@@ -305,6 +307,28 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             message.set_header(RequestHeader.JOB_ID, str(job_id))
             replies = self.send_request_to_clients(conn, message)
             self.process_replies_to_table(conn, replies)
+
+            client_errors = []
+            client_replies = replies or []
+            received_tokens = {client_reply.client_token for client_reply in client_replies}
+            expected_clients = conn.get_prop(self.TARGET_CLIENTS, {}) or {}
+            for client_token, client_name in expected_clients.items():
+                if client_token not in received_tokens:
+                    client_errors.append(f"{client_name or client_token}: no reply")
+
+            for client_reply in client_replies:
+                client_name = client_reply.client_name or client_reply.client_token or "client"
+                if client_reply.reply is None:
+                    client_errors.append(f"{client_name}: no reply")
+                    continue
+
+                return_code = client_reply.reply.get_header(MsgHeader.RETURN_CODE, AdminReturnCode.OK)
+                if return_code != AdminReturnCode.OK:
+                    detail = client_reply.reply.body or f"return code {return_code}"
+                    client_errors.append(f"{client_name}: {detail}")
+
+            if client_errors:
+                conn.update_meta(make_meta(MetaStatusValue.ERROR, info="\n".join(client_errors)))
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvflare.apis.job_def import JobMetaKey, RunStatus
+from nvflare.fuel.hci.conn import Connection
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
+from nvflare.private.admin_defs import MsgHeader, error_reply, ok_reply
+from nvflare.private.fed.server import job_cmds as job_cmds_module
+from nvflare.private.fed.server.job_cmds import JobCommandModule
+from nvflare.private.fed.server.message_send import ClientReply
+
+
+class _FakeContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class _FakeJobManager:
+    def get_job(self, job_id, fl_ctx):
+        return SimpleNamespace(meta={JobMetaKey.STATUS: RunStatus.RUNNING})
+
+
+class _FakeServerEngine:
+    def __init__(self):
+        self.job_def_manager = _FakeJobManager()
+        self.configure_job_log = MagicMock(return_value=None)
+
+    def new_context(self):
+        return _FakeContext()
+
+
+def _run_client_config(monkeypatch, replies, expected_clients=None, target_type="client"):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    engine = _FakeServerEngine()
+    conn = Connection(
+        app_ctx=engine,
+        props={JobCommandModule.TARGET_CLIENTS: expected_clients or {}},
+    )
+    module = JobCommandModule()
+    monkeypatch.setattr(module, "send_request_to_clients", lambda conn, message: replies)
+
+    module.configure_job_log(conn, ["configure_job_log", "job-1", target_type, "site-a", "DEBUG"])
+    return conn, engine
+
+
+def _reply_with_return_code(return_code, body):
+    reply = ok_reply(body=body)
+    reply.set_header(MsgHeader.RETURN_CODE, return_code)
+    return reply
+
+
+@pytest.mark.parametrize(
+    "reply, expected_info",
+    [
+        (error_reply("log configuration refused"), "log configuration refused"),
+        (_reply_with_return_code("timeout", "request timed out"), "request timed out"),
+        (None, "no reply"),
+    ],
+)
+def test_configure_job_log_client_failure_sets_error_meta(monkeypatch, reply, expected_info):
+    client_reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=reply)
+
+    conn, _ = _run_client_config(monkeypatch, [client_reply])
+
+    assert conn.buffer.meta[MetaKey.STATUS] == MetaStatusValue.ERROR
+    assert "site-a" in conn.buffer.meta[MetaKey.INFO]
+    assert expected_info in conn.buffer.meta[MetaKey.INFO]
+
+
+def test_configure_job_log_no_client_responses_sets_error_meta(monkeypatch):
+    conn, _ = _run_client_config(monkeypatch, [], expected_clients={"token-a": "site-a"})
+
+    assert conn.buffer.meta == {
+        MetaKey.STATUS: MetaStatusValue.ERROR,
+        MetaKey.INFO: "site-a: no reply",
+    }
+
+
+def test_configure_job_log_partial_client_responses_set_error_meta(monkeypatch):
+    reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())
+
+    conn, _ = _run_client_config(
+        monkeypatch,
+        [reply],
+        expected_clients={"token-a": "site-a", "token-b": "site-b"},
+    )
+
+    assert conn.buffer.meta == {
+        MetaKey.STATUS: MetaStatusValue.ERROR,
+        MetaKey.INFO: "site-b: no reply",
+    }
+
+
+def test_configure_job_log_success_does_not_set_error_meta(monkeypatch):
+    reply = ClientReply(client_token="token-a", client_name="site-a", req=None, reply=ok_reply())
+
+    conn, _ = _run_client_config(monkeypatch, [reply], expected_clients={"token-a": "site-a"})
+
+    assert MetaKey.STATUS not in conn.buffer.meta
+
+
+def test_configure_job_log_all_with_no_clients_remains_successful(monkeypatch):
+    conn, engine = _run_client_config(monkeypatch, [], target_type="all")
+
+    engine.configure_job_log.assert_called_once_with("job-1", "DEBUG")
+    assert MetaKey.STATUS not in conn.buffer.meta

--- a/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.fuel.hci.conn import Connection
-from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue
+from nvflare.fuel.hci.proto import MetaKey, MetaStatusValue, ProtoKey
 from nvflare.private.admin_defs import MsgHeader, error_reply, ok_reply
 from nvflare.private.fed.server import job_cmds as job_cmds_module
 from nvflare.private.fed.server.job_cmds import JobCommandModule
@@ -84,6 +84,10 @@ def test_configure_job_log_client_failure_sets_error_meta(monkeypatch, reply, ex
     assert conn.buffer.meta[MetaKey.STATUS] == MetaStatusValue.ERROR
     assert "site-a" in conn.buffer.meta[MetaKey.INFO]
     assert expected_info in conn.buffer.meta[MetaKey.INFO]
+    assert conn.buffer.data[-1] == {
+        ProtoKey.TYPE: ProtoKey.ERROR,
+        ProtoKey.DATA: conn.buffer.meta[MetaKey.INFO],
+    }
 
 
 def test_configure_job_log_no_client_responses_sets_error_meta(monkeypatch):
@@ -92,6 +96,10 @@ def test_configure_job_log_no_client_responses_sets_error_meta(monkeypatch):
     assert conn.buffer.meta == {
         MetaKey.STATUS: MetaStatusValue.ERROR,
         MetaKey.INFO: "site-a: no reply",
+    }
+    assert conn.buffer.data[-1] == {
+        ProtoKey.TYPE: ProtoKey.ERROR,
+        ProtoKey.DATA: "site-a: no reply",
     }
 
 
@@ -107,6 +115,10 @@ def test_configure_job_log_partial_client_responses_set_error_meta(monkeypatch):
     assert conn.buffer.meta == {
         MetaKey.STATUS: MetaStatusValue.ERROR,
         MetaKey.INFO: "site-b: no reply",
+    }
+    assert conn.buffer.data[-1] == {
+        ProtoKey.TYPE: ProtoKey.ERROR,
+        ProtoKey.DATA: "site-b: no reply",
     }
 
 


### PR DESCRIPTION
## Summary
- backport #5138 to the 2.7 release branch
- propagate client-side configure_job_log failures through a legacy HCI ERROR data item and detailed command metadata
- report non-OK, missing, and partial client replies while preserving successful no-client all behavior
- add focused release-compatible regression coverage for both response representations because the newer Session and CLI test scaffolding is not present on 2.7

## Validation
- python3 -m pytest tests/unit_test/private/fed/server/job_cmds_test.py tests/unit_test/private/fed/server/job_cmds_configure_log_test.py -q (14 passed)
- ./runtest.sh -s