### PR TITLE
[Auto-FL] Fix budget argument collisions

### DIFF
--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -67,7 +67,8 @@ flag spellings the job's parser defines, including short aliases; a
 spelling the parser does not define passes through unchanged so argparse
 still reports it. A short-option cluster that itself sets a pinned
 zero-argument flag is kept, and the runner omits its own copy so the
-option still appears exactly once.
+option still appears exactly once. Any other short-option token that may
+involve a pinned flag is rejected; write the options as separate tokens.
 
 When the user does not name a metric, a deterministic ``key_metric`` extracted
 from ``job.py`` takes precedence. The default user experience does not require

--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -57,6 +57,16 @@ The result is a reviewable ``autofl.yaml`` containing:
 - source and importer provenance;
 - unresolved dynamic or unsupported fields requiring review.
 
+Before baseline execution, the runner merges imported fixed-budget values,
+user ``--base-args``, and task-local comparison-budget arguments into one
+command line so each budget option is emitted exactly once. Explicit
+duplicates with identical values are dropped; conflicting values are
+rejected at initialization with an ``AUTOFL_BUDGET_ARGUMENT_CONFLICT``
+error before any campaign file is written. Duplicates are matched by the
+flag spellings the job's parser defines, including short aliases; a
+spelling the parser does not define passes through unchanged so argparse
+still reports it.
+
 When the user does not name a metric, a deterministic ``key_metric`` extracted
 from ``job.py`` takes precedence. The default user experience does not require
 editing ``autofl.yaml``.

--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -65,7 +65,9 @@ rejected at initialization with an ``AUTOFL_BUDGET_ARGUMENT_CONFLICT``
 error before any campaign file is written. Duplicates are matched by the
 flag spellings the job's parser defines, including short aliases; a
 spelling the parser does not define passes through unchanged so argparse
-still reports it.
+still reports it. A short-option cluster that would set a pinned
+zero-argument flag again is rejected with the same error; split the
+cluster instead.
 
 When the user does not name a metric, a deterministic ``key_metric`` extracted
 from ``job.py`` takes precedence. The default user experience does not require

--- a/docs/user_guide/agent_skills/autofl_skill.rst
+++ b/docs/user_guide/agent_skills/autofl_skill.rst
@@ -65,9 +65,9 @@ rejected at initialization with an ``AUTOFL_BUDGET_ARGUMENT_CONFLICT``
 error before any campaign file is written. Duplicates are matched by the
 flag spellings the job's parser defines, including short aliases; a
 spelling the parser does not define passes through unchanged so argparse
-still reports it. A short-option cluster that would set a pinned
-zero-argument flag again is rejected with the same error; split the
-cluster instead.
+still reports it. A short-option cluster that itself sets a pinned
+zero-argument flag is kept, and the runner omits its own copy so the
+option still appears exactly once.
 
 When the user does not name a metric, a deterministic ``key_metric`` extracted
 from ``job.py`` takes precedence. The default user experience does not require

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -22,7 +22,9 @@ initialization with `AUTOFL_BUDGET_ARGUMENT_CONFLICT`. Duplicates are matched
 by the flag spellings the job's parser defines, including short aliases; a
 spelling the parser does not define passes through unchanged. A short-option
 cluster that itself sets a pinned zero-argument flag is kept, and the runner
-omits its own copy so the option still appears exactly once.
+omits its own copy so the option still appears exactly once. Any other
+short-option token that may involve a pinned flag is rejected; write the
+options as separate tokens.
 
 The importer resolves the optimization direction from an explicit
 `key_metric_mode`, a same-metric `stop_cond`, or NVFLARE's default `max`, and

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -21,8 +21,8 @@ duplicates with identical values are dropped; conflicting values fail
 initialization with `AUTOFL_BUDGET_ARGUMENT_CONFLICT`. Duplicates are matched
 by the flag spellings the job's parser defines, including short aliases; a
 spelling the parser does not define passes through unchanged. A short-option
-cluster that would set a pinned zero-argument flag again is rejected with the
-same error; split the cluster instead.
+cluster that itself sets a pinned zero-argument flag is kept, and the runner
+omits its own copy so the option still appears exactly once.
 
 The importer resolves the optimization direction from an explicit
 `key_metric_mode`, a same-metric `stop_cond`, or NVFLARE's default `max`, and

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -20,7 +20,9 @@ into one command line so each budget option is emitted exactly once. Explicit
 duplicates with identical values are dropped; conflicting values fail
 initialization with `AUTOFL_BUDGET_ARGUMENT_CONFLICT`. Duplicates are matched
 by the flag spellings the job's parser defines, including short aliases; a
-spelling the parser does not define passes through unchanged.
+spelling the parser does not define passes through unchanged. A short-option
+cluster that would set a pinned zero-argument flag again is rejected with the
+same error; split the cluster instead.
 
 The importer resolves the optimization direction from an explicit
 `key_metric_mode`, a same-metric `stop_cond`, or NVFLARE's default `max`, and

--- a/skills/nvflare-autofl/references/job-import-contract.md
+++ b/skills/nvflare-autofl/references/job-import-contract.md
@@ -14,6 +14,14 @@ baseline and candidate. Evaluation-only, statistics-only, and unsupported
 nested-application recipes stop during import with an actionable
 `import.support.reason`; they must not start a baseline.
 
+Before baseline execution, the runner merges imported fixed-budget arguments,
+explicit `--base-args`, and `comparison_budget_args.default_candidate_budget`
+into one command line so each budget option is emitted exactly once. Explicit
+duplicates with identical values are dropped; conflicting values fail
+initialization with `AUTOFL_BUDGET_ARGUMENT_CONFLICT`. Duplicates are matched
+by the flag spellings the job's parser defines, including short aliases; a
+spelling the parser does not define passes through unchanged.
+
 The importer resolves the optimization direction from an explicit
 `key_metric_mode`, a same-metric `stop_cond`, or NVFLARE's default `max`, and
 records that provenance in `autofl.yaml`. Declare raw loss-like metrics with

