### PR TITLE
[2.9] Preserve client log errors in HCI output

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -419,7 +419,8 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
                     client_errors.append(f"{client_name}: {detail}")
 
             if client_errors:
-                conn.update_meta(make_meta(MetaStatusValue.ERROR, info="\n".join(client_errors)))
+                error_info = "\n".join(client_errors)
+                conn.append_error(error_info, make_meta(MetaStatusValue.ERROR, info=error_info))
 
         if target_type not in [self.TARGET_TYPE_ALL, self.TARGET_TYPE_CLIENT, self.TARGET_TYPE_SERVER]:
             conn.append_error(

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -115,6 +115,8 @@ class _MockConnection:
 
     def append_error(self, msg, meta=None):
         self.errors.append((msg, meta))
+        if meta:
+            self.update_meta(meta)
 
     def append_string(self, msg, meta=None):
         self.strings.append((msg, meta))
@@ -1778,6 +1780,7 @@ def test_configure_job_log_client_failure_sets_error_meta(tmp_path, monkeypatch,
     assert conn.meta[MetaKey.STATUS] == MetaStatusValue.ERROR
     assert "site-a" in conn.meta[MetaKey.INFO]
     assert expected_info in conn.meta[MetaKey.INFO]
+    assert conn.errors == [(conn.meta[MetaKey.INFO], conn.meta)]
 
 
 def test_configure_job_log_no_client_responses_sets_error_meta(tmp_path, monkeypatch):
@@ -1798,6 +1801,7 @@ def test_configure_job_log_no_client_responses_sets_error_meta(tmp_path, monkeyp
         MetaKey.STATUS: MetaStatusValue.ERROR,
         MetaKey.INFO: "site-a: no reply",
     }
+    assert conn.errors == [("site-a: no reply", conn.meta)]
 
 
 def test_configure_job_log_partial_client_responses_set_error_meta(tmp_path, monkeypatch):
@@ -1819,6 +1823,7 @@ def test_configure_job_log_partial_client_responses_set_error_meta(tmp_path, mon
         MetaKey.STATUS: MetaStatusValue.ERROR,
         MetaKey.INFO: "site-b: no reply",
     }
+    assert conn.errors == [("site-b: no reply", conn.meta)]
 
 
 def test_authorize_job_id_hides_jobs_from_other_studies(monkeypatch):


### PR DESCRIPTION
## Summary
- follow up on #5138 by preserving client configure_job_log failures in the legacy HCI response data
- emit the detailed per-client failure text through append_error while retaining ERROR metadata for Session and CLI consumers
- cover explicit client errors, timeouts, missing payloads, missing responses, and partial responses in both output representations

## Validation
- python3 -m pytest tests/unit_test/private/fed/server/job_cmds_test.py tests/unit_test/fuel/flare_api/session_new_methods_test.py tests/unit_test/tool/job/job_log_test.py -q (184 passed)
- ./runtest.sh -s