### PR TITLE
Fix FedJob transitive package import export

### DIFF
--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -492,7 +492,7 @@ class FedJobConfig:
         self._check_destination_collision(source_file, dest_file)
         return source_file, source_root, dest_file
 
-    def _get_custom_file(self, custom_dir, module, source_file, source_root=None):
+    def _get_custom_file(self, custom_dir, module, source_file, source_root=None, flat_import_roots=None):
         module_parts = self._module_parts(module)
         if source_root is None:
             source_root = self._derive_source_root(module=module, source_file=source_file)
@@ -514,7 +514,14 @@ class FedJobConfig:
 
         self.custom_modules.append(module)
         try:
-            self._copy_source_file(custom_dir, module, source_file, dest_file, source_root=source_root)
+            self._copy_source_file(
+                custom_dir,
+                module,
+                source_file,
+                dest_file,
+                source_root=source_root,
+                flat_import_roots=flat_import_roots,
+            )
         except Exception:
             self.custom_modules.remove(module)
             raise
@@ -538,7 +545,16 @@ class FedJobConfig:
         resolved_parts = package_parts[:keep_parts] + import_parts
         return ".".join(resolved_parts) if resolved_parts else None
 
-    def _copy_source_file(self, custom_dir, module, source_file, dest_file, source_root, is_external_script=False):
+    def _copy_source_file(
+        self,
+        custom_dir,
+        module,
+        source_file,
+        dest_file,
+        source_root,
+        is_external_script=False,
+        flat_import_roots=None,
+    ):
         source_file, source_root, dest_file = self._validate_copy_paths(
             custom_dir=custom_dir,
             source_file=source_file,
@@ -556,19 +572,20 @@ class FedJobConfig:
 
         source_dir = os.path.dirname(source_file)
         is_flat_external_script = is_external_script and not os.path.isfile(os.path.join(source_dir, "__init__.py"))
-        search_source_dir = is_flat_external_script or "." not in module
+        is_flat_module = (is_flat_external_script or "." not in module) and os.path.basename(
+            source_file
+        ) != "__init__.py"
+        if is_flat_module and flat_import_roots is None:
+            flat_import_roots = [source_dir, source_root]
+            if is_external_script and "." not in module:
+                flat_import_roots.append(os.path.dirname(source_dir))
         for import_source, level in import_specs:
             import_module = self._resolve_import_module(module, import_source, level, source_file)
             if not import_module:
                 continue
             import_path = os.path.join(*self._module_parts(import_module)) + ".py"
-            search_roots = [source_root]
-            # Flat registered scripts and non-package modules can resolve unqualified imports from source-dir siblings.
-            if level == 0 and search_source_dir and os.path.basename(source_file) != "__init__.py":
-                search_roots.insert(0, source_dir)
-            # Preserve parent-helper lookup for top-level registered scripts without using that parent for recursion.
-            if level == 0 and is_external_script and "." not in module:
-                search_roots.append(os.path.dirname(source_dir))
+            # Flat modules retain the registered script's ordered roots; package modules stay anchored to their root.
+            search_roots = list(flat_import_roots) if level == 0 and is_flat_module else [source_root]
             checked_roots = set()
             for search_root in search_roots:
                 search_root = self._resolved_path(search_root)
@@ -577,15 +594,12 @@ class FedJobConfig:
                 checked_roots.add(search_root)
                 import_source_file = os.path.join(search_root, import_path)
                 if os.path.isfile(import_source_file):
-                    recursive_source_root = source_root
-                    if not self._is_path_within(import_source_file, source_root):
-                        # Parent-helper matches must not retain an unrelated project root during recursion.
-                        recursive_source_root = search_root
                     self._get_custom_file(
                         custom_dir,
                         import_module,
                         import_source_file,
-                        source_root=recursive_source_root,
+                        source_root=search_root,
+                        flat_import_roots=flat_import_roots if "." not in import_module else None,
                     )
                     break
 

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -577,11 +577,15 @@ class FedJobConfig:
                 checked_roots.add(search_root)
                 import_source_file = os.path.join(search_root, import_path)
                 if os.path.isfile(import_source_file):
+                    recursive_source_root = source_root
+                    if not self._is_path_within(import_source_file, source_root):
+                        # Parent-helper matches must not retain an unrelated project root during recursion.
+                        recursive_source_root = search_root
                     self._get_custom_file(
                         custom_dir,
                         import_module,
                         import_source_file,
-                        source_root=search_root,
+                        source_root=recursive_source_root,
                     )
                     break
 

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -377,7 +377,7 @@ class FedJobConfig:
                 if os.path.basename(source_file) != "__init__.py":
                     path_depth -= 1
                 source_root = os.path.dirname(source_path_for_root)
-                for _ in range(max(path_depth, 1)):
+                for _ in range(path_depth):
                     source_root = os.path.dirname(source_root)
                 self._copy_source_file(
                     custom_dir,
@@ -566,6 +566,9 @@ class FedJobConfig:
             # Flat registered scripts and non-package modules can resolve unqualified imports from source-dir siblings.
             if level == 0 and search_source_dir and os.path.basename(source_file) != "__init__.py":
                 search_roots.insert(0, source_dir)
+            # Preserve parent-helper lookup for top-level registered scripts without using that parent for recursion.
+            if level == 0 and is_external_script and "." not in module:
+                search_roots.append(os.path.dirname(source_dir))
             checked_roots = set()
             for search_root in search_roots:
                 search_root = self._resolved_path(search_root)
@@ -578,7 +581,7 @@ class FedJobConfig:
                         custom_dir,
                         import_module,
                         import_source_file,
-                        source_root=source_root,
+                        source_root=search_root,
                     )
                     break
 

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -403,6 +403,44 @@ class TestFedJobConfig:
         assert (custom_dir / "pkg" / "helper.py").is_file()
         assert not (custom_dir / "helper.py").exists()
 
+    def test_copy_ext_script_resolves_transitive_package_import_from_top_level_script(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "proj"
+        package_dir = project_dir / "pkg"
+        package_dir.mkdir(parents=True)
+        (project_dir / "train.py").write_text("from pkg.a import A\n", encoding="utf-8")
+        (package_dir / "__init__.py").write_text("", encoding="utf-8")
+        (package_dir / "a.py").write_text("from pkg.b import B\nA = B + 1\n", encoding="utf-8")
+        (package_dir / "b.py").write_text("B = 1\n", encoding="utf-8")
+        monkeypatch.chdir(project_dir)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["train.py"])
+
+        assert (custom_dir / "train.py").is_file()
+        assert (custom_dir / "pkg" / "a.py").is_file()
+        assert (custom_dir / "pkg" / "b.py").read_text(encoding="utf-8") == "B = 1\n"
+
+    def test_transitive_package_import_does_not_resolve_from_parent_directory(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "proj"
+        package_dir = project_dir / "pkg"
+        package_dir.mkdir(parents=True)
+        (project_dir / "train.py").write_text("from pkg.a import A\n", encoding="utf-8")
+        (package_dir / "__init__.py").write_text("", encoding="utf-8")
+        (package_dir / "a.py").write_text("from pkg.b import B\nA = B + 1\n", encoding="utf-8")
+        (package_dir / "b.py").write_text("B = 'project'\n", encoding="utf-8")
+        parent_package_dir = tmp_path / "pkg"
+        parent_package_dir.mkdir()
+        (parent_package_dir / "b.py").write_text("B = 'foreign'\n", encoding="utf-8")
+        monkeypatch.chdir(project_dir)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["train.py"])
+
+        exported_module = custom_dir / "pkg" / "b.py"
+        assert exported_module.read_text(encoding="utf-8") == "B = 'project'\n"
+
     def test_copy_ext_script_resolves_valid_multi_level_relative_import(self, tmp_path, monkeypatch):
         package_dir = tmp_path / "pkg"
         script_dir = package_dir / "sub"

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -336,6 +336,22 @@ class TestFedJobConfig:
         assert (custom_dir / "net.py").is_file()
         assert not (custom_dir / "src" / "net.py").exists()
 
+    def test_flat_sibling_import_preserves_project_root_for_recursion(self, tmp_path, monkeypatch):
+        script_dir = tmp_path / "src"
+        script_dir.mkdir()
+        (tmp_path / "root_helper.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (script_dir / "net.py").write_text("from root_helper import VALUE\n", encoding="utf-8")
+        (script_dir / "client.py").write_text("from net import VALUE\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["src/client.py"])
+
+        assert (custom_dir / "src" / "client.py").is_file()
+        assert (custom_dir / "net.py").is_file()
+        assert (custom_dir / "root_helper.py").is_file()
+
     def test_copy_ext_scripts_reject_distinct_absolute_sources_with_same_destination(self, tmp_path, monkeypatch):
         first_dir = tmp_path / "first"
         second_dir = tmp_path / "second"

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -293,6 +293,27 @@ class TestFedJobConfig:
         assert (custom_dir / "client.py").is_file()
         assert (custom_dir / "custom_layers.py").is_file()
 
+    def test_parent_package_import_anchors_transitive_imports_to_parent_directory(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "client.py").write_text("from parent_pkg.a import A\n", encoding="utf-8")
+        parent_package_dir = tmp_path / "parent_pkg"
+        parent_package_dir.mkdir()
+        (parent_package_dir / "a.py").write_text("from parent_pkg.b import B\nA = B\n", encoding="utf-8")
+        (parent_package_dir / "b.py").write_text("B = 'parent'\n", encoding="utf-8")
+        project_package_dir = project_dir / "parent_pkg"
+        project_package_dir.mkdir()
+        (project_package_dir / "b.py").write_text("B = 'project'\n", encoding="utf-8")
+        monkeypatch.chdir(project_dir)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["client.py"])
+
+        assert (custom_dir / "parent_pkg" / "a.py").is_file()
+        exported_module = custom_dir / "parent_pkg" / "b.py"
+        assert exported_module.read_text(encoding="utf-8") == "B = 'parent'\n"
+
     def test_copy_ext_script_finds_top_level_import_in_same_directory(self, tmp_path, monkeypatch):
         project_dir = tmp_path / "proj"
         project_dir.mkdir()
@@ -351,6 +372,22 @@ class TestFedJobConfig:
         assert (custom_dir / "src" / "client.py").is_file()
         assert (custom_dir / "net.py").is_file()
         assert (custom_dir / "root_helper.py").is_file()
+
+    def test_flat_sibling_import_prefers_source_directory_during_recursion(self, tmp_path, monkeypatch):
+        script_dir = tmp_path / "src"
+        script_dir.mkdir()
+        (tmp_path / "helper.py").write_text("VALUE = 'project'\n", encoding="utf-8")
+        (script_dir / "helper.py").write_text("VALUE = 'source'\n", encoding="utf-8")
+        (script_dir / "net.py").write_text("from helper import VALUE\n", encoding="utf-8")
+        (script_dir / "client.py").write_text("from net import VALUE\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["src/client.py"])
+
+        exported_module = custom_dir / "helper.py"
+        assert exported_module.read_text(encoding="utf-8") == "VALUE = 'source'\n"
 
     def test_copy_ext_scripts_reject_distinct_absolute_sources_with_same_destination(self, tmp_path, monkeypatch):
         first_dir = tmp_path / "first"

--- a/tests/unit_test/job_config/fed_job_config_test.py
+++ b/tests/unit_test/job_config/fed_job_config_test.py
@@ -314,6 +314,27 @@ class TestFedJobConfig:
         exported_module = custom_dir / "parent_pkg" / "b.py"
         assert exported_module.read_text(encoding="utf-8") == "B = 'parent'\n"
 
+    @pytest.mark.parametrize("with_parent_shadow", [False, True])
+    def test_parent_helper_preserves_project_root_for_transitive_import(
+        self, tmp_path, monkeypatch, with_parent_shadow
+    ):
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "client.py").write_text("from parent_helper import VALUE\n", encoding="utf-8")
+        (project_dir / "project_local.py").write_text("VALUE = 'project'\n", encoding="utf-8")
+        (tmp_path / "parent_helper.py").write_text("from project_local import VALUE\n", encoding="utf-8")
+        if with_parent_shadow:
+            (tmp_path / "project_local.py").write_text("VALUE = 'parent'\n", encoding="utf-8")
+        monkeypatch.chdir(project_dir)
+
+        custom_dir = tmp_path / "exported" / "custom"
+        job_config = FedJobConfig(job_name="job_name", min_clients=1)
+        job_config._copy_ext_scripts(str(custom_dir), ["client.py"])
+
+        assert (custom_dir / "parent_helper.py").is_file()
+        exported_module = custom_dir / "project_local.py"
+        assert exported_module.read_text(encoding="utf-8") == "VALUE = 'project'\n"
+
     def test_copy_ext_script_finds_top_level_import_in_same_directory(self, tmp_path, monkeypatch):
         project_dir = tmp_path / "proj"
         project_dir.mkdir()


### PR DESCRIPTION
## Summary

- fix FedJob export recursion for qualified package imports reached from a top-level external script
- preserve the parent-directory helper lookup added by #4885
- carry the registered script's ordered roots through unqualified flat-helper recursion
- keep qualified package modules anchored to the root where they were resolved
- prevent both missing project dependencies and same-named parent files from corrupting parent-helper exports
- add regression coverage for package recursion, flat siblings, source-root precedence, parent-package anchoring, and parent-helper back-imports

## Root cause

For a depth-0 registered script, the exporter always moved source_root one directory above the project. Direct imports could still resolve from the script directory, but recursive package imports inherited the parent root. As a result, pkg.a importing pkg.b either omitted the project module or copied a same-named file from the parent directory.

A single recursive root also cannot model flat helpers correctly: subdirectory siblings need the project root as a fallback, while parent helpers need the original project-first lookup order for their own unqualified imports. This change carries that ordered flat-import root chain across unqualified modules and drops it when entering a qualified package, which remains anchored to its matched root.

## Testing

- 55 tests passed: tests/unit_test/job_config/fed_job_config_test.py
- project style checks passed for both changed files (black, isort, flake8, and agent skill lint)
- public FedJob.export_job reproductions passed for qualified packages, transitive flat siblings, and parent-helper project back-imports with and without a parent shadow
- a 12-case differential matrix against tag 2.8.1 found zero compatibility regressions