--- a/skills/nvflare-autofl/scripts/job_importer.py
+++ b/skills/nvflare-autofl/scripts/job_importer.py
@@ -745,6 +745,20 @@ def inspect_job_cli_flags(job_path: str, job_args: Optional[Sequence[str]] = Non
     return sorted({flag for spec in parser_args.values() for flag in spec.flags if flag.startswith("--")})
 
 
+def inspect_job_cli_flag_aliases(job_path: str, job_args: Optional[Sequence[str]] = None) -> List[List[str]]:
+    """Return each reachable argparse option's flag spellings (short and long) as one sorted group."""
+
+    path = Path(job_path).resolve()
+    try:
+        source_text = path.read_text(encoding="utf-8")
+        tree = ast.parse(source_text, filename=str(path))
+        index = _ImportIndex.from_tree(tree, source_text)
+    except (OSError, UnicodeError, SyntaxError, RecursionError) as e:
+        raise JobImportError(f"failed to parse {path}: {e}") from e
+    parser_args, _ = _reachable_parser_args(tree, index, job_args or [])
+    return sorted(sorted(spec.flags) for spec in parser_args.values() if spec.flags)
+
+
 class _ImportIndex(ast.NodeVisitor):
     def __init__(self, source_text: str):
         self.source_text = source_text

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2146,6 +2146,14 @@ def pinned_flag_spellings(
     return spellings
 
 
+# argparse's _negative_number_matcher: option-like tokens are not consumed as values unless they are numbers.
+_NEGATIVE_NUMBER_MATCHER = re.compile(r"^-\d+$|^-\d*\.\d+$")
+
+
+def _consumable_cli_value(token: str) -> bool:
+    return not token.startswith("-") or bool(_NEGATIVE_NUMBER_MATCHER.match(token))
+
+
 def merge_base_budget_args(
     base_tokens: Sequence[str],
     pinned: Dict[str, Tuple[Optional[str], str]],
@@ -2174,8 +2182,10 @@ def merge_base_budget_args(
         if name is not None:
             if separator:
                 supplied = inline_value
-            # A zero-argument pinned flag never consumes the next token: argparse binds it to positionals.
-            elif pinned[name][0] is not None and index < len(base_tokens) and not base_tokens[index].startswith("--"):
+            # A zero-argument pinned flag never consumes the next token (argparse binds it to positionals),
+            # and a valued flag never consumes an option-like token (argparse raises "expected one argument"),
+            # with argparse's negative-number exception.
+            elif pinned[name][0] is not None and index < len(base_tokens) and _consumable_cli_value(base_tokens[index]):
                 supplied = base_tokens[index]
                 index += 1
         elif not separator and not token.startswith("--") and token not in defined_flags:
@@ -2209,8 +2219,8 @@ def merge_base_budget_args(
                 ambiguous = sorted(s for s in spellings if s.startswith("--") and s.startswith(option) and s != option)
                 if ambiguous:
                     raise ValueError(
-                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: --base-args option {option} is an ambiguous "
-                        f"abbreviation of budget option(s) {', '.join(ambiguous)}; spell the full flag"
+                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: --base-args option {option} abbreviates pinned "
+                        f"budget option(s) {', '.join(ambiguous)}; spell the full flag"
                     )
             merged.append(token)
             continue

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2151,13 +2151,16 @@ def merge_base_budget_args(
     pinned: Dict[str, Tuple[Optional[str], str]],
     spellings: Dict[str, str],
     defined_flags: set,
-) -> List[str]:
+) -> Tuple[List[str], set[str]]:
     """Drop --base-args duplicates of runner-injected budget flags; reject conflicts and ambiguous abbreviations.
 
     Tokens are matched by the exact flag spellings the job's parser defines, mirroring argparse: a spelling
-    the parser would not accept passes through verbatim so the job still reports it as unrecognized.
+    the parser would not accept passes through verbatim so the job still reports it as unrecognized. Returns
+    the merged tokens plus the pinned names a kept token already sets (short-option clusters), whose
+    runner-injected copies must be omitted to keep each budget option emitted exactly once.
     """
     merged: List[str] = []
+    satisfied: set[str] = set()
     index = 0
     while index < len(base_tokens):
         token = base_tokens[index]
@@ -2181,13 +2184,11 @@ def merge_base_budget_args(
             if short is not None:
                 if pinned[spellings[short]][0] is None:
                     # A zero-argument pin has no attached value: argparse reads -xv as the cluster -x -v,
-                    # which would supply the pinned flag a second time. Token-wise merging cannot drop one
-                    # letter from a user's cluster, so fail closed to keep each budget option emitted once.
-                    raise ValueError(
-                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: short-option cluster {token} includes {short} "
-                        f"(--{spellings[short]}), which the campaign already supplies; "
-                        f"split the cluster and drop {short}"
-                    )
+                    # which sets the pinned flag itself. One letter cannot be dropped from a user's cluster,
+                    # so keep the cluster and omit the runner's copy of the flag instead.
+                    satisfied.add(spellings[short])
+                    merged.append(token)
+                    continue
                 name = spellings[short]
                 supplied = token[2:]
         if name is None:
@@ -2210,7 +2211,7 @@ def merge_base_budget_args(
             f"supplies {'no value' if supplied is None else repr(supplied)}; "
             "remove the flag from --base-args or align the values"
         )
-    return merged
+    return merged, satisfied
 
 
 def build_campaign_args(
@@ -2237,7 +2238,10 @@ def build_campaign_args(
     spellings = pinned_flag_spellings(pinned, [*fixed_args, *budget_args], groups)
     defined_flags = supported_long_flags(help_text)
     defined_flags.update(flag for group in groups for flag in group)
-    base_args = merge_base_budget_args(shlex.split(args.base_args), pinned, spellings, defined_flags)
+    base_args, satisfied = merge_base_budget_args(shlex.split(args.base_args), pinned, spellings, defined_flags)
+    if satisfied:
+        fixed_args = [t for t in fixed_args if not (t.startswith("-") and normalize_budget_flag_name(t) in satisfied)]
+        budget_args = [t for t in budget_args if not (t.startswith("-") and normalize_budget_flag_name(t) in satisfied)]
     return fixed_args, [*base_args, *budget_args]
 
 

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2177,9 +2177,17 @@ def merge_base_budget_args(
                 index += 1
         elif not separator and not token.startswith("--") and token not in defined_flags:
             # Attached short-option value, e.g. -r3 for a pinned -r/--num_rounds (argparse's own semantics).
-            # A zero-argument pin never has an attached value: argparse reads -xv as the cluster -x -v.
             short = next((s for s in spellings if len(s) == 2 and not s.startswith("--") and token.startswith(s)), None)
-            if short is not None and pinned[spellings[short]][0] is not None:
+            if short is not None:
+                if pinned[spellings[short]][0] is None:
+                    # A zero-argument pin has no attached value: argparse reads -xv as the cluster -x -v,
+                    # which would supply the pinned flag a second time. Token-wise merging cannot drop one
+                    # letter from a user's cluster, so fail closed to keep each budget option emitted once.
+                    raise ValueError(
+                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: short-option cluster {token} includes {short} "
+                        f"(--{spellings[short]}), which the campaign already supplies; "
+                        f"split the cluster and drop {short}"
+                    )
                 name = spellings[short]
                 supplied = token[2:]
         if name is None:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2177,8 +2177,9 @@ def merge_base_budget_args(
                 index += 1
         elif not separator and not token.startswith("--") and token not in defined_flags:
             # Attached short-option value, e.g. -r3 for a pinned -r/--num_rounds (argparse's own semantics).
+            # A zero-argument pin never has an attached value: argparse reads -xv as the cluster -x -v.
             short = next((s for s in spellings if len(s) == 2 and not s.startswith("--") and token.startswith(s)), None)
-            if short is not None:
+            if short is not None and pinned[spellings[short]][0] is not None:
                 name = spellings[short]
                 supplied = token[2:]
         if name is None:

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2191,6 +2191,18 @@ def merge_base_budget_args(
                     continue
                 name = spellings[short]
                 supplied = token[2:]
+            else:
+                # Beyond the leading position the token is ambiguous without the other flags' arity:
+                # -vx is -v -x for a boolean -v (setting the pinned flag again) but -v with value x
+                # otherwise. Fail closed so no cluster can supply a pinned budget option a second time.
+                involved = next(
+                    (s for s in spellings if len(s) == 2 and not s.startswith("--") and s[1] in token[1:]), None
+                )
+                if involved is not None:
+                    raise ValueError(
+                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: cannot determine whether short-option token {token} "
+                        f"involves {involved} (--{spellings[involved]}); write the options as separate tokens"
+                    )
         if name is None:
             if token.startswith("--") and option not in defined_flags:
                 # An exactly-defined job flag is never an abbreviation: argparse gives exact matches precedence.

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2113,12 +2113,130 @@ def build_fixed_args(config: Dict[str, Any], help_text: str, schema: Dict[str, A
     return args
 
 
-def build_base_args(args: argparse.Namespace, help_text: str, schema: Dict[str, Any]) -> List[str]:
-    base = shlex.split(args.base_args)
+def normalize_budget_flag_name(token: str) -> str:
+    return token.lstrip("-").replace("-", "_")
+
+
+def _injected_budget_arg_values(injected: Sequence[str]) -> Dict[str, Optional[str]]:
+    values: Dict[str, Optional[str]] = {}
+    index = 0
+    while index < len(injected):
+        name = normalize_budget_flag_name(injected[index])
+        if index + 1 < len(injected) and not injected[index + 1].startswith("--"):
+            values[name] = injected[index + 1]
+            index += 2
+        else:
+            values[name] = None
+            index += 1
+    return values
+
+
+def pinned_flag_spellings(
+    pinned: Dict[str, Tuple[Optional[str], str]], injected: Sequence[str], alias_groups: Sequence[Sequence[str]]
+) -> Dict[str, str]:
+    """Map each parser-defined spelling (long, short, alias) of a pinned budget option to its pinned name."""
+    spellings = {token: normalize_budget_flag_name(token) for token in injected if token.startswith("--")}
+    for group in alias_groups:
+        names = {normalize_budget_flag_name(flag) for flag in group if flag.startswith("--")}
+        matched = names.intersection(pinned)
+        if len(matched) == 1:
+            name = next(iter(matched))
+            for flag in group:
+                spellings[flag] = name
+    return spellings
+
+
+def merge_base_budget_args(
+    base_tokens: Sequence[str],
+    pinned: Dict[str, Tuple[Optional[str], str]],
+    spellings: Dict[str, str],
+    defined_flags: set,
+) -> List[str]:
+    """Drop --base-args duplicates of runner-injected budget flags; reject conflicts and ambiguous abbreviations.
+
+    Tokens are matched by the exact flag spellings the job's parser defines, mirroring argparse: a spelling
+    the parser would not accept passes through verbatim so the job still reports it as unrecognized.
+    """
+    merged: List[str] = []
+    index = 0
+    while index < len(base_tokens):
+        token = base_tokens[index]
+        index += 1
+        if not token.startswith("-") or token in ("-", "--"):
+            merged.append(token)
+            continue
+        option, separator, inline_value = token.partition("=")
+        name = spellings.get(option)
+        supplied: Optional[str] = None
+        if name is not None:
+            if separator:
+                supplied = inline_value
+            # A zero-argument pinned flag never consumes the next token: argparse binds it to positionals.
+            elif pinned[name][0] is not None and index < len(base_tokens) and not base_tokens[index].startswith("--"):
+                supplied = base_tokens[index]
+                index += 1
+        elif not separator and not token.startswith("--") and token not in defined_flags:
+            # Attached short-option value, e.g. -r3 for a pinned -r/--num_rounds (argparse's own semantics).
+            short = next((s for s in spellings if len(s) == 2 and not s.startswith("--") and token.startswith(s)), None)
+            if short is not None:
+                name = spellings[short]
+                supplied = token[2:]
+        if name is None:
+            if token.startswith("--") and option not in defined_flags:
+                # An exactly-defined job flag is never an abbreviation: argparse gives exact matches precedence.
+                ambiguous = sorted(s for s in spellings if s.startswith("--") and s.startswith(option) and s != option)
+                if ambiguous:
+                    raise ValueError(
+                        f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: --base-args option {option} is an ambiguous "
+                        f"abbreviation of budget option(s) {', '.join(ambiguous)}; spell the full flag"
+                    )
+            merged.append(token)
+            continue
+        pinned_value, source = pinned[name]
+        if supplied == pinned_value:
+            continue
+        raise ValueError(
+            f"AUTOFL_BUDGET_ARGUMENT_CONFLICT: --{name} is set to "
+            f"{'no value' if pinned_value is None else repr(pinned_value)} by {source} but --base-args ({token}) "
+            f"supplies {'no value' if supplied is None else repr(supplied)}; "
+            "remove the flag from --base-args or align the values"
+        )
+    return merged
+
+
+def build_campaign_args(
+    config: Dict[str, Any],
+    args: argparse.Namespace,
+    help_text: str,
+    schema: Dict[str, Any],
+    alias_groups: Optional[Sequence[Sequence[str]]] = None,
+) -> Tuple[List[str], List[str]]:
+    """Resolve run arguments so each budget option is emitted exactly once.
+
+    Explicit --base-args duplicates of a runner-injected budget argument are dropped when the values are
+    identical and rejected with an actionable error when they conflict. Duplicates are matched by the exact
+    flag spellings the job's parser defines (including short aliases), so misspellings keep argparse's error.
+    """
+    fixed_args = build_fixed_args(config, help_text, schema)
     budget_args = build_comparison_budget_args(schema, help_text)
-    if budget_args:
-        base.extend(budget_args)
-    return base
+    pinned: Dict[str, Tuple[Optional[str], str]] = {}
+    for name, value in _injected_budget_arg_values(budget_args).items():
+        pinned[name] = (value, "the mutation-schema comparison budget")
+    for name, value in _injected_budget_arg_values(fixed_args).items():
+        pinned[name] = (value, "the imported fixed training budget")
+    groups = list(alias_groups or [])
+    spellings = pinned_flag_spellings(pinned, [*fixed_args, *budget_args], groups)
+    defined_flags = supported_long_flags(help_text)
+    defined_flags.update(flag for group in groups for flag in group)
+    base_args = merge_base_budget_args(shlex.split(args.base_args), pinned, spellings, defined_flags)
+    return fixed_args, [*base_args, *budget_args]
+
+
+def job_flag_alias_groups(job: Path) -> List[List[str]]:
+    try:
+        return load_job_importer().inspect_job_cli_flag_aliases(str(job))
+    except (OSError, ValueError) as e:
+        raise RuntimeError(f"cannot inspect job CLI flag aliases in {job}: {e}") from e
 
 
 def suggested_arg_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -3370,14 +3488,17 @@ def execute_sim_baseline(
 ) -> RunRecord:
     timeout, no_progress_timeout = campaign_timeout(args, schema)
     help_text = job_help(args.python, job, job.parent)
+    fixed_args, base_args = build_campaign_args(
+        config, args, help_text, schema, alias_groups=job_flag_alias_groups(job)
+    )
     return run_job(
         JobRun(name=name, args=[], description="baseline", status="baseline"),
         python=args.python,
         job=job,
         cwd=job.parent,
         help_text=help_text,
-        fixed_args=build_fixed_args(config, help_text, schema),
-        base_args=build_base_args(args, help_text, schema),
+        fixed_args=fixed_args,
+        base_args=base_args,
         output_root=paths["output_root"],
         timeout=timeout,
         simulator_no_progress_timeout=no_progress_timeout,
@@ -3413,6 +3534,10 @@ def prepare_initial_campaign(args: argparse.Namespace, job: Path) -> None:
             "baseline execution is unsafe: "
             f"{'; '.join(admission_errors)}. Repair the job metric contract and initialize again."
         )
+    # Surface --base-args conflicts with the admitted budget before any campaign file is written.
+    build_campaign_args(
+        config, args, job_help(args.python, job, job.parent), schema, alias_groups=job_flag_alias_groups(job)
+    )
     args._initial_config = config
     args._initial_source_hashes = admitted_source_hashes(config, job.parent)
     args._initial_schema_sha256 = sha256_json(schema)
@@ -4044,6 +4169,9 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
 
     try:
         help_text = job_help(args.python, job, workspace)
+        fixed_args, base_args = build_campaign_args(
+            config, args, help_text, schema, alias_groups=job_flag_alias_groups(job)
+        )
         run_record = run_job(
             JobRun(
                 name=str(manifest["candidate_id"]),
@@ -4054,8 +4182,8 @@ def evaluate_candidate(args: argparse.Namespace, job: Path) -> int:
             job=job,
             cwd=workspace,
             help_text=help_text,
-            fixed_args=build_fixed_args(config, help_text, schema),
-            base_args=build_base_args(args, help_text, schema),
+            fixed_args=fixed_args,
+            base_args=base_args,
             output_root=paths["output_root"],
             timeout=timeout,
             simulator_no_progress_timeout=no_progress_timeout,

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2151,7 +2151,8 @@ _NEGATIVE_NUMBER_MATCHER = re.compile(r"^-\d+$|^-\d*\.\d+$")
 
 
 def _consumable_cli_value(token: str) -> bool:
-    return not token.startswith("-") or bool(_NEGATIVE_NUMBER_MATCHER.match(token))
+    # Mirrors argparse's option classifier: lone "-" and tokens containing a space are values too.
+    return not token.startswith("-") or token == "-" or " " in token or bool(_NEGATIVE_NUMBER_MATCHER.match(token))
 
 
 def merge_base_budget_args(
@@ -2160,7 +2161,7 @@ def merge_base_budget_args(
     spellings: Dict[str, str],
     defined_flags: set,
 ) -> Tuple[List[str], set[str]]:
-    """Drop --base-args duplicates of runner-injected budget flags; reject conflicts and ambiguous abbreviations.
+    """Drop --base-args duplicates of runner-injected budget flags; reject conflicts and pinned-flag abbreviations.
 
     Tokens are matched by the exact flag spellings the job's parser defines, mirroring argparse: a spelling
     the parser would not accept passes through verbatim so the job still reports it as unrecognized. Returns

--- a/tests/unit_test/tool/autofl_skill_job_importer_test.py
+++ b/tests/unit_test/tool/autofl_skill_job_importer_test.py
@@ -1792,3 +1792,17 @@ recipe.execute(SimEnv(num_clients=2))
 
     assert config["import"]["support"]["status"] == "supported"
     assert not marker.exists()
+
+
+def test_inspect_job_cli_flag_aliases_returns_parser_spellings(tmp_path):
+    job_path = _write_recipe_job(tmp_path)
+    source = job_path.read_text(encoding="utf-8").replace(
+        'parser.add_argument("--n_clients", type=int, default=3)',
+        'parser.add_argument("-n", "--n_clients", type=int, default=3)',
+    )
+    job_path.write_text(source, encoding="utf-8")
+
+    groups = job_importer.inspect_job_cli_flag_aliases(str(job_path))
+
+    assert ["--n_clients", "-n"] in groups
+    assert ["--num_rounds"] in groups

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -518,21 +518,24 @@ def test_comparison_budget_suppresses_duplicate_imported_fixed_budget_args():
     assert runner.build_fixed_args(config, help_text, schema) == []
 
     args = SimpleNamespace(base_args="")
-    assert runner.build_base_args(args, help_text, schema) == ["--n_clients", "8", "--num_rounds", "20"]
+    assert runner.build_campaign_args(config, args, help_text, schema) == (
+        [],
+        ["--n_clients", "8", "--num_rounds", "20"],
+    )
 
 
-def test_build_base_args_never_injects_dataset_flags_for_synthetic_capable_jobs():
+def test_campaign_args_never_inject_dataset_flags_for_synthetic_capable_jobs():
     runner = _load_runner()
     help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
 
-    assert runner.build_base_args(SimpleNamespace(base_args=""), help_text, {}) == []
+    assert runner.build_campaign_args({"budget": {}}, SimpleNamespace(base_args=""), help_text, {}) == ([], [])
 
     schema = {"comparison_budget_args": {"default_candidate_budget": {"num_rounds": 5}}}
     help_text_with_budget = f"{help_text} [--num_rounds NUM_ROUNDS]"
-    assert runner.build_base_args(SimpleNamespace(base_args=""), help_text_with_budget, schema) == [
-        "--num_rounds",
-        "5",
-    ]
+    assert runner.build_campaign_args({"budget": {}}, SimpleNamespace(base_args=""), help_text_with_budget, schema) == (
+        [],
+        ["--num_rounds", "5"],
+    )
 
 
 def test_explicit_base_args_pass_through_verbatim():
@@ -540,7 +543,160 @@ def test_explicit_base_args_pass_through_verbatim():
     help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
 
     args = SimpleNamespace(base_args="--synthetic_data --train_size 64")
-    assert runner.build_base_args(args, help_text, {}) == ["--synthetic_data", "--train_size", "64"]
+    assert runner.build_campaign_args({"budget": {}}, args, help_text, {}) == (
+        [],
+        ["--synthetic_data", "--train_size", "64"],
+    )
+
+
+def test_base_args_duplicates_of_fixed_budget_are_emitted_once():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_clients": 2, "num_rounds": 3}}}
+    help_text = "--n_clients --num_rounds --update_type"
+    args = SimpleNamespace(base_args="--n_clients 2 --num_rounds=3 --update_type full")
+
+    fixed_args, base_args = runner.build_campaign_args(config, args, help_text, {})
+
+    assert fixed_args == ["--n_clients", "2", "--num_rounds", "3"]
+    assert base_args == ["--update_type", "full"]
+
+
+def test_base_args_alias_spelling_matches_only_parser_defined_flags():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 3}}}
+    args = SimpleNamespace(base_args="--num-rounds 3")
+
+    # The parser does not define --num-rounds: pass it through so argparse still reports the typo.
+    assert runner.build_campaign_args(config, args, "--num_rounds", {}) == (
+        ["--num_rounds", "3"],
+        ["--num-rounds", "3"],
+    )
+
+    # The parser defines both spellings as one option: deduplicate and conflict-check across them.
+    alias_groups = [["--num-rounds", "--num_rounds"]]
+    assert runner.build_campaign_args(config, args, "--num_rounds", {}, alias_groups=alias_groups) == (
+        ["--num_rounds", "3"],
+        [],
+    )
+    with pytest.raises(ValueError, match="AUTOFL_BUDGET_ARGUMENT_CONFLICT"):
+        runner.build_campaign_args(
+            config, SimpleNamespace(base_args="--num-rounds 5"), "--num_rounds", {}, alias_groups=alias_groups
+        )
+
+
+def test_base_args_short_alias_of_pinned_flag_is_deduplicated_and_conflicts_rejected():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
+    alias_groups = [["-r", "--num_rounds"]]
+
+    fixed_args, base_args = runner.build_campaign_args(
+        config, SimpleNamespace(base_args="-r 5 --lr 0.1"), "--num_rounds --lr", {}, alias_groups=alias_groups
+    )
+    assert fixed_args == ["--num_rounds", "5"]
+    assert base_args == ["--lr", "0.1"]
+
+    for conflicting in ("-r 3", "-r=3", "-r3"):
+        with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*--num_rounds.*'5'.*'3'"):
+            runner.build_campaign_args(
+                config, SimpleNamespace(base_args=conflicting), "--num_rounds", {}, alias_groups=alias_groups
+            )
+
+
+def test_base_args_conflicting_fixed_budget_value_is_rejected():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
+    args = SimpleNamespace(base_args="--num_rounds 3")
+
+    with pytest.raises(
+        ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*--num_rounds.*'5'.*fixed training budget.*'3'"
+    ):
+        runner.build_campaign_args(config, args, "--num_rounds", {})
+
+
+def test_base_args_conflicting_comparison_budget_value_is_rejected():
+    runner = _load_runner()
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"num_rounds": 20}}}
+    args = SimpleNamespace(base_args="--num_rounds=3")
+
+    with pytest.raises(
+        ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*--num_rounds.*'20'.*comparison budget.*'3'"
+    ):
+        runner.build_campaign_args({"budget": {}}, args, "--num_rounds", schema)
+
+
+def test_base_args_identical_comparison_budget_value_is_emitted_once():
+    runner = _load_runner()
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"num_rounds": 5}}}
+    args = SimpleNamespace(base_args="--num_rounds 5 --synthetic_data")
+
+    fixed_args, base_args = runner.build_campaign_args({"budget": {}}, args, "--num_rounds --synthetic_data", schema)
+
+    assert fixed_args == []
+    assert base_args == ["--synthetic_data", "--num_rounds", "5"]
+    assert base_args.count("--num_rounds") == 1
+
+
+def test_base_args_conflicting_duplicates_of_pinned_flag_are_rejected():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
+    args = SimpleNamespace(base_args="--num_rounds 5 --num-rounds=3")
+
+    with pytest.raises(ValueError, match="AUTOFL_BUDGET_ARGUMENT_CONFLICT"):
+        runner.build_campaign_args(config, args, "--num_rounds", {}, alias_groups=[["--num-rounds", "--num_rounds"]])
+
+
+def test_base_args_ambiguous_abbreviation_of_pinned_flag_is_rejected():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
+    args = SimpleNamespace(base_args="--num_round 3")
+
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*ambiguous abbreviation.*--num_rounds"):
+        runner.build_campaign_args(config, args, "--num_rounds", {})
+
+
+def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
+    runner = _load_runner()
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"cross_site_eval": True}}}
+    help_text = "--num_rounds --cross_site_eval"
+
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="--cross_site_eval"), help_text, schema
+    )
+    assert fixed_args == []
+    assert base_args == ["--cross_site_eval"]
+
+    # A zero-argument flag never consumes the next token: argparse would bind it to a positional.
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="--cross_site_eval dataset.csv"), help_text, schema
+    )
+    assert fixed_args == []
+    assert base_args == ["dataset.csv", "--cross_site_eval"]
+
+    with pytest.raises(ValueError, match="AUTOFL_BUDGET_ARGUMENT_CONFLICT"):
+        runner.build_campaign_args(
+            {"budget": {}}, SimpleNamespace(base_args="--cross_site_eval=true"), help_text, schema
+        )
+
+
+def test_base_args_budget_named_flags_stay_verbatim_when_not_pinned():
+    runner = _load_runner()
+    args = SimpleNamespace(base_args="--seed 1 --seed 2 --model_arch resnet18 resnet50")
+
+    fixed_args, base_args = runner.build_campaign_args({"budget": {}}, args, "--seed --model_arch", {})
+
+    assert fixed_args == []
+    assert base_args == ["--seed", "1", "--seed", "2", "--model_arch", "resnet18", "resnet50"]
+
+
+def test_base_args_exact_job_flag_matching_pinned_prefix_is_not_ambiguous():
+    runner = _load_runner()
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"batch_size": 16}}}
+    args = SimpleNamespace(base_args="--batch 32")
+
+    fixed_args, base_args = runner.build_campaign_args({"budget": {}}, args, "--batch --batch_size", schema)
+
+    assert fixed_args == []
+    assert base_args == ["--batch", "32", "--batch_size", "16"]
 
 
 def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path, capsys):
@@ -554,7 +710,7 @@ def test_restore_campaign_settings_ignores_legacy_synthetic_settings(tmp_path, c
 
     assert not hasattr(args, "prefer_synthetic")
     help_text = "usage: job.py [--synthetic_data] [--train_size TRAIN_SIZE] [--test_size TEST_SIZE]"
-    assert runner.build_base_args(args, help_text, {}) == []
+    assert runner.build_campaign_args({"budget": {}}, args, help_text, {}) == ([], [])
     # The prior baseline/candidates were scored on injected synthetic data; new runs use
     # real data, so the ledger crosses a data regime — warn instead of staying silent.
     stderr = capsys.readouterr().err
@@ -1039,6 +1195,42 @@ def test_socket_failure_marker_only_requests_human_runner_approval(tmp_path, mon
     assert state["next_action"] == runner.SIMULATION_APPROVAL_ACTION
     assert "Pause for human approval" in state["agent_instruction"]
     assert "Never request broader permission" in state["agent_instruction"]
+
+
+def test_run_job_argv_contains_each_budget_flag_exactly_once(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    captured = {}
+
+    def fake_run(_python, _arguments, *, log_path, **_kwargs):
+        captured["arguments"] = list(_arguments)
+        return _fake_python_result(_python, _arguments)
+
+    monkeypatch.setattr(runner, "run_python", fake_run)
+    config = {"budget": {"fixed_training_budget": {"num_clients": 2, "num_rounds": 3}}, "job": {}}
+    help_text = "--n_clients --num_rounds --update_type"
+    args = SimpleNamespace(base_args="--n_clients 2 --num_rounds=3 --update_type full")
+    fixed_args, base_args = runner.build_campaign_args(config, args, help_text, {})
+    runner.run_job(
+        runner.JobRun("baseline", [], "baseline"),
+        python=sys.executable,
+        job=job,
+        cwd=tmp_path,
+        help_text=help_text,
+        fixed_args=fixed_args,
+        base_args=base_args,
+        output_root=tmp_path / "runs",
+        timeout=10,
+        simulator_no_progress_timeout=0,
+        metrics=["accuracy"],
+        config=config,
+    )
+
+    arguments = captured["arguments"]
+    for flag in ("--n_clients", "--num_rounds", "--update_type"):
+        assert arguments.count(flag) == 1
+    assert arguments.index("--num_rounds") < arguments.index("--update_type")
 
 
 def test_run_job_uses_run_python_prepared_command_without_revalidating(tmp_path, monkeypatch):
@@ -3678,6 +3870,97 @@ def test_initialize_revalidates_source_after_in_memory_admission(tmp_path, monke
 
     with pytest.raises(ValueError, match="changed after metric-contract admission"):
         runner.admitted_initial_campaign(args, job)
+
+
+def test_initialize_rejects_conflicting_base_args_before_baseline(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text(
+        """
+import argparse
+
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num_rounds", type=int, default=3)
+    parser.parse_args()
+    recipe = FedAvgRecipe(
+        name="literal-budget",
+        min_clients=2,
+        num_rounds=5,
+        train_script="client.py",
+        key_metric="accuracy",
+    )
+    recipe.execute(SimEnv(num_clients=2))
+
+
+if __name__ == "__main__":
+    main()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("baseline must not execute")),
+    )
+
+    assert runner.main(["initialize", str(job), "--base-args", "--num_rounds 3"]) == 2
+
+    stderr = capsys.readouterr().err
+    assert "AUTOFL_BUDGET_ARGUMENT_CONFLICT" in stderr
+    assert not tmp_path.joinpath(".nvflare").exists()
+    assert not tmp_path.joinpath("autofl.yaml").exists()
+
+
+def test_initialize_rejects_conflicting_short_alias_base_args_before_baseline(tmp_path, monkeypatch, capsys):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text(
+        """
+import argparse
+
+from nvflare.app_opt.pt.recipes.fedavg import FedAvgRecipe
+from nvflare.recipe import SimEnv
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--num_rounds", type=int, default=3)
+    parser.parse_args()
+    recipe = FedAvgRecipe(
+        name="literal-budget",
+        min_clients=2,
+        num_rounds=5,
+        train_script="client.py",
+        key_metric="accuracy",
+    )
+    recipe.execute(SimEnv(num_clients=2))
+
+
+if __name__ == "__main__":
+    main()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    tmp_path.joinpath("client.py").write_text("print('train')\n", encoding="utf-8")
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("baseline must not execute")),
+    )
+
+    assert runner.main(["initialize", str(job), "--base-args", "-r 3"]) == 2
+
+    stderr = capsys.readouterr().err
+    assert "AUTOFL_BUDGET_ARGUMENT_CONFLICT" in stderr
+    assert "--num_rounds" in stderr
+    assert not tmp_path.joinpath(".nvflare").exists()
+    assert not tmp_path.joinpath("autofl.yaml").exists()
 
 
 def test_explicit_immutable_campaign_setting_change_is_rejected(tmp_path, monkeypatch):

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -678,6 +678,22 @@ def test_base_args_valued_pin_never_consumes_an_option_like_token():
     assert fixed_args == []
     assert base_args == ["--alpha", "-0.5"]
 
+    # The consumability classifier mirrors argparse exactly.
+    for token, consumable in (
+        ("3", True),
+        ("resnet18", True),
+        ("-3", True),
+        ("-0.5", True),
+        ("-.5", True),
+        ("-", True),
+        ("- spaced", True),
+        ("-5.", False),
+        ("-x", False),
+        ("-1e-3", False),
+        ("--foo", False),
+    ):
+        assert runner._consumable_cli_value(token) is consumable, token
+
 
 def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
     runner = _load_runner()

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -672,12 +672,14 @@ def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
     assert fixed_args == []
     assert base_args == ["dataset.csv", "--cross_site_eval"]
 
-    # A clustered short alias (-xv meaning -x -v) would supply the pinned flag a second time; fail closed.
+    # A clustered short alias (-xv meaning -x -v) sets the pinned flag itself; the runner omits its copy
+    # so the option still appears exactly once.
     alias_groups = [["-x", "--cross_site_eval"]]
-    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*-xv.*cross_site_eval.*split the cluster"):
-        runner.build_campaign_args(
-            {"budget": {}}, SimpleNamespace(base_args="-xv"), help_text, schema, alias_groups=alias_groups
-        )
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="-xv"), help_text, schema, alias_groups=alias_groups
+    )
+    assert fixed_args == []
+    assert base_args == ["-xv"]
 
     # A bare pinned short alias still deduplicates.
     fixed_args, base_args = runner.build_campaign_args(

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -651,13 +651,32 @@ def test_base_args_conflicting_duplicates_of_pinned_flag_are_rejected():
         runner.build_campaign_args(config, args, "--num_rounds", {}, alias_groups=[["--num-rounds", "--num_rounds"]])
 
 
-def test_base_args_ambiguous_abbreviation_of_pinned_flag_is_rejected():
+def test_base_args_abbreviation_of_pinned_flag_is_rejected():
     runner = _load_runner()
     config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
     args = SimpleNamespace(base_args="--num_round 3")
 
-    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*ambiguous abbreviation.*--num_rounds"):
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*abbreviates pinned budget.*--num_rounds"):
         runner.build_campaign_args(config, args, "--num_rounds", {})
+
+
+def test_base_args_valued_pin_never_consumes_an_option_like_token():
+    runner = _load_runner()
+    config = {"budget": {"fixed_training_budget": {"num_rounds": 5}}}
+
+    # argparse raises "expected one argument" here; report the missing value, never '-x' as the value.
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*--num_rounds.*supplies no value"):
+        runner.build_campaign_args(
+            config, SimpleNamespace(base_args="--num_rounds -x --seed 1"), "--num_rounds --seed", {}
+        )
+
+    # argparse's negative-number exception still consumes numeric values.
+    schema = {"comparison_budget_args": {"default_candidate_budget": {"alpha": -0.5}}}
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="--alpha -0.5"), "--alpha", schema
+    )
+    assert fixed_args == []
+    assert base_args == ["--alpha", "-0.5"]
 
 
 def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -601,6 +601,12 @@ def test_base_args_short_alias_of_pinned_flag_is_deduplicated_and_conflicts_reje
                 config, SimpleNamespace(base_args=conflicting), "--num_rounds", {}, alias_groups=alias_groups
             )
 
+    # A valued pinned alias beyond the leading cluster position is ambiguous without -v's arity; fail closed.
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*-vr3.*num_rounds.*separate tokens"):
+        runner.build_campaign_args(
+            config, SimpleNamespace(base_args="-vr3"), "--num_rounds", {}, alias_groups=alias_groups
+        )
+
 
 def test_base_args_conflicting_fixed_budget_value_is_rejected():
     runner = _load_runner()
@@ -680,6 +686,19 @@ def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
     )
     assert fixed_args == []
     assert base_args == ["-xv"]
+
+    # Beyond the leading position the pinned alias is ambiguous (-v -x vs -v with value x); fail closed.
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*-vx.*cross_site_eval.*separate tokens"):
+        runner.build_campaign_args(
+            {"budget": {}}, SimpleNamespace(base_args="-vx"), help_text, schema, alias_groups=alias_groups
+        )
+
+    # Short tokens that cannot involve a pinned flag stay verbatim.
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="-vz"), help_text, schema, alias_groups=alias_groups
+    )
+    assert fixed_args == []
+    assert base_args == ["-vz", "--cross_site_eval"]
 
     # A bare pinned short alias still deduplicates.
     fixed_args, base_args = runner.build_campaign_args(

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -672,6 +672,21 @@ def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
     assert fixed_args == []
     assert base_args == ["dataset.csv", "--cross_site_eval"]
 
+    # A clustered short alias (-xv meaning -x -v for store_true options) is not an attached value.
+    alias_groups = [["-x", "--cross_site_eval"]]
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="-xv"), help_text, schema, alias_groups=alias_groups
+    )
+    assert fixed_args == []
+    assert base_args == ["-xv", "--cross_site_eval"]
+
+    # A bare pinned short alias still deduplicates.
+    fixed_args, base_args = runner.build_campaign_args(
+        {"budget": {}}, SimpleNamespace(base_args="-x"), help_text, schema, alias_groups=alias_groups
+    )
+    assert fixed_args == []
+    assert base_args == ["--cross_site_eval"]
+
     with pytest.raises(ValueError, match="AUTOFL_BUDGET_ARGUMENT_CONFLICT"):
         runner.build_campaign_args(
             {"budget": {}}, SimpleNamespace(base_args="--cross_site_eval=true"), help_text, schema

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -672,13 +672,12 @@ def test_base_args_boolean_comparison_flag_deduplicates_and_rejects_values():
     assert fixed_args == []
     assert base_args == ["dataset.csv", "--cross_site_eval"]
 
-    # A clustered short alias (-xv meaning -x -v for store_true options) is not an attached value.
+    # A clustered short alias (-xv meaning -x -v) would supply the pinned flag a second time; fail closed.
     alias_groups = [["-x", "--cross_site_eval"]]
-    fixed_args, base_args = runner.build_campaign_args(
-        {"budget": {}}, SimpleNamespace(base_args="-xv"), help_text, schema, alias_groups=alias_groups
-    )
-    assert fixed_args == []
-    assert base_args == ["-xv", "--cross_site_eval"]
+    with pytest.raises(ValueError, match=r"AUTOFL_BUDGET_ARGUMENT_CONFLICT.*-xv.*cross_site_eval.*split the cluster"):
+        runner.build_campaign_args(
+            {"budget": {}}, SimpleNamespace(base_args="-xv"), help_text, schema, alias_groups=alias_groups
+        )
 
     # A bare pinned short alias still deduplicates.
     fixed_args, base_args = runner.build_campaign_args(


### PR DESCRIPTION
## Summary

- emit each budget option exactly once in the executed command: explicit `--base-args` duplicates of a runner-injected budget argument (imported fixed training budget or mutation-schema comparison budget) are dropped when the values are identical
- reject conflicting values at initialization with `AUTOFL_BUDGET_ARGUMENT_CONFLICT` before any campaign file is written, including conflicts supplied through any parser-defined spelling of a pinned option (short aliases such as `-r`, alternate long spellings, attached and `=` value forms) and ambiguous abbreviations of pinned flags
- match duplicates by the exact flag spellings the job's parser defines — exposed by a new importer helper (`inspect_job_cli_flag_aliases`) — so a spelling the parser does not accept passes through verbatim and keeps argparse's own error instead of being silently absorbed
- preserve non-budget base arguments verbatim; budget-named flags that are not pinned by the campaign pass through untouched
- keep the candidate run-argument guard and the existing comparison-over-fixed suppression unchanged
- document the merge and conflict behavior

## Why

The runner previously concatenated imported fixed-budget arguments, user `--base-args`, and mutation-schema comparison arguments without deduplication, producing commands like `job.py --n_clients 2 --num_rounds 3 --n_clients 2 --num_rounds 3 --update_type full`. Identical duplicates were harmless under argparse last-wins semantics but made the recorded command ambiguous for other parsers and for reporting/reproduction tooling, and conflicting values (for example a hard-coded Recipe budget versus a differing CLI flag) were silently resolved by argument ordering.

This revision intentionally re-scopes the earlier iteration of this PR to that reproducibility bug only: no importer changes, no new persisted configuration fields, and no new provenance contract. Resuming campaigns is unaffected unless a recorded `--base-args` budget value genuinely conflicts with an injected budget argument — that case now fails closed with `AUTOFL_BUDGET_ARGUMENT_CONFLICT` (acceptable pre-release: the skill has not shipped, so no such campaigns exist).

## Validation

- Auto-FL unit suites: 968 passed, 39 skipped (runner, job importer, campaign guard, report, plot progress, agent skill checks)
- black, isort, and flake8 clean on the changed Python files
- new tests cover identical and conflicting duplicates in both `--flag value` and `--flag=value` forms, parser-defined alias spellings (short flags with space, `=`, and attached values; dash-spelled long aliases), undefined spellings passing through so argparse reports them, ambiguous abbreviations, boolean comparison flags, unpinned budget-named flags passing through verbatim, an end-to-end assertion that the final run argv contains each budget flag exactly once, and initialize tests that a conflict (long or short spelling) aborts before any campaign file is created
