### PR TITLE
[2.9] Improve Lightning and Hugging Face conversion skill reliability

### DIFF
--- a/nvflare/client/hf/__init__.py
+++ b/nvflare/client/hf/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from typing import Optional, Union
+
 from nvflare.apis.analytix import AnalyticsDataType as AnalyticsDataType
 from nvflare.app_common.abstract.fl_model import FLModel as FLModel
 from nvflare.app_common.abstract.fl_model import ParamsType as ParamsType
@@ -21,7 +24,7 @@ from nvflare.client.api import get_config as get_config
 from nvflare.client.api import get_job_id as get_job_id
 from nvflare.client.api import get_site_name as get_site_name
 from nvflare.client.api import get_task_name as get_task_name
-from nvflare.client.api import init as init
+from nvflare.client.api import init as _client_api_init
 from nvflare.client.api import is_evaluate as is_evaluate
 from nvflare.client.api import is_submit_model as is_submit_model
 from nvflare.client.api import is_train as is_train
@@ -33,6 +36,56 @@ from nvflare.client.api import system_info as system_info
 from nvflare.client.decorator import evaluate as evaluate
 from nvflare.client.decorator import train as train
 from nvflare.client.ipc.ipc_agent import IPCAgent as IPCAgent
+
+_MULTIRANK_SIZE_ENV_VARS = ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS")
+
+
+def _get_initialized_distributed_rank():
+    try:
+        import torch.distributed as dist
+    except ImportError:
+        return None
+
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        return int(dist.get_rank())
+    return None
+
+
+def _environment_declares_multirank() -> bool:
+    for name in _MULTIRANK_SIZE_ENV_VARS:
+        try:
+            if int(os.environ.get(name, "1") or 1) > 1:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _resolve_init_rank(rank):
+    if rank is not None:
+        return rank
+
+    distributed_rank = _get_initialized_distributed_rank()
+    if distributed_rank is not None:
+        return distributed_rank
+
+    if _environment_declares_multirank():
+        global_rank = os.environ.get("RANK")
+        try:
+            int(global_rank)
+        except (TypeError, ValueError):
+            raise RuntimeError(
+                "Hugging Face Client API detected a multi-process launch but global RANK is unavailable; "
+                "initialize torch.distributed or export a valid global RANK before flare.init()"
+            )
+        return global_rank
+    return None
+
+
+def init(rank: Optional[Union[str, int]] = None, config_file: Optional[str] = None):
+    """Initialize the Client API with Hugging Face distributed-rank validation."""
+    return _client_api_init(rank=_resolve_init_rank(rank), config_file=config_file)
+
 
 __all__ = [
     "AnalyticsDataType",

--- a/nvflare/client/hf/__init__.py
+++ b/nvflare/client/hf/__init__.py
@@ -72,13 +72,15 @@ def _resolve_init_rank(rank):
     if _environment_declares_multirank():
         global_rank = os.environ.get("RANK")
         try:
-            int(global_rank)
+            normalized_rank = int(global_rank)
         except (TypeError, ValueError):
+            normalized_rank = -1
+        if normalized_rank < 0:
             raise RuntimeError(
-                "Hugging Face Client API detected a multi-process launch but global RANK is unavailable; "
-                "initialize torch.distributed or export a valid global RANK before flare.init()"
+                "Hugging Face Client API detected a multi-process launch but global RANK is unavailable or invalid; "
+                "initialize torch.distributed or export a valid non-negative global RANK before flare.init()"
             )
-        return global_rank
+        return str(normalized_rank)
     return None
 
 

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -139,8 +139,8 @@ Use `run_script()` only during the validation phase after loading `references/hu
 - Must follow the Client API initialization and conditional rank contract in
   `../nvflare-shared/references/conversion-common.md`. Do not make rank a client
   argument for the standard single-process path. Only a distributed
-  multi-process launch requires a resolved global process rank; load
-  `references/huggingface-state-and-distributed.md` for that path.
+  multi-process launch requires the asset to resolve the global process rank;
+  load `references/huggingface-state-and-distributed.md` for that path.
 - Must preserve source evaluation. When per-round global-model evaluation is
   required, call `trainer.evaluate()` before `trainer.train()` on every rank.
   Do not invent `compute_metrics`, label mappings, averaging denominators, or

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -115,12 +115,13 @@ Use `run_script()` only during the validation phase after loading `references/hu
    not use `parse_known_args()`.
 7. Only after generated files exist, load `../nvflare-shared/references/validation-evidence.md`
    and `references/huggingface-validation.md`. Follow the shared compile,
-   construction, simulation, and terminal-evidence ladder. Inspect export/package
-   evidence only for an exported final target; inspect a local target's
-   materialized evidence after its run. Apply only the standard HF Trainer checks
-   and stop at the first failed rung. Review and exercise the maintained assets directly;
-   do not inspect NVFLARE implementation source, improvise Recipe API probes, or
-   write one-off AST programs to re-prove them. Use
+   construction, simulation, and terminal-evidence ladder. Run the final
+   simulation with `run_in_background: false`; never finalize with an active
+   simulation. Inspect export/package evidence only for an exported final target;
+   inspect a local target's materialized evidence after its run. Apply only the
+   standard HF Trainer checks and stop at the first failed rung. Review and exercise
+   the maintained assets directly; do not inspect NVFLARE implementation source,
+   improvise Recipe API probes, or write one-off AST programs to re-prove them. Use
    `references/huggingface-state-and-distributed.md`
    only when inspection found PEFT, DDP, checkpoint/restore overrides,
    auxiliary trainable models, or another non-default patch setting.

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -137,10 +137,10 @@ Use `run_script()` only during the validation phase after loading `references/hu
   inside a patched loop may inspect task metadata only; it must not load a
   second copy of the global model.
 - Must follow the Client API initialization and conditional rank contract in
-  `../nvflare-shared/references/conversion-common.md`. Do not make rank a client
-  argument for the standard single-process path. Only a distributed
-  multi-process launch requires the asset to resolve the global process rank;
-  load `references/huggingface-state-and-distributed.md` for that path.
+  `../nvflare-shared/references/conversion-common.md`. Keep the generated client
+  rankless; `nvflare.client.hf.init()` owns distributed-rank resolution and
+  rejection. Load `references/huggingface-state-and-distributed.md` only for a
+  distributed multi-process source path.
 - Must preserve source evaluation. When per-round global-model evaluation is
   required, call `trainer.evaluate()` before `trainer.train()` on every rank.
   Do not invent `compute_metrics`, label mappings, averaging denominators, or

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -136,11 +136,11 @@ Use `run_script()` only during the validation phase after loading `references/hu
 - Must use `flare.patch(trainer)` as the sole model-exchange owner. `receive()`
   inside a patched loop may inspect task metadata only; it must not load a
   second copy of the global model.
-- Must make the client entry's global `rank` argument required and pass it to
-  `flare.init(rank=rank)`; never default every process to rank zero. Resolve it
-  from an initialized process group or global `RANK`, using explicit zero only
-  for a verified single-process launch. Client API initialization order
-  otherwise follows `../nvflare-shared/references/conversion-common.md`.
+- Must follow the Client API initialization and conditional rank contract in
+  `../nvflare-shared/references/conversion-common.md`. Do not make rank a client
+  argument for the standard single-process path. Only a distributed
+  multi-process launch requires a resolved global process rank; load
+  `references/huggingface-state-and-distributed.md` for that path.
 - Must preserve source evaluation. When per-round global-model evaluation is
   required, call `trainer.evaluate()` before `trainer.train()` on every rank.
   Do not invent `compute_metrics`, label mappings, averaging denominators, or

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -115,9 +115,8 @@ Use `run_script()` only during the validation phase after loading `references/hu
    not use `parse_known_args()`.
 7. Only after generated files exist, load `../nvflare-shared/references/validation-evidence.md`
    and `references/huggingface-validation.md`. Follow the shared compile,
-   construction, simulation, and terminal-evidence ladder. Run the final
-   simulation with `run_in_background: false`; never finalize with an active
-   simulation. Inspect export/package evidence only for an exported final target;
+   construction, simulation, and terminal-evidence ladder. Inspect export/package
+   evidence only for an exported final target;
    inspect a local target's materialized evidence after its run. Apply only the
    standard HF Trainer checks and stop at the first failed rung. Review and exercise
    the maintained assets directly; do not inspect NVFLARE implementation source,

--- a/skills/nvflare-convert-huggingface/SKILL.md
+++ b/skills/nvflare-convert-huggingface/SKILL.md
@@ -72,9 +72,8 @@ Use `run_script()` only during the validation phase after loading `references/hu
    callbacks, checkpoint and PEFT settings, precision, local budget,
    distributed launcher, site/round counts, data location, and aggregation
    intent. Do not import or execute user training modules to discover them.
-3. Apply the dependency-install ordering rule in `../nvflare-shared/references/conversion-common.md` before
-   any Python command imports user, framework, NVFLARE, or declared dependency
-   modules.
+3. Apply the dependency-install ordering rule in `../nvflare-shared/references/conversion-common.md` before any Python command imports user, framework, NVFLARE, or declared dependencies. Keep dependency inventory single-purpose: check NVFLARE separately, inventory non-product packages separately, and do not append Hugging Face cache or filesystem discovery.
+   Defer model and dataset availability checks to the maintained resolver during validation. If an optional path must be inspected, run it separately and report a missing directory with exit code zero.
 4. Select the recipe from FL intent. For explicit FedAvg, run `nvflare recipe
    show fedavg-pt --format json`, then immediately load
    `../nvflare-shared/references/pytorch-family-recipe-construction.md` and use

--- a/skills/nvflare-convert-huggingface/assets/client_with_eval.py
+++ b/skills/nvflare-convert-huggingface/assets/client_with_eval.py
@@ -13,40 +13,13 @@ best-model selection is required. Set it to ``False`` only for a valid
 train-only source path.
 
 The entry is rankless for CPU, single-GPU, and other single-process training.
-With an initialized multi-process group, it passes
-``torch.distributed.get_rank()`` to FLARE. If environment markers declare a
-multi-process launch before the process group is initialized, global ``RANK``
-must already be available; otherwise the entry fails before FLARE initialization.
-For a preserved multi-GPU launch, follow
+The Hugging Face Client API resolves an initialized process-group rank or global
+``RANK`` and rejects an unresolved multi-process launch. For a preserved
+multi-GPU launch, follow
 ``references/huggingface-state-and-distributed.md``.
 """
 
-import os
-
-import torch.distributed as dist
-
 import nvflare.client.hf as flare
-
-
-_MULTIRANK_SIZE_ENV_VARS = ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS")
-
-
-def _environment_declares_multirank() -> bool:
-    for name in _MULTIRANK_SIZE_ENV_VARS:
-        try:
-            if int(os.environ.get(name, "1") or 1) > 1:
-                return True
-        except (TypeError, ValueError):
-            continue
-    return False
-
-
-def _has_valid_global_rank_env() -> bool:
-    try:
-        int(os.environ["RANK"])
-    except (KeyError, TypeError, ValueError):
-        return False
-    return True
 
 
 def make_hf_argument_parser(dataclass_types):
@@ -58,17 +31,7 @@ def make_hf_argument_parser(dataclass_types):
 
 def main(trainer_factory, *, evaluate_before_train=True):
     """Run one persistent patched Trainer in single-process or distributed mode."""
-    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
-        flare.init(rank=dist.get_rank())
-    else:
-        if _environment_declares_multirank() and not _has_valid_global_rank_env():
-            raise RuntimeError(
-                "multi-process launch detected but global RANK is unavailable; initialize torch.distributed "
-                "or export a valid global RANK before FLARE Client API initialization"
-            )
-        # CPU and single-GPU runs stay rankless. Under torchrun, flare.init()
-        # resolves the global RANK environment value.
-        flare.init()
+    flare.init()
     trainer = trainer_factory()
     flare.patch(trainer)
 

--- a/skills/nvflare-convert-huggingface/assets/client_with_eval.py
+++ b/skills/nvflare-convert-huggingface/assets/client_with_eval.py
@@ -14,13 +14,39 @@ train-only source path.
 
 The entry is rankless for CPU, single-GPU, and other single-process training.
 With an initialized multi-process group, it passes
-``torch.distributed.get_rank()`` to FLARE. For a preserved multi-GPU launch, follow
+``torch.distributed.get_rank()`` to FLARE. If environment markers declare a
+multi-process launch before the process group is initialized, global ``RANK``
+must already be available; otherwise the entry fails before FLARE initialization.
+For a preserved multi-GPU launch, follow
 ``references/huggingface-state-and-distributed.md``.
 """
+
+import os
 
 import torch.distributed as dist
 
 import nvflare.client.hf as flare
+
+
+_MULTIRANK_SIZE_ENV_VARS = ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS")
+
+
+def _environment_declares_multirank() -> bool:
+    for name in _MULTIRANK_SIZE_ENV_VARS:
+        try:
+            if int(os.environ.get(name, "1") or 1) > 1:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _has_valid_global_rank_env() -> bool:
+    try:
+        int(os.environ["RANK"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    return True
 
 
 def make_hf_argument_parser(dataclass_types):
@@ -35,6 +61,11 @@ def main(trainer_factory, *, evaluate_before_train=True):
     if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
         flare.init(rank=dist.get_rank())
     else:
+        if _environment_declares_multirank() and not _has_valid_global_rank_env():
+            raise RuntimeError(
+                "multi-process launch detected but global RANK is unavailable; initialize torch.distributed "
+                "or export a valid global RANK before FLARE Client API initialization"
+            )
         # CPU and single-GPU runs stay rankless. Under torchrun, flare.init()
         # resolves the global RANK environment value.
         flare.init()

--- a/skills/nvflare-convert-huggingface/assets/client_with_eval.py
+++ b/skills/nvflare-convert-huggingface/assets/client_with_eval.py
@@ -12,10 +12,13 @@ Keep ``evaluate_before_train=True`` when source-backed per-round evaluation or
 best-model selection is required. Set it to ``False`` only for a valid
 train-only source path.
 
-This standard asset assumes one training process per site. For a preserved
-distributed multi-process launch, adapt Client API initialization using
+The entry is rankless for CPU, single-GPU, and other single-process training.
+With an initialized multi-process group, it passes
+``torch.distributed.get_rank()`` to FLARE. For a preserved multi-GPU launch, follow
 ``references/huggingface-state-and-distributed.md``.
 """
+
+import torch.distributed as dist
 
 import nvflare.client.hf as flare
 
@@ -28,8 +31,13 @@ def make_hf_argument_parser(dataclass_types):
 
 
 def main(trainer_factory, *, evaluate_before_train=True):
-    """Run one persistent patched Trainer in a single training process."""
-    flare.init()
+    """Run one persistent patched Trainer in single-process or distributed mode."""
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        flare.init(rank=dist.get_rank())
+    else:
+        # CPU and single-GPU runs stay rankless. Under torchrun, flare.init()
+        # resolves the global RANK environment value.
+        flare.init()
     trainer = trainer_factory()
     flare.patch(trainer)
 

--- a/skills/nvflare-convert-huggingface/assets/client_with_eval.py
+++ b/skills/nvflare-convert-huggingface/assets/client_with_eval.py
@@ -11,6 +11,10 @@ owns model exchange; do not add a manual ``FLModel`` receive/send path.
 Keep ``evaluate_before_train=True`` when source-backed per-round evaluation or
 best-model selection is required. Set it to ``False`` only for a valid
 train-only source path.
+
+This standard asset assumes one training process per site. For a preserved
+distributed multi-process launch, adapt Client API initialization using
+``references/huggingface-state-and-distributed.md``.
 """
 
 import nvflare.client.hf as flare
@@ -23,9 +27,9 @@ def make_hf_argument_parser(dataclass_types):
     return HfArgumentParser(dataclass_types, allow_abbrev=False)
 
 
-def main(trainer_factory, *, rank, evaluate_before_train=True):
-    """Run one persistent patched Trainer using the caller's resolved global rank."""
-    flare.init(rank=rank)
+def main(trainer_factory, *, evaluate_before_train=True):
+    """Run one persistent patched Trainer in a single training process."""
+    flare.init()
     trainer = trainer_factory()
     flare.patch(trainer)
 

--- a/skills/nvflare-convert-huggingface/assets/job.py
+++ b/skills/nvflare-convert-huggingface/assets/job.py
@@ -5,9 +5,11 @@
 
 Copy this file beside ``client.py``, ``server_model.py``, and packaged
 project-local modules such as ``model.py``. Adapt the client argument names and
-capability-gated recipe options to the source project. Keep the required Recipe,
-packaging, and execution structure; do not replace local file names with parent
-traversal paths.
+capability-gated recipe options to the source project. Use
+``resolve_source_local_path`` only for an inspected source argument that names a
+local file or directory; do not use it for Hub identifiers, URLs, or site-local
+paths. Keep the required Recipe, packaging, and execution structure; do not
+replace local file names with parent traversal paths.
 """
 
 import argparse
@@ -23,6 +25,14 @@ from nvflare.recipe import SimEnv, set_per_site_config
 
 DEFAULT_MAX_STEPS = 10
 SOURCE_DIR = Path(__file__).resolve().parent
+
+
+def resolve_source_local_path(value: str | Path) -> Path:
+    """Resolve an inspected source-project-relative local path."""
+    path = Path(value)
+    if not path.is_absolute():
+        path = SOURCE_DIR / path
+    return path.resolve()
 
 
 @contextmanager
@@ -72,7 +82,6 @@ def _positive_float_arg(value: str) -> float:
 
 def build_train_args(
     model_name_or_path: str,
-    data_root: str,
     num_clients: int,
     *,
     max_steps: int | None = None,
@@ -97,8 +106,6 @@ def build_train_args(
     args = [
         "--model_name_or_path",
         _token(model_name_or_path, "model_name_or_path"),
-        "--data_root",
-        _token(data_root, "data_root"),
         "--num_clients",
         str(num_clients),
     ]
@@ -116,7 +123,6 @@ def build_recipe(
     *,
     name: str,
     model_name_or_path: str,
-    data_root: str,
     num_clients: int,
     num_rounds: int,
     key_metric: str = "",
@@ -129,7 +135,6 @@ def build_recipe(
     """Build FedAvg using only options confirmed by ``recipe show``."""
     train_args = build_train_args(
         model_name_or_path,
-        data_root,
         num_clients,
         max_steps=max_steps,
         num_train_epochs=num_train_epochs,
@@ -198,7 +203,6 @@ def main():
     parser = argparse.ArgumentParser(description="Hugging Face Trainer FedAvg job", allow_abbrev=False)
     parser.add_argument("--name", default="hf-trainer-fedavg")
     parser.add_argument("--model_name_or_path", required=True)
-    parser.add_argument("--data_root", required=True)
     parser.add_argument("--num_clients", type=int, default=2)
     parser.add_argument("--num_rounds", type=int, default=2)
     budget = parser.add_mutually_exclusive_group()
@@ -221,7 +225,6 @@ def main():
     recipe = build_recipe(
         name=args.name,
         model_name_or_path=args.model_name_or_path,
-        data_root=args.data_root,
         num_clients=args.num_clients,
         num_rounds=args.num_rounds,
         max_steps=args.max_steps,

--- a/skills/nvflare-convert-huggingface/assets/job.py
+++ b/skills/nvflare-convert-huggingface/assets/job.py
@@ -7,9 +7,10 @@ Copy this file beside ``client.py``, ``server_model.py``, and packaged
 project-local modules such as ``model.py``. Adapt the client argument names and
 capability-gated recipe options to the source project. Use
 ``resolve_source_local_path`` only for an inspected source argument that names a
-local file or directory; do not use it for Hub identifiers, URLs, or site-local
-paths. Keep the required Recipe, packaging, and execution structure; do not
-replace local file names with parent traversal paths.
+local file or directory, and pass the inspected source-project root explicitly;
+do not use it for Hub identifiers, URLs, or site-local paths. Keep the required
+Recipe, packaging, and execution structure; do not replace local file names
+with parent traversal paths.
 """
 
 import argparse
@@ -27,12 +28,16 @@ DEFAULT_MAX_STEPS = 10
 SOURCE_DIR = Path(__file__).resolve().parent
 
 
-def resolve_source_local_path(value: str | Path) -> Path:
-    """Resolve an inspected source-project-relative local path."""
+def resolve_source_local_path(value: str | Path, *, source_root: str | Path) -> Path:
+    """Resolve a local path against its explicit inspected source-project root."""
     path = Path(value)
-    if not path.is_absolute():
-        path = SOURCE_DIR / path
-    return path.resolve()
+    if path.is_absolute():
+        return path.resolve()
+
+    root = Path(source_root).expanduser()
+    if not root.is_absolute():
+        raise ValueError("source_root must be an absolute path")
+    return (root / path).resolve()
 
 
 @contextmanager

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -376,6 +376,7 @@
       "assertions": [
         "The agent detects that load_dataset reads JSONL splits from an external absolute path rather than a hub dataset.",
         "The generated job passes the original data root through configurable train_args or per_site_config values so sites can override it.",
+        "The absolute /data/nvflare/reviews path remains unchanged and is not prefixed with SOURCE_DIR; site-specific overrides remain controlled by per_site_config rather than being resolved on the authoring machine.",
         "The generated client does not embed the absolute data path as a fixed non-configurable literal.",
         "The generated configuration points at the original external dataset location and not at data inside the nvflare run workspace.",
         "The agent preserves the source tokenization, collation, and compute_metrics semantics while adapting the Trainer to flare.patch(trainer)."
@@ -392,6 +393,46 @@
           {
             "id": "no-hardcoded-absolute-data-path",
             "description": "does not embed an absolute data path as a fixed non-configurable literal in generated client code and does not point at data inside the nvflare run workspace"
+          }
+        ]
+      }
+    },
+    {
+      "id": "huggingface-convert-relative-data-path",
+      "prompt": "Convert this Hugging Face Trainer project to a two-site NVFLARE FedAvg job. Preserve its dataset_path argument, whose default datasets/sst2 location is relative to the source project, and validate recipe construction from outside the project directory.",
+      "expected_output": "A Hugging Face conversion that preserves dataset_path, resolves its relative local value against the generated job's SOURCE_DIR before recipe construction, transmits the resulting absolute source location through train_args, and proves the behavior from a fresh caller working directory without applying filesystem resolution to Hub identifiers, URLs, or site-controlled paths.",
+      "files": [
+        "files/relative-data-hf/train.py",
+        "files/relative-data-hf/model.py"
+      ],
+      "assertions": [
+        "The generated job preserves the source argument name dataset_path and does not replace it with data_root or another invented option.",
+        "The generated job calls the maintained resolve_source_local_path helper for the inspected relative local dataset_path before Recipe construction.",
+        "Validation changes to a fresh working directory outside the project, constructs the Recipe with the relative dataset_path, and confirms that final train_args carries the expected absolute source location.",
+        "An absolute dataset_path remains absolute without a SOURCE_DIR prefix.",
+        "Hub identifiers, URLs, and per-site paths are not passed through the source-local filesystem resolver. Per-site paths remain controlled by per_site_config.",
+        "The conversion does not add path-specific code for source inputs that are not local file or directory arguments."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-huggingface",
+        "mandatory_behavior": [
+          {
+            "id": "resolve-relative-source-local-path",
+            "description": "preserves dataset_path and resolves its relative local value against SOURCE_DIR before Recipe construction"
+          },
+          {
+            "id": "validate-source-path-from-fresh-cwd",
+            "description": "constructs the Recipe from outside the project and verifies final train_args carries the expected absolute source location"
+          }
+        ],
+        "prohibited_behavior": [
+          {
+            "id": "no-invented-data-root-option",
+            "description": "does not replace dataset_path with data_root or add a generic data-path option unrelated to the inspected source"
+          },
+          {
+            "id": "no-filesystem-resolution-for-nonlocal-inputs",
+            "description": "does not pass Hub identifiers, URLs, or per-site paths through the source-local filesystem resolver"
           }
         ]
       }

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -405,16 +405,16 @@
     {
       "id": "huggingface-convert-relative-data-path",
       "prompt": "Convert this Hugging Face Trainer project to a two-site NVFLARE FedAvg job. Preserve its dataset_path argument, whose default datasets/sst2 location is relative to the source project, and validate recipe construction from outside the project directory.",
-      "expected_output": "A Hugging Face conversion that preserves dataset_path, resolves its relative local value against the generated job's SOURCE_DIR before recipe construction, transmits the resulting absolute source location through train_args, and proves the behavior from a fresh caller working directory without applying filesystem resolution to Hub identifiers, URLs, or site-controlled paths.",
+      "expected_output": "A Hugging Face conversion that preserves dataset_path, resolves its relative local value against the explicit inspected source-project root before recipe construction, uses SOURCE_DIR only when generated job.py is colocated with that source, transmits the resulting absolute source location through train_args, and proves the behavior from a fresh caller working directory without applying filesystem resolution to Hub identifiers, URLs, or site-controlled paths.",
       "files": [
         "files/relative-data-hf/train.py",
         "files/relative-data-hf/model.py"
       ],
       "assertions": [
         "The generated job preserves the source argument name dataset_path and does not replace it with data_root or another invented option.",
-        "The generated job calls the maintained resolve_source_local_path helper for the inspected relative local dataset_path before Recipe construction.",
+        "The generated job calls the maintained resolve_source_local_path helper with the explicit inspected source-project root for the relative local dataset_path before Recipe construction.",
         "Validation changes to a fresh working directory outside the project, constructs the Recipe with the relative dataset_path, and confirms that final train_args carries the expected absolute source location.",
-        "An absolute dataset_path remains absolute without a SOURCE_DIR prefix.",
+        "An absolute dataset_path remains absolute without a source-root prefix, and a read-only source root is not replaced by the generated job directory.",
         "Hub identifiers, URLs, and per-site paths are not passed through the source-local filesystem resolver. Per-site paths remain controlled by per_site_config.",
         "The conversion does not add path-specific code for source inputs that are not local file or directory arguments."
       ],
@@ -423,7 +423,7 @@
         "mandatory_behavior": [
           {
             "id": "resolve-relative-source-local-path",
-            "description": "preserves dataset_path and resolves its relative local value against SOURCE_DIR before Recipe construction"
+            "description": "preserves dataset_path and resolves its relative local value against the explicit inspected source-project root before Recipe construction, using SOURCE_DIR only for colocated generation"
           },
           {
             "id": "validate-source-path-from-fresh-cwd",

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -489,16 +489,16 @@
     {
       "id": "huggingface-ddp-contract",
       "prompt": "Convert this Hugging Face Trainer job for torchrun with two GPU processes per site. Keep checkpoint state across FL rounds and explain any shared-storage requirement.",
-      "expected_output": "A Hugging Face conversion that preserves torchrun, initializes torch.distributed before flare.patch, requires and forwards the resolved global rank to flare.init, keeps every rank in the same is_running/evaluate/train sequence, validates the two-process path with observed ranks 0 and 1, uses external execution, and explains that in-memory parameter broadcast needs no shared output directory while restore_state checkpoint paths must be visible to every rank.",
+      "expected_output": "A Hugging Face conversion that preserves torchrun, initializes torch.distributed before flare.patch, calls rankless nvflare.client.hf.init so the product resolves or rejects the global rank, keeps every rank in the same is_running/evaluate/train sequence, validates the two-process path with observed ranks 0 and 1, uses external execution, and explains that in-memory parameter broadcast needs no shared output directory while restore_state checkpoint paths must be visible to every rank.",
       "files": [
         "files/trainer-basic/train.py",
         "files/trainer-basic/model.py"
       ],
       "assertions": [
         "The generated client initializes torch.distributed before flare.patch when WORLD_SIZE is greater than one.",
-        "The generated client requires a resolved global rank with no rank-zero default, uses global RANK or the initialized process-group rank rather than LOCAL_RANK, and forwards that value to flare.init(rank=rank).",
+        "The generated client calls nvflare.client.hf.init() without reimplementing rank resolution; the product uses global RANK or the initialized process-group rank rather than LOCAL_RANK and rejects an unresolved multi-process launch before creating a Client API context.",
         "Every rank calls is_running, evaluate, and train in identical order.",
-        "Before claiming DDP coverage, the agent runs a two-process torchrun validation and records distinct resolved and flare.init ranks 0 and 1.",
+        "Before claiming DDP coverage, the agent runs a two-process torchrun validation and records distinct launcher and product-resolved Client API ranks 0 and 1.",
         "The agent preserves the user-provided torchrun process count and does not invent multi-node rendezvous settings.",
         "The agent distinguishes default in-memory parameter broadcast from shared checkpoint-path requirements."
       ],
@@ -507,11 +507,11 @@
         "mandatory_behavior": [
           {
             "id": "initialize-distributed-before-patch",
-            "description": "initializes the distributed process group before patching when a multi-rank environment is declared, requires the resolved global rank, and forwards it unchanged to flare.init without a rank-zero default"
+            "description": "initializes the distributed process group before patching when a multi-rank environment is declared and relies on rankless nvflare.client.hf.init for product-owned global-rank resolution and fail-fast rejection"
           },
           {
             "id": "rank-symmetric-trainer-loop",
-            "description": "keeps all ranks in the same patched Trainer call order and validates the two-process path with observed global and flare.init ranks 0 and 1 before claiming DDP coverage"
+            "description": "keeps all ranks in the same patched Trainer call order and validates the two-process path with observed launcher and product-resolved Client API ranks 0 and 1 before claiming DDP coverage"
           },
           {
             "id": "checkpoint-storage-contract",
@@ -522,6 +522,10 @@
           {
             "id": "no-local-rank-as-global-rank",
             "description": "does not use LOCAL_RANK as the global FLARE process rank"
+          },
+          {
+            "id": "no-generated-rank-resolution",
+            "description": "does not duplicate product-owned environment or process-group rank resolution in the generated client"
           },
           {
             "id": "no-invented-distributed-launch",

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -57,6 +57,7 @@
         "The generated job imports FedAvgRecipe from nvflare.app_opt.pt.recipes.fedavg after recipe show confirms it.",
         "The agent treats recipe show as recipe metadata only, uses SimEnv with recipe.execute for local validation and standard export flags, and does not guess a separate export environment, private class-loader helper, internal command splitter, or another recipe-adjacent API.",
         "The agent establishes host-provided NVFLARE availability separately through nvflare agent inspect source, nvflare --version, or a public capability check before generic package inventory; it never includes nvflare in a batch of importlib.metadata lookups, handles missing non-product metadata as an inventory result rather than a failed command, and skips installation when all applicable requirements are already compatible.",
+        "The agent keeps dependency inventory separate from optional Hugging Face cache or filesystem discovery, defers model and dataset availability checks to the maintained resolver, and makes any separately necessary missing-path probe exit zero.",
         "The agent tells the maintained resolver whether each model identifier is a local path or Hub repository ID instead of inferring from slash syntax. When public checkpoint download is authorized if uncached, it uses one normal cache-aware load pinned to a full immutable commit SHA instead of an unguarded cache-only probe that fails on a normal miss.",
         "A generated or preserved HfArgumentParser is constructed with allow_abbrev=False. Intentional typo and abbreviation rejection checks run through assertion wrappers whose top-level commands succeed only when the generated parser rejects them; the wrapper accepts an expected unused-argument ValueError only when its diagnostic names the rejected argument.",
         "Standalone preflight may construct the Trainer but does not call flare.init(), flare.patch(), flare.is_running(), or patched Trainer methods without a launcher-created Client API context; the first bounded simulation validates runtime patch acceptance.",
@@ -201,6 +202,10 @@
           {
             "id": "no-failing-nvflare-metadata-probe",
             "description": "checks host-provided NVFLARE separately through its CLI or a public capability probe, excludes nvflare from generic distribution-metadata batches, and handles missing non-product metadata without a failed top-level inventory command"
+          },
+          {
+            "id": "no-compound-dependency-and-cache-probe",
+            "description": "does not combine required dependency inventory with optional Hugging Face cache or filesystem discovery whose absence can fail the command"
           },
           {
             "id": "no-raising-cache-only-model-probe",

--- a/skills/nvflare-convert-huggingface/evals/evals.json
+++ b/skills/nvflare-convert-huggingface/evals/evals.json
@@ -49,6 +49,7 @@
         "The agent completes inspect, dependency handling, recipe show and capability construction, conversion, job construction, and validation in order without preloading advanced or validation references.",
         "The generated conversion adapts the maintained HF client_with_eval.py, server_model.py, and job.py assets instead of drafting another loop or probing Recipe, persistor, class-loader, simulator, or argument-transport implementation source.",
         "The generated FL client entry cannot bypass flare.init() or flare.patch(trainer) through CLIENT_API_TYPE or other launch-environment detection; any preserved standalone path is behind an explicit non-client entry parameter.",
+        "For this single-process simulation, the generated client calls flare.init() without a required rank parser field or a --rank recipe argument.",
         "The generated client does not implement manual FLModel receive/send model exchange.",
         "The model, datasets, TrainingArguments, and Trainer are constructed once before the FL round loop.",
         "The agent encodes a prompt-specified local budget once in Trainer max_steps or num_train_epochs and lets flare.patch infer it; when the prompt is silent it reports max_steps=10 unless source-budget preservation was requested, and it does not interrupt a valid run because cumulative max_steps covers all rounds.",
@@ -90,6 +91,10 @@
           {
             "id": "fl-only-client-entry",
             "description": "ensures the generated FL client entry always reaches flare.init and flare.patch, with no CLIENT_API_TYPE or launch-environment auto-detection"
+          },
+          {
+            "id": "single-process-rankless-init",
+            "description": "uses flare.init() without a required rank parser field or --rank recipe argument for the standard single-process launch"
           },
           {
             "id": "global-evaluation-before-training",

--- a/skills/nvflare-convert-huggingface/evals/files/relative-data-hf/model.py
+++ b/skills/nvflare-convert-huggingface/evals/files/relative-data-hf/model.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from transformers import AutoModelForSequenceClassification
+
+MODEL_NAME = "distilbert/distilbert-base-uncased"
+
+
+def create_model():
+    return AutoModelForSequenceClassification.from_pretrained(MODEL_NAME, num_labels=2)

--- a/skills/nvflare-convert-huggingface/evals/files/relative-data-hf/train.py
+++ b/skills/nvflare-convert-huggingface/evals/files/relative-data-hf/train.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from pathlib import Path
+
+from datasets import load_dataset
+from model import MODEL_NAME, create_model
+from transformers import AutoTokenizer, Trainer, TrainingArguments
+
+DEFAULT_DATASET_PATH = Path("datasets/sst2")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_path", type=Path, default=DEFAULT_DATASET_PATH)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    dataset = load_dataset(
+        "json",
+        data_files={
+            "train": str(args.dataset_path / "train.jsonl"),
+            "validation": str(args.dataset_path / "valid.jsonl"),
+        },
+    )
+    tokenized = dataset.map(lambda row: tokenizer(row["text"], truncation=True), batched=True)
+    trainer = Trainer(
+        model=create_model(),
+        args=TrainingArguments(output_dir="outputs", max_steps=2, report_to=[]),
+        train_dataset=tokenized["train"],
+        eval_dataset=tokenized["validation"],
+    )
+    trainer.evaluate()
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -124,6 +124,12 @@ NVFLARE rejects parent-traversal external-script paths. For an exceptional
 non-co-located module, pass its existing resolved absolute source path to the
 packaging API.
 
+`SOURCE_DIR` identifies the generated-file directory for packaging; it is the
+source-project root only in the colocated case. If a read-only source root puts
+generated files elsewhere, pass the inspected original root explicitly to
+`resolve_source_local_path(..., source_root=...)` for source-relative data. Do
+not resolve those data paths against the writable generated-file directory.
+
 Add optional recipe arguments and decomposers only as directed by the selected
 recipe's capability profile and the shared construction reference. Do not copy
 the FedAvg constructor shape to another recipe. When sites genuinely need

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -44,10 +44,12 @@ so every `flare.*` call below resolves to `nvflare.client.hf`.
 
 Follow the framework-neutral Client API initialization and rank contract in
 `../../nvflare-shared/references/conversion-common.md`. The standard
-single-process asset calls `flare.init()` with no rank argument. For a preserved
-distributed multi-process launch, load
-`huggingface-state-and-distributed.md` and pass its resolved global process rank
-to `flare.init(...)`. In either path, initialize explicitly before
+single-process path calls `flare.init()` with no rank argument. When a process
+group is already initialized with world size greater than one, the same asset
+passes `torch.distributed.get_rank()` to `flare.init(...)`. Otherwise the Client
+API resolves torchrun's global `RANK` environment value, and `flare.patch()`
+verifies it after Trainer initialization. For a preserved multi-GPU launch,
+load `huggingface-state-and-distributed.md`. In either path, initialize before
 `flare.get_site_name()`, `flare.get_config()`, or other Client API context
 access that occurs before `patch()`. The patch initializes the Client API when
 no earlier context access is needed.

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -44,15 +44,13 @@ so every `flare.*` call below resolves to `nvflare.client.hf`.
 
 Follow the framework-neutral Client API initialization and rank contract in
 `../../nvflare-shared/references/conversion-common.md`. The standard
-single-process path calls `flare.init()` with no rank argument. When a process
-group is already initialized with world size greater than one, the same asset
-passes `torch.distributed.get_rank()` to `flare.init(...)`. Otherwise the Client
-API resolves torchrun's global `RANK` environment value, and `flare.patch()`
-verifies it after Trainer initialization. For a preserved multi-GPU launch,
-load `huggingface-state-and-distributed.md`. In either path, initialize before
-`flare.get_site_name()`, `flare.get_config()`, or other Client API context
-access that occurs before `patch()`. The patch initializes the Client API when
-no earlier context access is needed.
+asset always calls rankless `nvflare.client.hf.init()`. The product resolves an
+initialized process-group rank or global `RANK` and rejects an unresolved
+multi-process launch before creating a Client API context; do not reimplement
+that logic in generated code. For a preserved multi-GPU launch, load
+`huggingface-state-and-distributed.md`. Initialize before
+`flare.get_site_name()`, `flare.get_config()`, or other Client API context access
+that occurs before `patch()`.
 
 Do not add manual model loading from `flare.receive()` or model sending through
 `flare.send()`. The patch wraps `train()` and `evaluate()`, loads the received

--- a/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-conversion.md
@@ -42,10 +42,15 @@ default selector. See the Best-Model Metric section of
 Import the Client API as `import nvflare.client.hf as flare`, as the asset does,
 so every `flare.*` call below resolves to `nvflare.client.hf`.
 
-Call `flare.init(rank=rank)` explicitly before `flare.get_site_name()`,
-`flare.get_config()`, or other Client API context access that occurs before
-`patch()`. The patch initializes the Client API when no earlier context access
-is needed.
+Follow the framework-neutral Client API initialization and rank contract in
+`../../nvflare-shared/references/conversion-common.md`. The standard
+single-process asset calls `flare.init()` with no rank argument. For a preserved
+distributed multi-process launch, load
+`huggingface-state-and-distributed.md` and pass its resolved global process rank
+to `flare.init(...)`. In either path, initialize explicitly before
+`flare.get_site_name()`, `flare.get_config()`, or other Client API context
+access that occurs before `patch()`. The patch initializes the Client API when
+no earlier context access is needed.
 
 Do not add manual model loading from `flare.receive()` or model sending through
 `flare.send()`. The patch wraps `train()` and `evaluate()`, loads the received

--- a/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
@@ -63,7 +63,13 @@ Initialize `torch.distributed` before `flare.patch(trainer)` whenever
 the initialized process group or global `RANK`, not `LOCAL_RANK`. The maintained
 asset passes `torch.distributed.get_rank()` to `flare.init(...)` when the group
 is already initialized; otherwise `flare.init()` resolves global `RANK`, and
-`flare.patch(trainer)` verifies the rank after Trainer initialization.
+`flare.patch(trainer)` verifies the rank after Trainer initialization. If
+`WORLD_SIZE`, `LOCAL_WORLD_SIZE`, `OMPI_COMM_WORLD_SIZE`, or `SLURM_NTASKS`
+declares multiple processes while the group is still uninitialized, the asset
+requires a valid global `RANK` and rejects the launch before `flare.init()` when
+it is missing. Configure the launcher to export global `RANK` or initialize the
+process group before this entry; never let scheduler-specific rank variables
+silently become rank zero.
 `LOCAL_RANK` selects the local device and may differ from global `RANK` on
 multi-node launches; do not pass it as the FLARE rank.
 

--- a/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
@@ -53,13 +53,18 @@ optimizer/scheduler state.
 
 ## Distributed Training
 
+This section applies only to a preserved distributed multi-process launch.
+Apply the framework-neutral global-rank contract in
+`../../nvflare-shared/references/conversion-common.md`; do not add a rank
+argument to a standard single-process conversion.
+
 Initialize `torch.distributed` before `flare.patch(trainer)` whenever
 `WORLD_SIZE` or `LOCAL_WORLD_SIZE` is greater than one. Resolve global rank from
-the initialized process group or global `RANK`, not `LOCAL_RANK`. Pass that rank
-to the generated client's required `rank` argument and then to
-`flare.init(rank=rank)`. `LOCAL_RANK` selects the local device and may differ
-from global `RANK` on multi-node launches; do not pass it as the FLARE rank.
-Reject a multi-process launch when global rank cannot be resolved.
+the initialized process group or global `RANK`, not `LOCAL_RANK`, and pass it to
+`flare.init(rank=global_rank)`. If the generated entry exposes rank as an
+argument, make it required and verify that the preserved distributed launcher
+supplies it. `LOCAL_RANK` selects the local device and may differ from global
+`RANK` on multi-node launches; do not pass it as the FLARE rank.
 
 Every rank must execute the same generated sequence of patched methods. If the
 source-backed loop evaluates before training, all ranks call

--- a/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
@@ -60,11 +60,12 @@ argument to a standard single-process conversion.
 
 Initialize `torch.distributed` before `flare.patch(trainer)` whenever
 `WORLD_SIZE` or `LOCAL_WORLD_SIZE` is greater than one. Resolve global rank from
-the initialized process group or global `RANK`, not `LOCAL_RANK`, and pass it to
-`flare.init(rank=global_rank)`. If the generated entry exposes rank as an
-argument, make it required and verify that the preserved distributed launcher
-supplies it. `LOCAL_RANK` selects the local device and may differ from global
-`RANK` on multi-node launches; do not pass it as the FLARE rank.
+the initialized process group or global `RANK`, not `LOCAL_RANK`. The maintained
+asset passes `torch.distributed.get_rank()` to `flare.init(...)` when the group
+is already initialized; otherwise `flare.init()` resolves global `RANK`, and
+`flare.patch(trainer)` verifies the rank after Trainer initialization.
+`LOCAL_RANK` selects the local device and may differ from global `RANK` on
+multi-node launches; do not pass it as the FLARE rank.
 
 Every rank must execute the same generated sequence of patched methods. If the
 source-backed loop evaluates before training, all ranks call

--- a/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md
@@ -60,16 +60,11 @@ argument to a standard single-process conversion.
 
 Initialize `torch.distributed` before `flare.patch(trainer)` whenever
 `WORLD_SIZE` or `LOCAL_WORLD_SIZE` is greater than one. Resolve global rank from
-the initialized process group or global `RANK`, not `LOCAL_RANK`. The maintained
-asset passes `torch.distributed.get_rank()` to `flare.init(...)` when the group
-is already initialized; otherwise `flare.init()` resolves global `RANK`, and
-`flare.patch(trainer)` verifies the rank after Trainer initialization. If
-`WORLD_SIZE`, `LOCAL_WORLD_SIZE`, `OMPI_COMM_WORLD_SIZE`, or `SLURM_NTASKS`
-declares multiple processes while the group is still uninitialized, the asset
-requires a valid global `RANK` and rejects the launch before `flare.init()` when
-it is missing. Configure the launcher to export global `RANK` or initialize the
-process group before this entry; never let scheduler-specific rank variables
-silently become rank zero.
+the initialized process group or global `RANK`, not `LOCAL_RANK`.
+`nvflare.client.hf.init()` owns this resolution and rejects a declared
+multi-process launch when neither source is available, before creating a Client
+API context. Keep the generated client rankless instead of duplicating product
+logic.
 `LOCAL_RANK` selects the local device and may differ from global `RANK` on
 multi-node launches; do not pass it as the FLARE rank.
 

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -176,8 +176,8 @@ reaches the applicable phase, and stop at the first failure.
   applicable checks.
 - Do not report DDP validated from a single-process or rank-zero-only
   simulation. A DDP validation claim requires a two-process `torchrun` case in
-  which each process records its resolved global rank and the rank passed to
-  `flare.init()`, and the observed ranks are exactly `{0, 1}`.
+  which each process records its launcher rank and product-resolved Client API
+  rank, and the observed ranks are exactly `{0, 1}`.
 
 ## Report
 

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -23,7 +23,8 @@ reaches the applicable phase, and stop at the first failure.
   unused argument. When the generated client uses `HfArgumentParser`, construct
   it with `allow_abbrev=False` and parse with the same project and framework
   dataclass types. When it preserves `argparse` or another parser, use that
-  parser instead.
+  parser instead. Test the exact arguments produced by the generated job helper;
+  do not append an argument only in preflight that the recipe will not deliver.
 - Run intentional typo and abbreviation rejection cases through the shared
   assertion-wrapper rule. `HfArgumentParser.parse_args_into_dataclasses()` may
   raise `ValueError` for unused arguments rather than `SystemExit`; the wrapper

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -39,6 +39,15 @@ reaches the applicable phase, and stop at the first failure.
   `train_args` values. Do not assume shell parsing or call internal command
   splitters. If a required value contains whitespace and no documented
   structured argument surface exists, fail closed.
+- Only when source inspection found a source-project-relative local file or
+  directory argument, change to a fresh working directory outside the project,
+  construct the Recipe with that relative source value, and inspect the final
+  `train_args`. Require the source argument name to be unchanged and its
+  transmitted value to be absolute and equal to the expected location under
+  `SOURCE_DIR` before running the full simulation. Skip this path-specific check
+  when the source has no local path argument. Do not pass absolute local paths,
+  per-site paths, Hub identifiers, or URLs through the relative-path test;
+  validate their classification using `site-data-and-paths.md` instead.
 
 ## Hugging Face Artifacts And Compatibility
 

--- a/skills/nvflare-convert-huggingface/references/huggingface-validation.md
+++ b/skills/nvflare-convert-huggingface/references/huggingface-validation.md
@@ -44,10 +44,13 @@ reaches the applicable phase, and stop at the first failure.
   construct the Recipe with that relative source value, and inspect the final
   `train_args`. Require the source argument name to be unchanged and its
   transmitted value to be absolute and equal to the expected location under
-  `SOURCE_DIR` before running the full simulation. Skip this path-specific check
-  when the source has no local path argument. Do not pass absolute local paths,
-  per-site paths, Hub identifiers, or URLs through the relative-path test;
-  validate their classification using `site-data-and-paths.md` instead.
+  the explicit inspected source-project root before running the full simulation.
+  `SOURCE_DIR` is that root only when generated `job.py` is colocated with the
+  source; a read-only-source flow must validate against the separate original
+  root. Skip this path-specific check when the source has no local path argument.
+  Do not pass absolute local paths, per-site paths, Hub identifiers, or URLs
+  through the relative-path test; validate their classification using
+  `../../nvflare-shared/references/site-data-and-paths.md` instead.
 
 ## Hugging Face Artifacts And Compatibility
 

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-convert-lightning
-description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use when the user names PyTorch Lightning or preliminary source inspection identifies one Lightning owner, and not for plain PyTorch, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
+description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use only when the request expresses federated or NVFLARE conversion intent and either names PyTorch Lightning or preliminary source inspection identifies one Lightning owner; do not use for non-federated Lightning work such as DDP, profiling, inference serving, or training-loop changes, nor for plain PyTorch, TensorFlow/Keras, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
 metadata:
   version: "0.1.0"
@@ -18,16 +18,16 @@ metadata:
 
 ## Use When
 
-Use when the user asks to convert PyTorch Lightning code into an NVFLARE
-federated training job: a `LightningModule`, `LightningDataModule`, a `Trainer`
-fit/validate/test loop, Lightning callbacks, checkpointing, or loggers.
+Use only when the user asks to convert PyTorch Lightning code into an NVFLARE federated training job; require both federation intent and Lightning ownership.
+Lightning source evidence alone is not sufficient. Relevant source may contain a `LightningModule`, `LightningDataModule`, a `Trainer` fit/validate/test loop,
+Lightning callbacks, checkpointing, or loggers.
 Supported: the PyTorch recipe family with `flare.patch(trainer)` as the model
 exchange integration, Lightning-native evaluation, custom aggregation through
 the same recipe `aggregator=` hook, and local validation and export.
 
 ## Do Not Use When
 
-Do not use for plain `torch.nn.Module` manual training loops without Lightning
+Do not use for non-federated Lightning changes such as DDP-only configuration, profiling, inference serving, callbacks, early stopping, or schedulers; or for plain `torch.nn.Module` manual training loops without Lightning
 (route to `nvflare-convert-pytorch`), Hugging Face Trainer (route to `nvflare-convert-huggingface`), TensorFlow,
 XGBoost, scikit-learn, a failed job (route to `nvflare-diagnose-job`),
 federated statistics without training (route to `nvflare-fed-stats`), or

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -25,6 +25,28 @@ Supported: the PyTorch recipe family with `flare.patch(trainer)` as the model
 exchange integration, Lightning-native evaluation, custom aggregation through
 the same recipe `aggregator=` hook, and local validation and export.
 
+## Standard Path
+
+Always read this converter SKILL.md with
+`../nvflare-shared/references/conversion-common.md`. For an explicit-FedAvg
+conversion, load only these references, in workflow order:
+
+1. During inspection, `references/lightning-detection.md`.
+2. For generated splits, relative paths, or per-site data locations,
+   `../nvflare-shared/references/site-data-and-paths.md`.
+3. After `nvflare recipe show fedavg-pt --format json`,
+   `../nvflare-shared/references/pytorch-family-recipe-construction.md`.
+4. During conversion, `references/lightning-conversion.md`, then
+   `../nvflare-shared/references/pytorch-model-exchange.md`.
+5. Only after generated files exist,
+   `../nvflare-shared/references/validation-evidence.md`, then
+   `references/lightning-validation.md`.
+
+Complete each workflow phase before loading the next phase's reference. Do not
+enumerate reference directories or preload validation, DDP/tracking, broad
+workflow, dependency, runtime-output, or reporting references. Do not depend on
+NVFLARE repository examples.
+
 ## Do Not Use When
 
 Do not use for non-federated Lightning changes such as DDP-only configuration, profiling, inference serving, callbacks, early stopping, or schedulers; or for plain `torch.nn.Module` manual training loops without Lightning
@@ -50,16 +72,10 @@ distribution; handle conversion later as a separate request.
 
 ## Workflow
 
-1. Load `../nvflare-shared/references/conversion-common.md` and apply it for the
-   whole conversion; this SKILL.md states only the framework-specific deltas.
-   Load `../nvflare-shared/references/conversion-workflow.md` only for a non-standard
-   rerun, authorization, or missing-semantics case; it no longer holds the
-   data-location or partitioning contracts, whose invariants `conversion-common.md`
-   owns. Load `../nvflare-shared/references/site-data-and-paths.md` for generated
-   partitions, relative paths, or per-site data locations.
+1. Apply `../nvflare-shared/references/conversion-common.md` for the whole
+   conversion; this SKILL.md states only the framework-specific deltas.
 2. Inspect before editing with `nvflare agent inspect source <path> --format json`
-   plus direct reading; fact extraction is static. Use
-   `references/lightning-detection.md` to confirm Lightning versus plain
+   plus direct reading; fact extraction is static. Confirm Lightning versus plain
    PyTorch and hand off to `nvflare-convert-pytorch` when no Lightning evidence
    exists. If inspection recommends `nvflare-orient` for active Lightning and
    Hugging Face Trainer owners, stop and hand off before editing.
@@ -81,16 +97,11 @@ distribution; handle conversion later as a separate request.
    For the standard case — the user explicitly requests FedAvg and inspection
    identifies Lightning — run `nvflare recipe show fedavg-pt --format json`
    directly and construct it. For `fedavg-pt`, import `FedAvgRecipe` only from
-   `nvflare.app_opt.pt.recipes.fedavg`, never from `nvflare.recipe`. Load
-   `../nvflare-shared/references/pytorch-family-recipe-selection.md` (discovery,
-   algorithm guide, catalog-based selection, HE-not-supported rule; FedAvg,
-   FedOpt, FedProx, SCAFFOLD, Cyclic, Swarm, FedEval) only for ambiguous or
-   non-FedAvg algorithms, reserving `nvflare recipe list` for those cases. Use
-   FedEval for evaluation-only. After every `recipe show`, load
-   `../nvflare-shared/references/pytorch-family-recipe-construction.md` and
-   derive its construction capabilities. After `recipe show` succeeds, use that documented
-   path: do not run exploratory NVFLARE imports or use `inspect`, `hasattr`, constant
-   discovery, SDK source/docstring reads, or lifecycle probes. If a required detail is absent,
+   `nvflare.app_opt.pt.recipes.fedavg`, never from `nvflare.recipe`. Use FedEval
+   for evaluation-only. After every `recipe show`, derive construction capabilities
+   from the construction reference. Then use that documented path: do not run
+   exploratory NVFLARE imports or use `inspect`, `hasattr`, constant discovery,
+   SDK source/docstring reads, or lifecycle probes. If a required detail is absent,
    report a skill gap or fail closed instead of guessing. Call `recipe.execute(SimEnv(...))`.
 6. Convert the training entry point to the Lightning Client API: build the
    `Trainer`, call `flare.patch(trainer)`, and let the patched trainer own
@@ -110,10 +121,10 @@ distribution; handle conversion later as a separate request.
    override the complete argument string; never split shared arguments and a
    site-specific data path across recipe-level and per-site values expecting a
    merge.
-8. Immediately after generated files exist and before any preflight, smoke test, cleanup, validation, or execution command, load
-   `../nvflare-shared/references/validation-evidence.md`, then
-   `references/lightning-validation.md`. Before executing a full run, select and
-   record exactly one final validation target:
+8. Immediately after generated files exist and before any preflight, smoke test,
+   cleanup, validation, or execution command, load the two validation references
+   in Standard Path order. Before executing a full run, select and record exactly
+   one final validation target:
    - for a requested local or first-run simulation without an export claim, run
      `python job.py` and do not export or run the exported simulator afterward;
    - for a requested exported/deployable artifact, export first and run only the
@@ -128,17 +139,32 @@ distribution; handle conversion later as a separate request.
    the environment and permission mechanisms supplied by the agent host; do not
    inspect or enforce its security boundary.
 9. Report the recipe, changed files, selected validation target, validation
-   status, metrics, and exact artifact paths. Load
-   `../nvflare-shared/references/metrics-and-artifact-reporting.md` only when
-   normal metric artifacts are absent or inconsistent.
+   status, metrics, and exact artifact paths.
+
+## Non-standard Cases
+
+Load only the reference matching an encountered case:
+
+- `../nvflare-shared/references/conversion-workflow.md` for an unresolved
+  non-standard rerun, authorization, or missing-semantics case; it no longer
+  holds the data-location or partitioning contracts.
+- `../nvflare-shared/references/pytorch-family-recipe-selection.md` for an
+  ambiguous or non-FedAvg algorithm; use its catalog for FedAvg, FedOpt, FedProx,
+  SCAFFOLD, Cyclic, Swarm, or FedEval, and reserve `nvflare recipe list` for these cases.
+- `../nvflare-shared/references/dependency-install.md` when an applicable
+  dependency is missing.
+- `../nvflare-shared/references/runtime-output-guidance.md` for a read-only
+  source root or user-chosen output destination.
+- `references/lightning-ddp-and-tracking.md` when inspection finds its trigger.
+- `../nvflare-shared/references/metrics-and-artifact-reporting.md` when normal
+  metric artifacts are absent or inconsistent.
 
 ## Requirements
 
 - Must integrate through `flare.patch(trainer)` and let the patched trainer own
   model exchange. Must not generate a manual `FLModel` send/receive path as the
   default Lightning exchange, and must not pass the received `input_model` into
-  the `Trainer`. Load `../nvflare-shared/references/pytorch-model-exchange.md`
-  and `references/lightning-conversion.md` for the patch pattern.
+  the `Trainer`.
 - Must treat `flare.receive()` inside the patched loop as optional metadata or
   task-progression access only, not as a second model-load path.
 - Must keep evaluation inside Lightning (`trainer.validate`/`trainer.test`,
@@ -158,12 +184,9 @@ distribution; handle conversion later as a separate request.
   must be clear from source, configuration, or supplied metadata. Otherwise ask
   one semantic question when an answer channel exists or fail closed.
 - Must use the PyTorch recipe family; must not invent a Lightning-only recipe.
-- Must apply
-  `../nvflare-shared/references/pytorch-family-recipe-construction.md` after
-  `recipe show`; it is the canonical policy for optional recipe parameters,
-  model selection, tensor transport, server disk offload, and execution mode.
-  For Lightning DDP details see
-  `references/lightning-ddp-and-tracking.md`.
+  Apply the construction reference after `recipe show`; it is canonical for
+  optional recipe parameters, model selection, tensor transport, server disk
+  offload, and execution mode.
 - Must preserve local-only callbacks and logger behavior where safe. Existing
   network-connected tracking, upload callbacks, and custom/unknown loggers are
   evidence, not a user request: keep them disabled during validation unless
@@ -173,28 +196,3 @@ distribution; handle conversion later as a separate request.
   `../nvflare-shared/references/pytorch-model-exchange.md`.
 - Site partitioning, custom aggregation, the Source Of Truth Boundary, and user
   input/authorization follow `../nvflare-shared/references/conversion-common.md`.
-
-Always read this converter SKILL.md together with
-`../nvflare-shared/references/conversion-common.md`. Complete each workflow
-phase before loading the next phase's reference. Do not enumerate reference
-directories or preload validation, DDP/tracking, broad workflow, dependency,
-runtime-output, or reporting references. The standard explicit-FedAvg path
-loads, in order: `../nvflare-shared/references/conversion-common.md`,
-`references/lightning-detection.md`,
-`../nvflare-shared/references/site-data-and-paths.md` only when generated splits,
-relative-path resolution, or per-site data locations are involved,
-`../nvflare-shared/references/pytorch-family-recipe-construction.md`,
-`references/lightning-conversion.md`,
-`../nvflare-shared/references/pytorch-model-exchange.md`, then only after files
-exist, `../nvflare-shared/references/validation-evidence.md` and
-`references/lightning-validation.md`. Load
-`../nvflare-shared/references/conversion-workflow.md` only for an unresolved
-non-standard case; `../nvflare-shared/references/pytorch-family-recipe-selection.md`
-only for ambiguous or non-FedAvg algorithms;
-`../nvflare-shared/references/dependency-install.md` only when an applicable
-dependency is missing; `../nvflare-shared/references/runtime-output-guidance.md`
-only for a read-only source root or user-chosen output destination;
-`references/lightning-ddp-and-tracking.md` only when inspection found its
-trigger; and `../nvflare-shared/references/metrics-and-artifact-reporting.md`
-only when normal metrics are absent or inconsistent. Do not depend on NVFLARE
-repository examples.

--- a/skills/nvflare-convert-lightning/SKILL.md
+++ b/skills/nvflare-convert-lightning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvflare-convert-lightning
-description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use only when the request expresses federated or NVFLARE conversion intent and either names PyTorch Lightning or preliminary source inspection identifies one Lightning owner; do not use for non-federated Lightning work such as DDP, profiling, inference serving, or training-loop changes, nor for plain PyTorch, TensorFlow/Keras, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
+description: "Convert existing PyTorch Lightning training code into an NVFLARE federated job using the Lightning Client API patch, local validation, and job export; use only when the request names federated/NVFLARE conversion or asks multiple sites to train collaboratively while keeping each site's data local, and either names PyTorch Lightning or preliminary source inspection identifies one Lightning owner; do not use for non-federated Lightning work such as DDP, profiling, inference serving, or training-loop changes, nor for plain PyTorch, TensorFlow/Keras, other frameworks, deployment, POC/production lifecycle, or experiment workflows."
 license: Apache-2.0
 metadata:
   version: "0.1.0"
@@ -18,7 +18,7 @@ metadata:
 
 ## Use When
 
-Use only when the user asks to convert PyTorch Lightning code into an NVFLARE federated training job; require both federation intent and Lightning ownership.
+Use only when the user asks to convert PyTorch Lightning code into an NVFLARE federated training job; require both federation intent and Lightning ownership. Treat requests for multiple sites or institutions to train collaboratively while each site's data remains local as federation intent, even when the request does not say "federated" or "NVFLARE."
 Lightning source evidence alone is not sufficient. Relevant source may contain a `LightningModule`, `LightningDataModule`, a `Trainer` fit/validate/test loop,
 Lightning callbacks, checkpointing, or loggers.
 Supported: the PyTorch recipe family with `flare.patch(trainer)` as the model

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -743,6 +743,121 @@
       }
     },
     {
+      "id": "lightning-negative-ddp-without-federation",
+      "prompt": "Add DistributedDataParallel on 4 GPUs to this Lightning training project. Keep it non-federated and do not convert it to NVFLARE.",
+      "expected_output": "The Lightning conversion skill does not trigger because the request is distributed-training work without federated or NVFLARE conversion intent.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is not nvflare-convert-lightning.",
+        "The agent does not start an NVFLARE conversion merely because the project uses Lightning."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "nvflare-convert-lightning",
+        "prohibited_behavior": [
+          {
+            "id": "no-lightning-conversion-for-ddp-only-request",
+            "description": "does not invoke Lightning conversion for a DDP-only request without federation intent"
+          }
+        ]
+      }
+    },
+    {
+      "id": "lightning-negative-profiling",
+      "prompt": "Profile and speed up this Lightning training loop. Do not federate it or convert it to NVFLARE.",
+      "expected_output": "The Lightning conversion skill does not trigger for profiling or performance work without federated conversion intent.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is not nvflare-convert-lightning.",
+        "The agent does not start an NVFLARE conversion merely because the profiled code uses Lightning."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "nvflare-convert-lightning",
+        "prohibited_behavior": [
+          {
+            "id": "no-lightning-conversion-for-profiling",
+            "description": "does not invoke Lightning conversion for profiling or performance tuning without federation intent"
+          }
+        ]
+      }
+    },
+    {
+      "id": "lightning-negative-inference-serving",
+      "prompt": "Wrap this Lightning model in a FastAPI inference server. This is serving work, not federated training.",
+      "expected_output": "The Lightning conversion skill does not trigger for inference-serving work without federated conversion intent.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is not nvflare-convert-lightning.",
+        "The agent does not start an NVFLARE conversion merely because the served model uses Lightning."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "nvflare-convert-lightning",
+        "prohibited_behavior": [
+          {
+            "id": "no-lightning-conversion-for-inference-serving",
+            "description": "does not invoke Lightning conversion for inference-serving work without federation intent"
+          }
+        ]
+      }
+    },
+    {
+      "id": "lightning-negative-training-loop-change",
+      "prompt": "Add early stopping and a cosine learning-rate scheduler to this Lightning Trainer. Do not turn it into a federated job.",
+      "expected_output": "The Lightning conversion skill does not trigger for an ordinary Lightning training-loop change without federated conversion intent.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is not nvflare-convert-lightning.",
+        "The agent does not start an NVFLARE conversion for ordinary callbacks or scheduler changes."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "nvflare-convert-lightning",
+        "prohibited_behavior": [
+          {
+            "id": "no-lightning-conversion-for-training-loop-change",
+            "description": "does not invoke Lightning conversion for callbacks, early stopping, or scheduler changes without federation intent"
+          }
+        ]
+      }
+    },
+    {
+      "id": "lightning-negative-tensorflow-keras",
+      "prompt": "Convert my TensorFlow/Keras training workflow to an NVFLARE federated job. The Lightning files in this workspace are unrelated and must not be used.",
+      "expected_output": "The Lightning conversion skill does not trigger because the requested training owner is TensorFlow/Keras, outside this PyTorch Lightning converter.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is not nvflare-convert-lightning.",
+        "The agent does not substitute unrelated Lightning source for the explicitly requested TensorFlow/Keras workflow."
+      ],
+      "nvflare": {
+        "expected_skill": null,
+        "negative_for": "nvflare-convert-lightning",
+        "prohibited_behavior": [
+          {
+            "id": "no-lightning-conversion-for-tensorflow-keras",
+            "description": "does not invoke the PyTorch Lightning converter for an explicitly requested TensorFlow/Keras workflow"
+          }
+        ]
+      }
+    },
+    {
       "id": "lightning-negative-plain-pytorch",
       "prompt": "Convert my plain PyTorch nn.Module and manual training loop to an NVFLARE job. There is no Lightning here.",
       "expected_output": "The Lightning conversion skill should not be the lead; route to nvflare-convert-pytorch for plain PyTorch manual loops.",

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -574,7 +574,7 @@
     {
       "id": "lightning-ddp-multigpu",
       "prompt": "My Lightning Trainer uses DDP across multiple GPUs. Federate it with FedAvg and keep multi-GPU training on each site.",
-      "expected_output": "The agent treats the DDP evidence as a high-impact runtime decision: it confirms the selected recipe documents an external-process launch parameter with nvflare recipe show before using it, applies the rank-synchronized round loop when the documented external-process path is used, keeps the patched trainer in charge of exchange, uses explicit standalone pre-fit validation with source-backed distributed reduction so the patched callback delivers finite scalar metrics, and configures key_metric only after the exact metric is proven to reach server FLModel.metrics.",
+      "expected_output": "The agent treats the DDP evidence as a high-impact runtime decision: it confirms the selected recipe documents an external-process launch parameter with nvflare recipe show before using it, resolves and forwards global process rank to flare.init, applies the rank-synchronized round loop when the documented external-process path is used, keeps the patched trainer in charge of exchange, uses explicit standalone pre-fit validation with source-backed distributed reduction so the patched callback delivers finite scalar metrics, and configures key_metric only after the exact metric is proven to reach server FLModel.metrics.",
       "files": [
         "files/hello-lightning/train.py",
         "files/hello-lightning/model.py"
@@ -582,6 +582,7 @@
       "assertions": [
         "The agent observes and reports the DDP/multi-GPU evidence as a high-impact runtime decision.",
         "The agent confirms the selected recipe documents an external-process launch parameter via nvflare recipe show before using it, instead of applying an implicit DDP-to-parameter mapping.",
+        "The generated client resolves global process rank from the initialized process group or RANK, never LOCAL_RANK, and passes it to flare.init(rank=global_rank).",
         "When the documented external-process path is used, the agent applies the rank-synchronized while loop that broadcasts flare.is_running() from rank 0 before receive/validate/fit.",
         "If the recipe did not document a launch parameter for DDP, the agent would ask in interactive mode or fail closed in unattended mode, reporting the DDP evidence and the missing product surface.",
         "The agent keeps flare.patch(trainer) in charge of model exchange and does not pass input_model into the Trainer.",
@@ -601,6 +602,10 @@
             "description": "broadcasts flare.is_running() from rank 0 before receive/validate/fit when the documented external-process path is used"
           },
           {
+            "id": "global-rank-for-distributed-processes",
+            "description": "resolves global process rank from the initialized process group or RANK and passes it to flare.init without using LOCAL_RANK"
+          },
+          {
             "id": "ddp-key-metric-requires-server-delivery",
             "description": "uses explicit standalone pre-fit DDP validation with source-backed distributed reduction, relies on patched callback delivery, and configures key_metric only after the exact metric is proven in client and aggregated FLModel.metrics"
           }
@@ -617,6 +622,10 @@
           {
             "id": "no-unguarded-receive-on-nonzero-ranks",
             "description": "does not insert an unguarded flare.receive() on every rank for metadata and ensures non-zero ranks do not receive the task or model object"
+          },
+          {
+            "id": "no-local-rank-as-global-rank",
+            "description": "does not use LOCAL_RANK as the global FLARE process rank"
           },
           {
             "id": "no-local-validate-metric-delivery-inference",

--- a/skills/nvflare-convert-lightning/evals/evals.json
+++ b/skills/nvflare-convert-lightning/evals/evals.json
@@ -752,6 +752,29 @@
       }
     },
     {
+      "id": "lightning-positive-implicit-federation-intent",
+      "prompt": "Train this collaboratively across 3 hospitals without moving their data. Use the existing Lightning Trainer and show the combined validation result.",
+      "expected_output": "The Lightning conversion skill triggers because collaborative training across hospitals without moving data expresses cross-site privacy-preserving training intent, and source inspection confirms Lightning ownership.",
+      "files": [
+        "files/hello-lightning/train.py",
+        "files/hello-lightning/model.py"
+      ],
+      "assertions": [
+        "The selected skill is nvflare-convert-lightning even though the request does not name FLARE, NVFLARE, or federated learning.",
+        "The agent confirms Lightning ownership from source inspection before conversion.",
+        "The agent converts the collaborative three-hospital request into a three-site privacy-preserving training job."
+      ],
+      "nvflare": {
+        "expected_skill": "nvflare-convert-lightning",
+        "mandatory_behavior": [
+          {
+            "id": "implicit-federation-intent-recall",
+            "description": "recognizes collaborative cross-hospital training without moving data as federation intent after Lightning ownership is confirmed"
+          }
+        ]
+      }
+    },
+    {
       "id": "lightning-negative-ddp-without-federation",
       "prompt": "Add DistributedDataParallel on 4 GPUs to this Lightning training project. Keep it non-federated and do not convert it to NVFLARE.",
       "expected_output": "The Lightning conversion skill does not trigger because the request is distributed-training work without federated or NVFLARE conversion intent.",

--- a/skills/nvflare-convert-lightning/references/lightning-ddp-and-tracking.md
+++ b/skills/nvflare-convert-lightning/references/lightning-ddp-and-tracking.md
@@ -12,6 +12,11 @@ only covers Lightning behavior after that decision.
 
 ## Rank-Synchronized Round Loop
 
+Before patching under DDP, apply the framework-neutral global-rank contract in
+`../../nvflare-shared/references/conversion-common.md`: resolve the global
+process rank from the initialized process group or global `RANK`, never
+`LOCAL_RANK`, and pass it to `flare.init(rank=global_rank)`.
+
 Under DDP, only rank 0 communicates with the FL server, so all ranks must agree
 on whether to continue. Broadcast `flare.is_running()` from rank 0 before each
 round, and let the patched trainer callback receive and broadcast the model

--- a/skills/nvflare-shared/references/conversion-common.md
+++ b/skills/nvflare-shared/references/conversion-common.md
@@ -44,6 +44,15 @@ context is read pre-patch; do not rely on the patch for pre-patch site-data or
 logging setup. The patch initializes the Client API on its own only when no
 earlier context access is needed.
 
+Rank is a process-level Client API property, not a framework-specific training
+argument. For a single-process launch, call `flare.init()` without an explicit
+rank and do not add a required `rank` parser field or `--rank` to recipe
+arguments. For a distributed multi-process launch, resolve the global process
+rank from the initialized process group or global `RANK`, never `LOCAL_RANK`,
+and pass it to `flare.init(rank=global_rank)`. Reject a multi-process launch
+when the global rank cannot be resolved; never default every process to rank
+zero.
+
 ## SimEnv Execution
 
 `SimEnv` is a plain execution-environment object, not a context manager. Never

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -179,6 +179,10 @@ from GPU count:
   strategies, or another source launch that creates distributed worker
   processes requires `launch_external_process=True`.
 
+For every distributed multi-process selection, apply the canonical Client API
+global-rank contract in `conversion-common.md`. It does not apply to
+single-process `DataParallel`.
+
 Before setting it, confirm `launch_external_process` is exposed. Also confirm
 the recipe exposes `command`, `launcher`, or another public launch surface that
 can preserve required distributed-launch arguments. If either capability is

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -84,6 +84,13 @@ string. When present, it replaces the recipe-level `train_args`; the recipe does
 not merge shared arguments into the site override. Compose every site value from
 the shared and site-specific arguments before calling `set_per_site_config(...)`:
 
+Call `set_per_site_config(...)` immediately after recipe construction and
+before adding client configuration, files, filters, or components. Those
+operations prepare the client apps and close the per-site configuration window.
+The safe construction order is: construct the recipe -> set per-site config ->
+add files, filters, and components -> add required decomposers -> export or
+execute.
+
 ```python
 shared_train_args = f"--epochs {epochs} --batch-size {batch_size}"
 per_site_config = {

--- a/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
+++ b/skills/nvflare-shared/references/pytorch-family-recipe-construction.md
@@ -107,6 +107,12 @@ full simulations.
 
 ## Tensor-Native Transport
 
+Import the recipe transport enums from their public module:
+
+```python
+from nvflare.client.config import ExchangeFormat, TransferType
+```
+
 Use the workflow-side format keyword exposed by the selected recipe:
 
 - When `aggregation_format` is exposed, pass

--- a/skills/nvflare-shared/references/site-data-and-paths.md
+++ b/skills/nvflare-shared/references/site-data-and-paths.md
@@ -43,12 +43,39 @@ Apply the `conversion-common.md` "Data Location" invariants first: a configurabl
 the conversion ports to real multi-site deployment, where each site's data lives
 at a different location.
 
-Resolve a relative source data path in `job.py` against the original
-source-project root before recipe construction. Pass the resolved value through
-`train_args` or `per_site_config`; the client must consume it unchanged. Do not
-reinterpret it relative to packaged `client.py`, the export directory, or the
-simulator process working directory. Validate relative-path conversions from a
-fresh caller working directory.
+Classify each detected input before adapting `job.py`, preserving the source's
+argument name and semantics:
+
+- For a source-project-relative local file or directory, resolve it in `job.py`
+  against the source-project root before Recipe construction. Hugging Face
+  conversions use the maintained `resolve_source_local_path()` helper, which
+  resolves against `SOURCE_DIR`, not the caller's working directory.
+- Preserve an absolute local file or directory path; the helper accepts it
+  without prefixing `SOURCE_DIR`.
+- Pass a per-site path through `per_site_config`. Do not resolve it on the
+  central authoring machine.
+- Do not pass a Hugging Face Hub identifier or URL through a filesystem
+  resolver.
+- When the source has no file or directory argument, generate no path-specific
+  option, helper call, or Recipe argument.
+
+For example, if source inspection finds a local `dataset_path` argument, adapt
+the maintained Hugging Face `job.py` asset without renaming it:
+
+```python
+parser.add_argument("--dataset_path", type=Path, default=DEFAULT_DATASET_PATH)
+dataset_path = resolve_source_local_path(args.dataset_path)
+
+recipe = build_recipe(
+    ...,
+    dataset_path=dataset_path,
+)
+```
+
+Pass the resolved value through `train_args`; the client must consume it
+unchanged. Do not reinterpret it relative to packaged `client.py`, the export
+directory, or the simulator process working directory. Validate relative-path
+conversions from a fresh caller working directory outside the source project.
 
 When `per_site_config` supplies `train_args`, each site value completely
 replaces recipe-level `train_args`; it is not a fragment to merge. Compose the

--- a/skills/nvflare-shared/references/site-data-and-paths.md
+++ b/skills/nvflare-shared/references/site-data-and-paths.md
@@ -47,11 +47,15 @@ Classify each detected input before adapting `job.py`, preserving the source's
 argument name and semantics:
 
 - For a source-project-relative local file or directory, resolve it in `job.py`
-  against the source-project root before Recipe construction. Hugging Face
-  conversions use the maintained `resolve_source_local_path()` helper, which
-  resolves against `SOURCE_DIR`, not the caller's working directory.
+  against an explicit absolute source-project root before Recipe construction.
+  Hugging Face conversions use the maintained `resolve_source_local_path()`
+  helper and pass that root through its `source_root` argument. Use `SOURCE_DIR`
+  as that root only when the generated `job.py` is colocated with the inspected
+  source project. When a read-only source root forces generated files elsewhere,
+  pass the original inspected root through a configurable job-level value; never
+  substitute the generated output directory or the caller's working directory.
 - Preserve an absolute local file or directory path; the helper accepts it
-  without prefixing `SOURCE_DIR`.
+  without prefixing the explicit source root.
 - Pass a per-site path through `per_site_config`. Do not resolve it on the
   central authoring machine.
 - Do not pass a Hugging Face Hub identifier or URL through a filesystem
@@ -64,13 +68,19 @@ the maintained Hugging Face `job.py` asset without renaming it:
 
 ```python
 parser.add_argument("--dataset_path", type=Path, default=DEFAULT_DATASET_PATH)
-dataset_path = resolve_source_local_path(args.dataset_path)
+source_root = SOURCE_DIR  # Only when generated job.py is colocated with the source.
+dataset_path = resolve_source_local_path(args.dataset_path, source_root=source_root)
 
 recipe = build_recipe(
     ...,
     dataset_path=dataset_path,
 )
 ```
+
+For a read-only source root and a separate generated directory, expose or
+otherwise preserve the inspected absolute source root in `job.py` and pass it as
+`source_root`. Do not silently default it to the directory containing the
+generated `job.py`.
 
 Pass the resolved value through `train_args`; the client must consume it
 unchanged. Do not reinterpret it relative to packaged `client.py`, the export

--- a/skills/nvflare-shared/references/validation-evidence.md
+++ b/skills/nvflare-shared/references/validation-evidence.md
@@ -59,10 +59,10 @@ exported-job validation.
 
 ## Terminal Simulation Evidence
 
-The hard rule — the final validation must run in the foreground and finish in the
-same step before you report success — lives in `conversion-workflow.md` ("Final
-Validation Run Must Finish Before You Finalize"). This section covers the success
-evidence to collect once it finishes.
+Run the final simulation with `run_in_background: false`; never finalize with an
+active simulation. This framework-neutral rule applies to every converter that
+loads this reference. The final validation must finish in the same step before
+you report success.
 
 Prefer foreground execution for the final run. Do not depend on a background
 task notifying you after your final answer: in a non-interactive run the task

--- a/tests/unit_test/app_opt/hf/client_hf_contract_test.py
+++ b/tests/unit_test/app_opt/hf/client_hf_contract_test.py
@@ -102,6 +102,24 @@ def test_client_hf_init_uses_global_rank_before_delayed_process_group_init(monke
     assert calls == [("1", None)]
 
 
+@pytest.mark.parametrize(("raw_rank", "expected_rank"), (("+0", "0"), ("00", "0"), ("01", "1")))
+def test_client_hf_init_normalizes_environment_global_rank(monkeypatch, raw_rank, expected_rank):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", raw_rank)
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)) or "context",
+    )
+
+    assert hf_client.init() == "context"
+    assert calls == [(expected_rank, None)]
+
+
 @pytest.mark.parametrize("size_marker", ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS"))
 def test_client_hf_init_rejects_unresolved_multirank_before_client_context(monkeypatch, size_marker):
     hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
@@ -116,6 +134,25 @@ def test_client_hf_init_rejects_unresolved_multirank_before_client_context(monke
     )
 
     with pytest.raises(RuntimeError, match="global RANK is unavailable"):
+        hf_client.init()
+
+    assert calls == []
+
+
+def test_client_hf_init_rejects_negative_environment_global_rank_before_client_context(monkeypatch):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "-1")
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)),
+    )
+
+    with pytest.raises(RuntimeError, match="valid non-negative global RANK"):
         hf_client.init()
 
     assert calls == []

--- a/tests/unit_test/app_opt/hf/client_hf_contract_test.py
+++ b/tests/unit_test/app_opt/hf/client_hf_contract_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ._helpers import ClientAPIMock, import_hf_module, patch_client_api_aliases
 
 
@@ -31,7 +33,6 @@ def test_client_hf_reexports_standard_client_api_surface(monkeypatch):
         "get_job_id",
         "get_site_name",
         "get_task_name",
-        "init",
         "is_evaluate",
         "is_submit_model",
         "is_train",
@@ -44,7 +45,96 @@ def test_client_hf_reexports_standard_client_api_surface(monkeypatch):
         assert hasattr(hf_client, name), f"nvflare.client.hf must export {name}"
         assert getattr(hf_client, name) is getattr(flare, name)
 
+    assert hf_client.init is not flare.init
     assert hf_client.is_running is not flare.is_running
+
+
+def _clear_rank_environment(monkeypatch, hf_client):
+    monkeypatch.delenv("RANK", raising=False)
+    for name in hf_client._MULTIRANK_SIZE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_client_hf_init_keeps_single_process_rankless(monkeypatch):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)) or "context",
+    )
+
+    assert hf_client.init(config_file="config.json") == "context"
+    assert calls == [(None, "config.json")]
+
+
+def test_client_hf_init_uses_initialized_distributed_rank(monkeypatch):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: 1)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)) or "context",
+    )
+
+    assert hf_client.init() == "context"
+    assert calls == [(1, None)]
+
+
+def test_client_hf_init_uses_global_rank_before_delayed_process_group_init(monkeypatch):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)) or "context",
+    )
+
+    assert hf_client.init() == "context"
+    assert calls == [("1", None)]
+
+
+@pytest.mark.parametrize("size_marker", ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS"))
+def test_client_hf_init_rejects_unresolved_multirank_before_client_context(monkeypatch, size_marker):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setenv(size_marker, "2")
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)),
+    )
+
+    with pytest.raises(RuntimeError, match="global RANK is unavailable"):
+        hf_client.init()
+
+    assert calls == []
+
+
+def test_client_hf_init_accepts_explicit_rank_in_multirank_environment(monkeypatch):
+    hf_client = import_hf_module(monkeypatch, "nvflare.client.hf")
+    calls = []
+    _clear_rank_environment(monkeypatch, hf_client)
+    monkeypatch.setenv("SLURM_NTASKS", "2")
+    monkeypatch.setattr(hf_client, "_get_initialized_distributed_rank", lambda: None)
+    monkeypatch.setattr(
+        hf_client,
+        "_client_api_init",
+        lambda *, rank, config_file: calls.append((rank, config_file)) or "context",
+    )
+
+    assert hf_client.init(rank=1) == "context"
+    assert calls == [(1, None)]
 
 
 def test_client_hf_is_running_delegates_before_a_trainer_is_patched(monkeypatch):

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -622,8 +622,8 @@ def test_pytorch_eval_template_rejects_missing_or_invalid_round_steps(monkeypatc
 @pytest.mark.parametrize(
     "evaluate_before_train, expected_events",
     [
-        (True, ["init:3", "factory", "patch", "is_running", "evaluate", "train", "is_running"]),
-        (False, ["init:3", "factory", "patch", "is_running", "train", "is_running"]),
+        (True, ["init", "factory", "patch", "is_running", "evaluate", "train", "is_running"]),
+        (False, ["init", "factory", "patch", "is_running", "train", "is_running"]),
     ],
 )
 def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, evaluate_before_train, expected_events):
@@ -642,7 +642,7 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
         return _Trainer()
 
     running = iter((True, False))
-    monkeypatch.setattr(module.flare, "init", lambda rank: events.append(f"init:{rank}"))
+    monkeypatch.setattr(module.flare, "init", lambda: events.append("init"))
     monkeypatch.setattr(module.flare, "patch", lambda trainer: events.append("patch"))
     monkeypatch.setattr(
         module.flare,
@@ -650,25 +650,22 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
         lambda: events.append("is_running") or next(running),
     )
 
-    module.main(trainer_factory, rank=3, evaluate_before_train=evaluate_before_train)
+    module.main(trainer_factory, evaluate_before_train=evaluate_before_train)
 
     assert events == expected_events
 
 
-def test_huggingface_client_template_requires_and_forwards_global_rank(monkeypatch):
+def test_huggingface_client_template_uses_rankless_single_process_init(monkeypatch):
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
-    rank_parameter = inspect.signature(module.main).parameters["rank"]
     observed = []
 
-    monkeypatch.setattr(module.flare, "init", lambda rank: observed.append(rank))
+    monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
     monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
     monkeypatch.setattr(module.flare, "is_running", lambda: False)
 
-    assert rank_parameter.default is inspect.Parameter.empty
-    assert rank_parameter.kind is inspect.Parameter.KEYWORD_ONLY
-    for rank in (0, 1):
-        module.main(lambda: object(), rank=rank)
-    assert observed == [0, 1]
+    assert "rank" not in inspect.signature(module.main).parameters
+    module.main(lambda: object())
+    assert observed == ["init"]
 
 
 def test_huggingface_job_template_uses_private_persistent_implicit_simulation_workspace(tmp_path):
@@ -865,6 +862,7 @@ def test_huggingface_job_template_supports_one_resolved_budget_mode():
     assert "--max_steps" not in requested_epochs
     assert "--max_steps" not in preserved_source
     assert "--num_train_epochs" not in preserved_source
+    assert all("--rank" not in args for args in (requested_steps, requested_epochs, preserved_source))
 
     with pytest.raises(ValueError, match="only one"):
         module.build_train_args("local-model", "/tmp/data", 2, max_steps=7, num_train_epochs=3.0)

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -630,13 +630,6 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     events = []
 
-    monkeypatch.delenv("RANK", raising=False)
-    monkeypatch.delenv("WORLD_SIZE", raising=False)
-    monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
-    monkeypatch.delenv("OMPI_COMM_WORLD_SIZE", raising=False)
-    monkeypatch.delenv("SLURM_NTASKS", raising=False)
-    monkeypatch.setattr(module.dist, "is_available", lambda: False)
-
     class _Trainer:
         def evaluate(self):
             events.append("evaluate")
@@ -662,16 +655,10 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
     assert events == expected_events
 
 
-def test_huggingface_client_template_uses_rankless_single_process_init(monkeypatch):
+def test_huggingface_client_template_delegates_rank_resolution_to_product_init(monkeypatch):
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     observed = []
 
-    monkeypatch.delenv("RANK", raising=False)
-    monkeypatch.delenv("WORLD_SIZE", raising=False)
-    monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
-    monkeypatch.delenv("OMPI_COMM_WORLD_SIZE", raising=False)
-    monkeypatch.delenv("SLURM_NTASKS", raising=False)
-    monkeypatch.setattr(module.dist, "is_available", lambda: False)
     monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
     monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
     monkeypatch.setattr(module.flare, "is_running", lambda: False)
@@ -679,86 +666,6 @@ def test_huggingface_client_template_uses_rankless_single_process_init(monkeypat
     assert "rank" not in inspect.signature(module.main).parameters
     module.main(lambda: object())
     assert observed == ["init"]
-
-
-@pytest.mark.parametrize(
-    "size_marker",
-    ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS"),
-)
-def test_huggingface_client_template_rejects_unresolved_multirank_before_flare_init(monkeypatch, size_marker):
-    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
-    events = []
-
-    for name in ("RANK", *module._MULTIRANK_SIZE_ENV_VARS):
-        monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv(size_marker, "2")
-    monkeypatch.setattr(module.dist, "is_available", lambda: False)
-    monkeypatch.setattr(module.flare, "init", lambda *args, **kwargs: events.append("init"))
-
-    with pytest.raises(RuntimeError, match="global RANK is unavailable"):
-        module.main(lambda: events.append("factory"))
-
-    assert events == []
-
-
-def test_huggingface_client_template_allows_delayed_dist_init_with_global_rank(monkeypatch):
-    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
-    observed = []
-
-    monkeypatch.setenv("WORLD_SIZE", "2")
-    monkeypatch.setenv("RANK", "1")
-    monkeypatch.setattr(module.dist, "is_available", lambda: True)
-    monkeypatch.setattr(module.dist, "is_initialized", lambda: False)
-    monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
-    monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
-    monkeypatch.setattr(module.flare, "is_running", lambda: False)
-
-    module.main(lambda: object())
-
-    assert observed == ["init"]
-
-
-@pytest.mark.parametrize(
-    "evaluate_before_train, expected_events",
-    [
-        (True, ["init:1", "factory", "patch", "is_running", "evaluate", "train", "is_running"]),
-        (False, ["init:1", "factory", "patch", "is_running", "train", "is_running"]),
-    ],
-)
-def test_huggingface_client_template_preserves_multigpu_trainer_sequence(
-    monkeypatch, evaluate_before_train, expected_events
-):
-    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
-    events = []
-
-    class _Trainer:
-        def evaluate(self):
-            events.append("evaluate")
-
-        def train(self):
-            events.append("train")
-
-    def trainer_factory():
-        events.append("factory")
-        return _Trainer()
-
-    running = iter((True, False))
-    monkeypatch.setenv("WORLD_SIZE", "2")
-    monkeypatch.setattr(module.dist, "is_available", lambda: True)
-    monkeypatch.setattr(module.dist, "is_initialized", lambda: True)
-    monkeypatch.setattr(module.dist, "get_world_size", lambda: 2)
-    monkeypatch.setattr(module.dist, "get_rank", lambda: 1)
-    monkeypatch.setattr(module.flare, "init", lambda *, rank: events.append(f"init:{rank}"))
-    monkeypatch.setattr(module.flare, "patch", lambda trainer: events.append("patch"))
-    monkeypatch.setattr(
-        module.flare,
-        "is_running",
-        lambda: events.append("is_running") or next(running),
-    )
-
-    module.main(trainer_factory, evaluate_before_train=evaluate_before_train)
-
-    assert events == expected_events
 
 
 def test_huggingface_job_template_uses_private_persistent_implicit_simulation_workspace(tmp_path):

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -630,6 +630,10 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     events = []
 
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
+    monkeypatch.setattr(module.dist, "is_available", lambda: False)
+
     class _Trainer:
         def evaluate(self):
             events.append("evaluate")
@@ -659,6 +663,9 @@ def test_huggingface_client_template_uses_rankless_single_process_init(monkeypat
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     observed = []
 
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
+    monkeypatch.setattr(module.dist, "is_available", lambda: False)
     monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
     monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
     monkeypatch.setattr(module.flare, "is_running", lambda: False)
@@ -666,6 +673,49 @@ def test_huggingface_client_template_uses_rankless_single_process_init(monkeypat
     assert "rank" not in inspect.signature(module.main).parameters
     module.main(lambda: object())
     assert observed == ["init"]
+
+
+@pytest.mark.parametrize(
+    "evaluate_before_train, expected_events",
+    [
+        (True, ["init:1", "factory", "patch", "is_running", "evaluate", "train", "is_running"]),
+        (False, ["init:1", "factory", "patch", "is_running", "train", "is_running"]),
+    ],
+)
+def test_huggingface_client_template_preserves_multigpu_trainer_sequence(
+    monkeypatch, evaluate_before_train, expected_events
+):
+    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
+    events = []
+
+    class _Trainer:
+        def evaluate(self):
+            events.append("evaluate")
+
+        def train(self):
+            events.append("train")
+
+    def trainer_factory():
+        events.append("factory")
+        return _Trainer()
+
+    running = iter((True, False))
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setattr(module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(module.dist, "get_world_size", lambda: 2)
+    monkeypatch.setattr(module.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(module.flare, "init", lambda *, rank: events.append(f"init:{rank}"))
+    monkeypatch.setattr(module.flare, "patch", lambda trainer: events.append("patch"))
+    monkeypatch.setattr(
+        module.flare,
+        "is_running",
+        lambda: events.append("is_running") or next(running),
+    )
+
+    module.main(trainer_factory, evaluate_before_train=evaluate_before_train)
+
+    assert events == expected_events
 
 
 def test_huggingface_job_template_uses_private_persistent_implicit_simulation_workspace(tmp_path):

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -764,7 +764,7 @@ def test_huggingface_job_template_advertises_simulation_workspace(monkeypatch, t
     monkeypatch.setattr(module, "build_recipe", lambda **kwargs: _Recipe())
     monkeypatch.setattr(module, "SimEnv", lambda **kwargs: types.SimpleNamespace(**kwargs))
 
-    required_args = ["job.py", "--model_name_or_path", "model", "--data_root", "data"]
+    required_args = ["job.py", "--model_name_or_path", "model"]
     monkeypatch.setattr(sys, "argv", required_args)
     module.main()
     implicit_output = capsys.readouterr().out
@@ -787,6 +787,42 @@ def test_huggingface_job_template_advertises_simulation_workspace(monkeypatch, t
     assert status_workspaces == [executed_workspaces[0], explicit_workspace]
     assert result_workspaces == [executed_workspaces[0], explicit_workspace]
     assert explicit_workspace.is_dir()
+
+
+def test_huggingface_job_template_resolves_only_source_local_paths_from_another_cwd(tmp_path, monkeypatch):
+    generated_dir = tmp_path / "generated"
+    generated_dir.mkdir()
+    job_path = generated_dir / "job.py"
+    job_path.write_text((HF_TEMPLATES / "job.py").read_text(encoding="utf-8"), encoding="utf-8")
+    relative_data = generated_dir / "datasets" / "sst2"
+    relative_data.mkdir(parents=True)
+    absolute_data = tmp_path / "absolute-data"
+    absolute_data.mkdir()
+
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
+    module = _load_module(job_path)
+
+    assert module.resolve_source_local_path("datasets/sst2") == relative_data.resolve()
+    assert module.resolve_source_local_path(absolute_data) == absolute_data.resolve()
+    assert Path.cwd() == caller_dir
+
+
+def test_huggingface_job_template_does_not_assume_a_source_data_argument(monkeypatch):
+    module = _load_module(HF_TEMPLATES / "job.py")
+    source = (HF_TEMPLATES / "job.py").read_text(encoding="utf-8")
+
+    def fail_if_called(_value):
+        raise AssertionError("Hub identifiers must not be passed through the local-path resolver")
+
+    monkeypatch.setattr(module, "resolve_source_local_path", fail_if_called)
+    train_args = module.build_train_args("org/model", 2)
+
+    assert "--model_name_or_path org/model" in train_args
+    assert "data_root" not in inspect.signature(module.build_train_args).parameters
+    assert "data_root" not in inspect.signature(module.build_recipe).parameters
+    assert 'parser.add_argument("--data_root"' not in source
 
 
 def test_huggingface_client_template_has_one_patch_and_no_manual_exchange():
@@ -851,7 +887,6 @@ def test_huggingface_job_template_uses_pytorch_fast_path_and_packages_model_file
     recipe = module.build_recipe(
         name="hf-test",
         model_name_or_path="local-model",
-        data_root="/tmp/data",
         num_clients=2,
         num_rounds=3,
         key_metric="eval_accuracy",
@@ -887,7 +922,6 @@ def test_huggingface_train_only_job_disables_model_selection_by_default(tmp_path
     recipe = module.build_recipe(
         name="hf-train-only",
         model_name_or_path="local-model",
-        data_root="/tmp/data",
         num_clients=2,
         num_rounds=1,
     )
@@ -902,9 +936,9 @@ def test_huggingface_train_only_job_disables_model_selection_by_default(tmp_path
 def test_huggingface_job_template_supports_one_resolved_budget_mode():
     module = _load_module(HF_TEMPLATES / "job.py")
 
-    requested_steps = module.build_train_args("local-model", "/tmp/data", 2, max_steps=7)
-    requested_epochs = module.build_train_args("local-model", "/tmp/data", 2, num_train_epochs=3.0)
-    preserved_source = module.build_train_args("local-model", "/tmp/data", 2, preserve_source_budget=True)
+    requested_steps = module.build_train_args("local-model", 2, max_steps=7)
+    requested_epochs = module.build_train_args("local-model", 2, num_train_epochs=3.0)
+    preserved_source = module.build_train_args("local-model", 2, preserve_source_budget=True)
 
     assert "--max_steps 7" in requested_steps
     assert "--num_train_epochs" not in requested_steps
@@ -915,7 +949,7 @@ def test_huggingface_job_template_supports_one_resolved_budget_mode():
     assert all("--rank" not in args for args in (requested_steps, requested_epochs, preserved_source))
 
     with pytest.raises(ValueError, match="only one"):
-        module.build_train_args("local-model", "/tmp/data", 2, max_steps=7, num_train_epochs=3.0)
+        module.build_train_args("local-model", 2, max_steps=7, num_train_epochs=3.0)
 
 
 @pytest.mark.parametrize("max_steps", [True, 0, -1, 1.5])
@@ -923,7 +957,7 @@ def test_huggingface_job_template_rejects_invalid_programmatic_step_budgets(max_
     module = _load_module(HF_TEMPLATES / "job.py")
 
     with pytest.raises(ValueError, match="positive integer"):
-        module.build_train_args("local-model", "/tmp/data", 2, max_steps=max_steps)
+        module.build_train_args("local-model", 2, max_steps=max_steps)
 
 
 @pytest.mark.parametrize("num_train_epochs", [True, 0, -1, float("nan"), float("inf")])
@@ -931,7 +965,7 @@ def test_huggingface_job_template_rejects_invalid_programmatic_epoch_budgets(num
     module = _load_module(HF_TEMPLATES / "job.py")
 
     with pytest.raises(ValueError, match="finite positive number"):
-        module.build_train_args("local-model", "/tmp/data", 2, num_train_epochs=num_train_epochs)
+        module.build_train_args("local-model", 2, num_train_epochs=num_train_epochs)
 
 
 @pytest.mark.parametrize(
@@ -955,8 +989,6 @@ def test_huggingface_job_template_cli_rejects_invalid_budgets(monkeypatch, optio
             "job.py",
             "--model_name_or_path",
             "local-model",
-            "--data_root",
-            "/tmp/data",
             "--key_metric",
             "eval_accuracy",
             option,
@@ -972,7 +1004,7 @@ def test_huggingface_job_template_rejects_unrepresentable_in_process_arguments()
     module = _load_module(HF_TEMPLATES / "job.py")
 
     with pytest.raises(ValueError, match="whitespace-free"):
-        module.build_train_args("model with spaces", "/tmp/data", 2)
+        module.build_train_args("model with spaces", 2)
 
 
 def test_huggingface_job_template_exports_colocated_files_from_another_working_directory(tmp_path, monkeypatch):
@@ -991,7 +1023,6 @@ def test_huggingface_job_template_exports_colocated_files_from_another_working_d
     recipe = module.build_recipe(
         name="hf-cwd-independent",
         model_name_or_path="local-model",
-        data_root="/tmp/data",
         num_clients=2,
         num_rounds=1,
         key_metric="eval_accuracy",
@@ -1023,13 +1054,12 @@ def test_huggingface_job_template_exports_per_site_files_from_another_working_di
     monkeypatch.chdir(caller_dir)
     module = _load_module(job_path)
     site_args = {
-        "site-1": {"train_args": module.build_train_args("local-model", "/data/site-1", 2, max_steps=2)},
-        "site-2": {"train_args": module.build_train_args("local-model", "/data/site-2", 2, max_steps=3)},
+        "site-1": {"train_args": "--model_name_or_path local-model --dataset_path /data/site-1 --num_clients 2"},
+        "site-2": {"train_args": "--model_name_or_path local-model --dataset_path /data/site-2 --num_clients 2"},
     }
     recipe = module.build_recipe(
         name="hf-per-site-cwd-independent",
         model_name_or_path="local-model",
-        data_root="/tmp/data",
         num_clients=2,
         num_rounds=1,
         key_metric="eval_accuracy",
@@ -1054,7 +1084,10 @@ def test_huggingface_job_template_exports_per_site_files_from_another_working_di
 
 def test_huggingface_job_template_uses_one_simulator_topology_owner(tmp_path):
     module = _load_module(HF_TEMPLATES / "job.py")
-    per_site_config = {"site-a": {"train_args": "--data_root /data/a"}, "site-b": {"train_args": "--data_root /data/b"}}
+    per_site_config = {
+        "site-a": {"train_args": "--dataset_path /data/a"},
+        "site-b": {"train_args": "--dataset_path /data/b"},
+    }
 
     unified_env = module.build_sim_env(2, tmp_path / "unified")
     assert unified_env.clients is None
@@ -1077,7 +1110,6 @@ def test_huggingface_job_template_rejects_deprecated_per_site_constructor_option
         module.build_recipe(
             name="hf-deprecated-per-site",
             model_name_or_path="local-model",
-            data_root="/tmp/data",
             num_clients=2,
             num_rounds=1,
             key_metric="eval_accuracy",
@@ -1099,7 +1131,6 @@ def test_huggingface_job_template_rejects_per_site_train_script_overrides(tmp_pa
         module.build_recipe(
             name="hf-per-site-script",
             model_name_or_path="local-model",
-            data_root="/tmp/data",
             num_clients=2,
             num_rounds=1,
             key_metric="eval_accuracy",
@@ -1119,7 +1150,6 @@ def test_huggingface_job_template_restores_cwd_when_per_site_config_is_invalid(t
         module.build_recipe(
             name="hf-invalid-per-site",
             model_name_or_path="local-model",
-            data_root="/tmp/data",
             num_clients=2,
             num_rounds=1,
             key_metric="eval_accuracy",

--- a/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/conversion_templates_test.py
@@ -630,8 +630,11 @@ def test_huggingface_client_template_preserves_trainer_sequence(monkeypatch, eva
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     events = []
 
+    monkeypatch.delenv("RANK", raising=False)
     monkeypatch.delenv("WORLD_SIZE", raising=False)
     monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
+    monkeypatch.delenv("OMPI_COMM_WORLD_SIZE", raising=False)
+    monkeypatch.delenv("SLURM_NTASKS", raising=False)
     monkeypatch.setattr(module.dist, "is_available", lambda: False)
 
     class _Trainer:
@@ -663,8 +666,11 @@ def test_huggingface_client_template_uses_rankless_single_process_init(monkeypat
     module = _load_module(HF_TEMPLATES / "client_with_eval.py")
     observed = []
 
+    monkeypatch.delenv("RANK", raising=False)
     monkeypatch.delenv("WORLD_SIZE", raising=False)
     monkeypatch.delenv("LOCAL_WORLD_SIZE", raising=False)
+    monkeypatch.delenv("OMPI_COMM_WORLD_SIZE", raising=False)
+    monkeypatch.delenv("SLURM_NTASKS", raising=False)
     monkeypatch.setattr(module.dist, "is_available", lambda: False)
     monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
     monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
@@ -672,6 +678,43 @@ def test_huggingface_client_template_uses_rankless_single_process_init(monkeypat
 
     assert "rank" not in inspect.signature(module.main).parameters
     module.main(lambda: object())
+    assert observed == ["init"]
+
+
+@pytest.mark.parametrize(
+    "size_marker",
+    ("WORLD_SIZE", "LOCAL_WORLD_SIZE", "OMPI_COMM_WORLD_SIZE", "SLURM_NTASKS"),
+)
+def test_huggingface_client_template_rejects_unresolved_multirank_before_flare_init(monkeypatch, size_marker):
+    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
+    events = []
+
+    for name in ("RANK", *module._MULTIRANK_SIZE_ENV_VARS):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(size_marker, "2")
+    monkeypatch.setattr(module.dist, "is_available", lambda: False)
+    monkeypatch.setattr(module.flare, "init", lambda *args, **kwargs: events.append("init"))
+
+    with pytest.raises(RuntimeError, match="global RANK is unavailable"):
+        module.main(lambda: events.append("factory"))
+
+    assert events == []
+
+
+def test_huggingface_client_template_allows_delayed_dist_init_with_global_rank(monkeypatch):
+    module = _load_module(HF_TEMPLATES / "client_with_eval.py")
+    observed = []
+
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setattr(module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(module.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(module.flare, "init", lambda: observed.append("init"))
+    monkeypatch.setattr(module.flare, "patch", lambda trainer: None)
+    monkeypatch.setattr(module.flare, "is_running", lambda: False)
+
+    module.main(lambda: object())
+
     assert observed == ["init"]
 
 
@@ -794,7 +837,8 @@ def test_huggingface_job_template_resolves_only_source_local_paths_from_another_
     generated_dir.mkdir()
     job_path = generated_dir / "job.py"
     job_path.write_text((HF_TEMPLATES / "job.py").read_text(encoding="utf-8"), encoding="utf-8")
-    relative_data = generated_dir / "datasets" / "sst2"
+    source_root = tmp_path / "read-only-source"
+    relative_data = source_root / "datasets" / "sst2"
     relative_data.mkdir(parents=True)
     absolute_data = tmp_path / "absolute-data"
     absolute_data.mkdir()
@@ -804,9 +848,17 @@ def test_huggingface_job_template_resolves_only_source_local_paths_from_another_
     monkeypatch.chdir(caller_dir)
     module = _load_module(job_path)
 
-    assert module.resolve_source_local_path("datasets/sst2") == relative_data.resolve()
-    assert module.resolve_source_local_path(absolute_data) == absolute_data.resolve()
+    assert module.resolve_source_local_path("datasets/sst2", source_root=source_root) == relative_data.resolve()
+    assert module.resolve_source_local_path(absolute_data, source_root=source_root) == absolute_data.resolve()
+    assert module.resolve_source_local_path("datasets/sst2", source_root=module.SOURCE_DIR) != relative_data.resolve()
     assert Path.cwd() == caller_dir
+
+
+def test_huggingface_job_template_rejects_relative_source_root():
+    module = _load_module(HF_TEMPLATES / "job.py")
+
+    with pytest.raises(ValueError, match="source_root must be an absolute path"):
+        module.resolve_source_local_path("datasets/sst2", source_root="source")
 
 
 def test_huggingface_job_template_does_not_assume_a_source_data_argument(monkeypatch):

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1019,8 +1019,6 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "do not append Hugging Face cache or filesystem discovery" in normalized_hf_skill
     assert "Defer model and dataset availability checks to the maintained resolver" in normalized_hf_skill
     assert "report a missing directory with exit code zero" in normalized_hf_skill
-    assert "Run the final simulation with `run_in_background: false`" in normalized_hf_skill
-    assert "never finalize with an active simulation" in normalized_hf_skill
     assert "rerun its resolver once with the matching canonical invocation" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
     assert "`--source local`" in hf_validation
@@ -1086,7 +1084,28 @@ def test_orientation_routes_only_unresolved_explicit_conversions():
     assert "no-orient-for-single-owner-conversion" in prohibited_ids
 
 
-def test_lightning_conversion_trigger_contract_includes_adjacent_negative_evals():
+def test_shared_validation_requires_foreground_final_simulation():
+    repo_root = Path(__file__).resolve().parents[4]
+    shared_validation = " ".join(
+        repo_root.joinpath("skills/nvflare-shared/references/validation-evidence.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+    hf_skill = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-huggingface/SKILL.md").read_text(encoding="utf-8").split()
+    )
+    lightning_skill = " ".join(
+        repo_root.joinpath("skills/nvflare-convert-lightning/SKILL.md").read_text(encoding="utf-8").split()
+    )
+
+    assert "Run the final simulation with `run_in_background: false`" in shared_validation
+    assert "never finalize with an active simulation" in shared_validation
+    assert "../nvflare-shared/references/validation-evidence.md" in hf_skill
+    assert "../nvflare-shared/references/validation-evidence.md" in lightning_skill
+    assert "run_in_background: false" not in hf_skill
+
+
+def test_lightning_conversion_trigger_contract_includes_positive_and_adjacent_negative_evals():
     """Keep the externally executed routing cases tied to the skill trigger contract.
 
     Skill selection is performed by the agent/model, not by an in-repo router.
@@ -1104,9 +1123,18 @@ def test_lightning_conversion_trigger_contract_includes_adjacent_negative_evals(
         "lightning-negative-training-loop-change",
         "lightning-negative-tensorflow-keras",
     }
+    implicit_positive = _eval_by_id(eval_data, "lightning-positive-implicit-federation-intent")
 
     assert "use only when the request expresses federated or NVFLARE conversion intent" in description
     assert "Lightning source evidence alone is not sufficient" in skill_text
+    implicit_prompt = implicit_positive["prompt"].lower()
+    assert all(term not in implicit_prompt for term in ("flare", "nvflare", "federat"))
+    assert all(phrase in implicit_prompt for phrase in ("collaboratively", "hospitals", "without moving"))
+    assert implicit_positive["files"]
+    assert implicit_positive["nvflare"]["expected_skill"] == "nvflare-convert-lightning"
+    assert "implicit-federation-intent-recall" in {
+        item["id"] for item in implicit_positive["nvflare"]["mandatory_behavior"]
+    }
     for eval_id in negative_eval_ids:
         negative_eval = _eval_by_id(eval_data, eval_id)
         assert negative_eval["files"]

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -550,7 +550,7 @@ def test_data_location_invariants_stay_on_the_always_loaded_path():
     # The gated reference carries only the detailed mechanics, and stays smaller
     # than the broad workflow reference it was extracted from.
     assert 'Apply the `conversion-common.md` "Data Location" invariants first' in normalized_site_data
-    assert "Resolve a relative source data path" in normalized_site_data
+    assert "Classify each detected input before adapting `job.py`" in normalized_site_data
     assert len(site_data_text) < len(workflow_text)
 
     # No skill may gate the reference on a subjective "nontrivial" judgment, and
@@ -581,6 +581,40 @@ def test_data_location_invariants_stay_on_the_always_loaded_path():
         behavior = external_eval["nvflare"]
         assert "configurable-data-path" in {item["id"] for item in behavior["mandatory_behavior"]}, eval_id
         assert "no-hardcoded-absolute-data-path" in {item["id"] for item in behavior["prohibited_behavior"]}, eval_id
+
+
+def test_huggingface_source_local_paths_are_conditional_and_cwd_independent():
+    repo_root = Path(__file__).resolve().parents[4]
+    hf_root = repo_root / "skills" / "nvflare-convert-huggingface"
+    job_text = hf_root.joinpath("assets/job.py").read_text(encoding="utf-8")
+    site_data_text = repo_root.joinpath("skills/nvflare-shared/references/site-data-and-paths.md").read_text(
+        encoding="utf-8"
+    )
+    validation_text = hf_root.joinpath("references/huggingface-validation.md").read_text(encoding="utf-8")
+    eval_data = json.loads(hf_root.joinpath("evals/evals.json").read_text(encoding="utf-8"))
+    relative_eval = _eval_by_id(eval_data, "huggingface-convert-relative-data-path")
+    normalized_site_data = " ".join(site_data_text.split())
+    normalized_validation = " ".join(validation_text.split())
+
+    assert "def resolve_source_local_path(value: str | Path) -> Path:" in job_text
+    assert "path = SOURCE_DIR / path" in job_text
+    assert 'parser.add_argument("--data_root"' not in job_text
+    assert "data_root:" not in job_text
+    assert "preserving the source's argument name and semantics" in normalized_site_data
+    assert "source-project-relative local file or directory" in normalized_site_data
+    assert "Preserve an absolute local file or directory path" in normalized_site_data
+    assert "Pass a per-site path through `per_site_config`" in normalized_site_data
+    assert "Do not pass a Hugging Face Hub identifier or URL" in normalized_site_data
+    assert "generate no path-specific option, helper call, or Recipe argument" in normalized_site_data
+    assert "fresh working directory outside the project" in normalized_validation
+    assert "transmitted value to be absolute" in normalized_validation
+    assert "Skip this path-specific check when the source has no local path argument" in normalized_validation
+    for fixture in relative_eval["files"]:
+        assert hf_root.joinpath("evals", fixture).is_file(), fixture
+    mandatory_ids = {item["id"] for item in relative_eval["nvflare"]["mandatory_behavior"]}
+    prohibited_ids = {item["id"] for item in relative_eval["nvflare"]["prohibited_behavior"]}
+    assert {"resolve-relative-source-local-path", "validate-source-path-from-fresh-cwd"} <= mandatory_ids
+    assert {"no-invented-data-root-option", "no-filesystem-resolution-for-nonlocal-inputs"} <= prohibited_ids
 
 
 def test_pytorch_recipe_capability_profiles_match_tensor_disk_offload_support():
@@ -1133,12 +1167,9 @@ def test_pytorch_conversion_avoids_known_recipe_and_partition_retries():
     assert "validate properties rather than guessed site sizes" in normalized_validation
     assert "complete, non-overlapping coverage" in normalized_validation
     assert "Assert exact per-site row counts only when" in validation_text
-    assert (
-        "Resolve a relative source data path in `job.py` against the original source-project root"
-        in normalized_site_data
-    )
+    assert "resolve it in `job.py` against the source-project root before Recipe construction" in normalized_site_data
     assert "the simulator process working directory" in normalized_site_data
-    assert "Validate relative-path conversions from a fresh caller working directory" in normalized_site_data
+    assert "fresh caller working directory outside the source project" in normalized_site_data
     assert {"safe-pandas-partitioning", "invariant-based-partition-validation"} <= mandatory_ids
     assert {"no-deprecated-save-filename-alias", "no-hardcoded-guessed-partition-counts"} <= prohibited_ids
 

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1125,7 +1125,8 @@ def test_lightning_conversion_trigger_contract_includes_positive_and_adjacent_ne
     }
     implicit_positive = _eval_by_id(eval_data, "lightning-positive-implicit-federation-intent")
 
-    assert "use only when the request expresses federated or NVFLARE conversion intent" in description
+    assert "asks multiple sites to train collaboratively while keeping each site's data local" in description
+    assert "each site's data remains local as federation intent" in skill_text
     assert "Lightning source evidence alone is not sufficient" in skill_text
     implicit_prompt = implicit_positive["prompt"].lower()
     assert all(term not in implicit_prompt for term in ("flare", "nvflare", "federat"))

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -596,12 +596,16 @@ def test_huggingface_source_local_paths_are_conditional_and_cwd_independent():
     normalized_site_data = " ".join(site_data_text.split())
     normalized_validation = " ".join(validation_text.split())
 
-    assert "def resolve_source_local_path(value: str | Path) -> Path:" in job_text
-    assert "path = SOURCE_DIR / path" in job_text
+    assert "def resolve_source_local_path(value: str | Path, *, source_root: str | Path) -> Path:" in job_text
+    assert "source_root must be an absolute path" in job_text
     assert 'parser.add_argument("--data_root"' not in job_text
     assert "data_root:" not in job_text
     assert "preserving the source's argument name and semantics" in normalized_site_data
     assert "source-project-relative local file or directory" in normalized_site_data
+    assert "explicit absolute source-project root" in normalized_site_data
+    assert "Use `SOURCE_DIR` as that root only when" in normalized_site_data
+    assert "must validate against the separate original root" in normalized_validation
+    assert "`../../nvflare-shared/references/site-data-and-paths.md`" in validation_text
     assert "Preserve an absolute local file or directory path" in normalized_site_data
     assert "Pass a per-site path through `per_site_config`" in normalized_site_data
     assert "Do not pass a Hugging Face Hub identifier or URL" in normalized_site_data
@@ -611,9 +615,11 @@ def test_huggingface_source_local_paths_are_conditional_and_cwd_independent():
     assert "Skip this path-specific check when the source has no local path argument" in normalized_validation
     for fixture in relative_eval["files"]:
         assert hf_root.joinpath("evals", fixture).is_file(), fixture
-    mandatory_ids = {item["id"] for item in relative_eval["nvflare"]["mandatory_behavior"]}
+    mandatory = {item["id"]: item["description"] for item in relative_eval["nvflare"]["mandatory_behavior"]}
     prohibited_ids = {item["id"] for item in relative_eval["nvflare"]["prohibited_behavior"]}
-    assert {"resolve-relative-source-local-path", "validate-source-path-from-fresh-cwd"} <= mandatory_ids
+    assert {"resolve-relative-source-local-path", "validate-source-path-from-fresh-cwd"} <= mandatory.keys()
+    assert "explicit inspected source-project root" in mandatory["resolve-relative-source-local-path"]
+    assert "using SOURCE_DIR only for colocated generation" in mandatory["resolve-relative-source-local-path"]
     assert {"no-invented-data-root-option", "no-filesystem-resolution-for-nonlocal-inputs"} <= prohibited_ids
 
 
@@ -869,10 +875,13 @@ def test_client_api_rank_contract_is_shared_and_process_conditional():
     assert "def main(trainer_factory, *, evaluate_before_train=True)" in hf_client
     assert "flare.init()" in hf_client
     assert "flare.init(rank=dist.get_rank())" in hf_client
+    assert "_MULTIRANK_SIZE_ENV_VARS" in hf_client
+    assert "global RANK is unavailable" in hf_client
     assert "framework-neutral global-rank contract" in normalized_hf_state
     assert "do not add a rank argument to a standard single-process conversion" in normalized_hf_state
     assert "framework-neutral global-rank contract" in normalized_lightning_ddp
     assert "passes `torch.distributed.get_rank()` to `flare.init(...)`" in normalized_hf_state
+    assert "rejects the launch before `flare.init()` when it is missing" in normalized_hf_state
     assert "flare.init(rank=global_rank)" in lightning_ddp
 
     lightning_evals = json.loads(
@@ -1176,7 +1185,7 @@ def test_pytorch_conversion_avoids_known_recipe_and_partition_retries():
     assert "validate properties rather than guessed site sizes" in normalized_validation
     assert "complete, non-overlapping coverage" in normalized_validation
     assert "Assert exact per-site row counts only when" in validation_text
-    assert "resolve it in `job.py` against the source-project root before Recipe construction" in normalized_site_data
+    assert "resolve it in `job.py` against an explicit absolute source-project root" in normalized_site_data
     assert "the simulator process working directory" in normalized_site_data
     assert "fresh caller working directory outside the source project" in normalized_site_data
     assert {"safe-pandas-partitioning", "invariant-based-partition-validation"} <= mandatory_ids

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -795,6 +795,60 @@ def test_shared_conversion_uses_one_simulator_topology_owner():
         assert "no-mixed-named-and-generated-client-topology" in prohibited_ids
 
 
+def test_client_api_rank_contract_is_shared_and_process_conditional():
+    repo_root = Path(__file__).resolve().parents[4]
+    common_text = repo_root.joinpath("skills/nvflare-shared/references/conversion-common.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_common = " ".join(common_text.split())
+    hf_client = repo_root.joinpath("skills/nvflare-convert-huggingface/assets/client_with_eval.py").read_text(
+        encoding="utf-8"
+    )
+    hf_state = repo_root.joinpath(
+        "skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md"
+    ).read_text(encoding="utf-8")
+    lightning_ddp = repo_root.joinpath(
+        "skills/nvflare-convert-lightning/references/lightning-ddp-and-tracking.md"
+    ).read_text(encoding="utf-8")
+    construction_text = repo_root.joinpath(
+        "skills/nvflare-shared/references/pytorch-family-recipe-construction.md"
+    ).read_text(encoding="utf-8")
+    normalized_hf_state = " ".join(hf_state.split())
+    normalized_lightning_ddp = " ".join(lightning_ddp.split())
+    normalized_construction = " ".join(construction_text.split())
+
+    assert (
+        "Rank is a process-level Client API property, not a framework-specific training argument" in normalized_common
+    )
+    assert "For a single-process launch, call `flare.init()` without an explicit rank" in normalized_common
+    assert "do not add a required `rank` parser field or `--rank` to recipe arguments" in normalized_common
+    assert "For a distributed multi-process launch, resolve the global process rank" in normalized_common
+    assert "initialized process group or global `RANK`, never `LOCAL_RANK`" in normalized_common
+    assert "never default every process to rank zero" in normalized_common
+    assert "apply the canonical Client API global-rank contract in `conversion-common.md`" in normalized_construction
+    assert "It does not apply to single-process `DataParallel`" in normalized_construction
+
+    for framework in ("pytorch", "lightning", "huggingface"):
+        skill_text = repo_root.joinpath(f"skills/nvflare-convert-{framework}/SKILL.md").read_text(encoding="utf-8")
+        assert "../nvflare-shared/references/conversion-common.md" in skill_text
+
+    assert "def main(trainer_factory, *, evaluate_before_train=True)" in hf_client
+    assert "flare.init()" in hf_client
+    assert "flare.init(rank=" not in hf_client
+    assert "framework-neutral global-rank contract" in normalized_hf_state
+    assert "do not add a rank argument to a standard single-process conversion" in normalized_hf_state
+    assert "framework-neutral global-rank contract" in normalized_lightning_ddp
+    assert "flare.init(rank=global_rank)" in hf_state
+    assert "flare.init(rank=global_rank)" in lightning_ddp
+
+    lightning_evals = json.loads(
+        repo_root.joinpath("skills/nvflare-convert-lightning/evals/evals.json").read_text(encoding="utf-8")
+    )
+    ddp_eval = _eval_by_id(lightning_evals, "lightning-ddp-multigpu")["nvflare"]
+    assert "global-rank-for-distributed-processes" in {item["id"] for item in ddp_eval["mandatory_behavior"]}
+    assert "no-local-rank-as-global-rank" in {item["id"] for item in ddp_eval["prohibited_behavior"]}
+
+
 def test_all_conversion_skills_preserve_required_model_constructor_args():
     repo_root = Path(__file__).resolve().parents[4]
     references = repo_root / "skills" / "nvflare-shared" / "references"
@@ -1326,8 +1380,9 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "rejects parent-traversal external-script paths" in normalized_conversion
     assert "inspecting NVFLARE implementation source" in normalized_conversion
     assert "flare.patch(trainer)" in client_template
-    assert "def main(trainer_factory, *, rank, evaluate_before_train=True)" in client_template
-    assert "flare.init(rank=rank)" in client_template
+    assert "def main(trainer_factory, *, evaluate_before_train=True)" in client_template
+    assert "flare.init()" in client_template
+    assert "flare.init(rank=" not in client_template
     assert "HfArgumentParser(dataclass_types, allow_abbrev=False)" in client_template
     assert "while flare.is_running()" in client_template
     assert "return model" in server_model_template
@@ -1345,6 +1400,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
         "client entry's actual argument mechanism and actual dataclass types in parse-only mode"
         in normalized_validation
     )
+    assert "do not append an argument only in preflight that the recipe will not deliver" in normalized_validation
     assert "generated client uses `HfArgumentParser`" in validation_text
     assert "same project and framework dataclass types" in normalized_validation
     assert "When it preserves `argparse` or another parser" in normalized_validation
@@ -1366,7 +1422,9 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "missing/newly initialized without a deterministic reset" in normalized_validation
     assert "Do not first run an unconditional full-state equality assertion" in normalized_validation
     assert "two-process `torchrun` case" in normalized_validation
-    assert "generated client's required `rank` argument" in normalized_state
+    assert "This section applies only to a preserved distributed multi-process launch" in normalized_state
+    assert "standard single-process conversion" in normalized_state
+    assert "verify that the preserved distributed launcher supplies it" in normalized_state
     assert "do not pass it as the FLARE rank" in normalized_state
     basic_mandatory = {item["id"]: item["description"] for item in basic_eval["mandatory_behavior"]}
     ddp_mandatory = {item["id"]: item["description"] for item in ddp_eval["mandatory_behavior"]}
@@ -1378,6 +1436,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "no-unconditional-equality-for-newly-initialized-parameters" in {
         item["id"] for item in basic_eval["prohibited_behavior"]
     }
+    assert "single-process-rankless-init" in basic_mandatory
     assert "without a rank-zero default" in ddp_mandatory["initialize-distributed-before-patch"]
     assert "observed global and flare.init ranks 0 and 1" in ddp_mandatory["rank-symmetric-trainer-loop"]
     assert "Version-check only fields claimed to belong to a framework" in normalized_validation

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -366,6 +366,14 @@ def test_conversion_skills_treat_per_site_train_args_as_complete_replacements():
     assert "complete argument string" in normalized_construction
     assert "it replaces the recipe-level `train_args`" in normalized_construction
     assert "does not merge shared arguments into the site override" in normalized_construction
+    assert (
+        "Call `set_per_site_config(...)` immediately after recipe construction and before adding client "
+        "configuration, files, filters, or components" in normalized_construction
+    )
+    assert (
+        "construct the recipe -> set per-site config -> add files, filters, and components -> add required "
+        "decomposers -> export or execute" in normalized_construction
+    )
     assert "only the fallback for a site without its own `train_args` entry" in normalized_construction
     assert "`task_script_args` contains the full expected argument set" in normalized_construction
     assert "completely replaces recipe-level `train_args`" in normalized_site_data

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -952,6 +952,30 @@ def test_orientation_routes_only_unresolved_explicit_conversions():
     assert "no-orient-for-single-owner-conversion" in prohibited_ids
 
 
+def test_lightning_conversion_trigger_requires_federation_intent():
+    repo_root = Path(__file__).resolve().parents[4]
+    skill_root = repo_root / "skills" / "nvflare-convert-lightning"
+    skill_path = skill_root / "SKILL.md"
+    skill_text = " ".join(skill_path.read_text(encoding="utf-8").split())
+    description = parse_skill_frontmatter(skill_path)["description"]
+    eval_data = json.loads(skill_root.joinpath("evals", "evals.json").read_text(encoding="utf-8"))
+    negative_eval_ids = {
+        "lightning-negative-ddp-without-federation",
+        "lightning-negative-profiling",
+        "lightning-negative-inference-serving",
+        "lightning-negative-training-loop-change",
+        "lightning-negative-tensorflow-keras",
+    }
+
+    assert "use only when the request expresses federated or NVFLARE conversion intent" in description
+    assert "Lightning source evidence alone is not sufficient" in skill_text
+    for eval_id in negative_eval_ids:
+        negative_eval = _eval_by_id(eval_data, eval_id)
+        assert negative_eval["files"]
+        assert negative_eval["nvflare"]["expected_skill"] is None
+        assert negative_eval["nvflare"]["negative_for"] == "nvflare-convert-lightning"
+
+
 def test_huggingface_train_only_model_selection_contract_is_explicit():
     repo_root = Path(__file__).resolve().parents[4]
     hf_root = repo_root / "skills" / "nvflare-convert-huggingface"

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -844,6 +844,7 @@ def test_client_api_rank_contract_is_shared_and_process_conditional():
     hf_client = repo_root.joinpath("skills/nvflare-convert-huggingface/assets/client_with_eval.py").read_text(
         encoding="utf-8"
     )
+    hf_public_api = repo_root.joinpath("nvflare/client/hf/__init__.py").read_text(encoding="utf-8")
     hf_state = repo_root.joinpath(
         "skills/nvflare-convert-huggingface/references/huggingface-state-and-distributed.md"
     ).read_text(encoding="utf-8")
@@ -874,14 +875,15 @@ def test_client_api_rank_contract_is_shared_and_process_conditional():
 
     assert "def main(trainer_factory, *, evaluate_before_train=True)" in hf_client
     assert "flare.init()" in hf_client
-    assert "flare.init(rank=dist.get_rank())" in hf_client
-    assert "_MULTIRANK_SIZE_ENV_VARS" in hf_client
-    assert "global RANK is unavailable" in hf_client
+    assert "torch.distributed" not in hf_client
+    assert "_MULTIRANK_SIZE_ENV_VARS" not in hf_client
+    assert "_MULTIRANK_SIZE_ENV_VARS" in hf_public_api
+    assert "global RANK is unavailable" in hf_public_api
     assert "framework-neutral global-rank contract" in normalized_hf_state
     assert "do not add a rank argument to a standard single-process conversion" in normalized_hf_state
     assert "framework-neutral global-rank contract" in normalized_lightning_ddp
-    assert "passes `torch.distributed.get_rank()` to `flare.init(...)`" in normalized_hf_state
-    assert "rejects the launch before `flare.init()` when it is missing" in normalized_hf_state
+    assert "`nvflare.client.hf.init()` owns this resolution" in normalized_hf_state
+    assert "Keep the generated client rankless" in normalized_hf_state
     assert "flare.init(rank=global_rank)" in lightning_ddp
 
     lightning_evals = json.loads(
@@ -1431,7 +1433,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "flare.patch(trainer)" in client_template
     assert "def main(trainer_factory, *, evaluate_before_train=True)" in client_template
     assert "flare.init()" in client_template
-    assert "flare.init(rank=dist.get_rank())" in client_template
+    assert "torch.distributed" not in client_template
     assert "HfArgumentParser(dataclass_types, allow_abbrev=False)" in client_template
     assert "while flare.is_running()" in client_template
     assert "return model" in server_model_template
@@ -1473,7 +1475,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "two-process `torchrun` case" in normalized_validation
     assert "This section applies only to a preserved distributed multi-process launch" in normalized_state
     assert "do not add a rank argument to a standard single-process conversion" in normalized_state
-    assert "`flare.patch(trainer)` verifies the rank after Trainer initialization" in normalized_state
+    assert "`nvflare.client.hf.init()` owns this resolution" in normalized_state
     assert "do not pass it as the FLARE rank" in normalized_state
     basic_mandatory = {item["id"]: item["description"] for item in basic_eval["mandatory_behavior"]}
     ddp_mandatory = {item["id"]: item["description"] for item in ddp_eval["mandatory_behavior"]}
@@ -1486,8 +1488,15 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
         item["id"] for item in basic_eval["prohibited_behavior"]
     }
     assert "single-process-rankless-init" in basic_mandatory
-    assert "without a rank-zero default" in ddp_mandatory["initialize-distributed-before-patch"]
-    assert "observed global and flare.init ranks 0 and 1" in ddp_mandatory["rank-symmetric-trainer-loop"]
+    assert (
+        "product-owned global-rank resolution and fail-fast rejection"
+        in ddp_mandatory["initialize-distributed-before-patch"]
+    )
+    assert "no-generated-rank-resolution" in {item["id"] for item in ddp_eval["prohibited_behavior"]}
+    assert (
+        "observed launcher and product-resolved Client API ranks 0 and 1"
+        in ddp_mandatory["rank-symmetric-trainer-loop"]
+    )
     assert "Version-check only fields claimed to belong to a framework" in normalized_validation
     assert "project-defined subclass field" in normalized_validation
     assert "actual parser accepts it" in normalized_validation

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -469,6 +469,22 @@ def test_lightning_conversion_limits_reference_loading_and_full_run_validation()
     ]
     phase_positions = [skill_text.index(marker) for marker in phase_markers]
     assert phase_positions == sorted(phase_positions)
+    standard_path_position = skill_text.index("## Standard Path")
+    workflow_position = skill_text.index("## Workflow")
+    non_standard_position = skill_text.index("## Non-standard Cases")
+    requirements_position = skill_text.index("## Requirements")
+    assert standard_path_position < workflow_position < non_standard_position < requirements_position
+    conditional_references = (
+        "../nvflare-shared/references/conversion-workflow.md",
+        "../nvflare-shared/references/pytorch-family-recipe-selection.md",
+        "../nvflare-shared/references/dependency-install.md",
+        "../nvflare-shared/references/runtime-output-guidance.md",
+        "references/lightning-ddp-and-tracking.md",
+        "../nvflare-shared/references/metrics-and-artifact-reporting.md",
+    )
+    for reference in conditional_references:
+        assert skill_text.count(reference) == 1
+        assert skill_text.index(reference) > non_standard_position
     assert "Complete each workflow phase before loading the next phase's reference" in normalized_skill
     assert "before any preflight, smoke test, cleanup, validation, or execution command" in normalized_skill
     assert "Do not enumerate reference directories or preload validation" in normalized_skill

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -1008,6 +1008,8 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert "do not append Hugging Face cache or filesystem discovery" in normalized_hf_skill
     assert "Defer model and dataset availability checks to the maintained resolver" in normalized_hf_skill
     assert "report a missing directory with exit code zero" in normalized_hf_skill
+    assert "Run the final simulation with `run_in_background: false`" in normalized_hf_skill
+    assert "never finalize with an active simulation" in normalized_hf_skill
     assert "rerun its resolver once with the matching canonical invocation" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
     assert "`--source local`" in hf_validation

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -317,6 +317,8 @@ def test_pytorch_family_construction_policy_is_canonical_and_capability_based():
     assert "Never instantiate an incomplete `FedAvgRecipe`" in normalized_construction
     assert "When `aggregation_format` is exposed" in normalized_construction
     assert "when `server_expected_format` is exposed" in normalized_construction
+    assert "from nvflare.client.config import ExchangeFormat, TransferType" in construction_text
+    assert "from nvflare.app_common.abstract.fl_model import ExchangeFormat" not in construction_text
     assert "When tensor-native transport was selected" in normalized_construction
     assert "Disk offload is an aggregation-workflow memory optimization" in normalized_construction
     assert "temporary files on the aggregation host and materialized lazily" in normalized_construction

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -834,11 +834,11 @@ def test_client_api_rank_contract_is_shared_and_process_conditional():
 
     assert "def main(trainer_factory, *, evaluate_before_train=True)" in hf_client
     assert "flare.init()" in hf_client
-    assert "flare.init(rank=" not in hf_client
+    assert "flare.init(rank=dist.get_rank())" in hf_client
     assert "framework-neutral global-rank contract" in normalized_hf_state
     assert "do not add a rank argument to a standard single-process conversion" in normalized_hf_state
     assert "framework-neutral global-rank contract" in normalized_lightning_ddp
-    assert "flare.init(rank=global_rank)" in hf_state
+    assert "passes `torch.distributed.get_rank()` to `flare.init(...)`" in normalized_hf_state
     assert "flare.init(rank=global_rank)" in lightning_ddp
 
     lightning_evals = json.loads(
@@ -1382,7 +1382,7 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "flare.patch(trainer)" in client_template
     assert "def main(trainer_factory, *, evaluate_before_train=True)" in client_template
     assert "flare.init()" in client_template
-    assert "flare.init(rank=" not in client_template
+    assert "flare.init(rank=dist.get_rank())" in client_template
     assert "HfArgumentParser(dataclass_types, allow_abbrev=False)" in client_template
     assert "while flare.is_running()" in client_template
     assert "return model" in server_model_template
@@ -1423,8 +1423,8 @@ def test_pytorch_family_conversion_documents_fl_entry_packaging_and_metric_keys(
     assert "Do not first run an unconditional full-state equality assertion" in normalized_validation
     assert "two-process `torchrun` case" in normalized_validation
     assert "This section applies only to a preserved distributed multi-process launch" in normalized_state
-    assert "standard single-process conversion" in normalized_state
-    assert "verify that the preserved distributed launcher supplies it" in normalized_state
+    assert "do not add a rank argument to a standard single-process conversion" in normalized_state
+    assert "`flare.patch(trainer)` verifies the rank after Trainer initialization" in normalized_state
     assert "do not pass it as the FLARE rank" in normalized_state
     basic_mandatory = {item["id"]: item["description"] for item in basic_eval["mandatory_behavior"]}
     ddp_mandatory = {item["id"]: item["description"] for item in ddp_eval["mandatory_behavior"]}

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -996,12 +996,18 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     offline_eval = _eval_by_id(eval_data, "huggingface-offline-model-cache-miss")
     mandatory_ids = {item["id"] for item in basic_eval["mandatory_behavior"]}
     prohibited_ids = {item["id"] for item in basic_eval["prohibited_behavior"]}
+    normalized_hf_skill = " ".join(hf_skill.split())
     normalized_hf_validation = " ".join(hf_validation.split())
 
     assert "same interpreter selected for installation and validation" in " ".join(dependency_text.split())
     assert "make the inventory command exit zero" in " ".join(dependency_text.split())
     assert "optional capability or host-diagnostic utility as evidence" in " ".join(validation_text.split())
     assert "Do not append platform-specific utilities" in " ".join(validation_text.split())
+    assert "Keep dependency inventory single-purpose" in normalized_hf_skill
+    assert "check NVFLARE separately, inventory non-product packages separately" in normalized_hf_skill
+    assert "do not append Hugging Face cache or filesystem discovery" in normalized_hf_skill
+    assert "Defer model and dataset availability checks to the maintained resolver" in normalized_hf_skill
+    assert "report a missing directory with exit code zero" in normalized_hf_skill
     assert "rerun its resolver once with the matching canonical invocation" in normalized_hf_validation
     assert "`../scripts/resolve_model_snapshot.py`" in hf_validation
     assert "`--source local`" in hf_validation
@@ -1034,6 +1040,7 @@ def test_huggingface_preflights_and_metric_reporting_do_not_create_false_recover
     assert {"cache-aware-authorized-model-resolution", "numeric-primary-metric-reporting"} <= mandatory_ids
     assert {
         "no-raising-cache-only-model-probe",
+        "no-compound-dependency-and-cache-probe",
         "no-ambiguous-model-source",
         "no-invented-resolver-model-option",
         "no-unpinned-hub-download",

--- a/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/seed_skills_test.py
@@ -952,7 +952,11 @@ def test_orientation_routes_only_unresolved_explicit_conversions():
     assert "no-orient-for-single-owner-conversion" in prohibited_ids
 
 
-def test_lightning_conversion_trigger_requires_federation_intent():
+def test_lightning_conversion_trigger_contract_includes_adjacent_negative_evals():
+    """Keep the externally executed routing cases tied to the skill trigger contract.
+
+    Skill selection is performed by the agent/model, not by an in-repo router.
+    """
     repo_root = Path(__file__).resolve().parents[4]
     skill_root = repo_root / "skills" / "nvflare-convert-lightning"
     skill_path = skill_root / "SKILL.md"


### PR DESCRIPTION
## Summary
- tighten nvflare-convert-lightning triggering so it requires both federation intent—either explicit federated/NVFLARE conversion or collaborative training across sites while data remains local—and verified PyTorch Lightning ownership, with adjacent-negative routing evals for DDP, profiling, serving, training-loop, and TensorFlow/Keras requests
- add a positive Lightning routing eval for implicit federation intent expressed as collaborative cross-hospital training without moving data, protecting recall without naming FLARE or federated learning
- move the Lightning standard-path reference order ahead of the detailed workflow and consolidate non-standard conditional loads to reduce unnecessary reference reads without changing validation gates
- document shared PyTorch-family Recipe contracts for ExchangeFormat/TransferType imports and the required set_per_site_config ordering before files, filters, or components
- make Hugging Face rank resolution product-owned: nvflare.client.hf.init resolves an initialized process-group rank or global RANK, canonicalizes validated environment ranks, rejects negative ranks, and rejects unresolved multi-process launches before creating a Client API context; generated clients remain rankless and contain no launcher-parsing logic
- centralize the foreground final-simulation and no-active-finalization invariant in the shared validation reference used by both Lightning and Hugging Face converters
- make Hugging Face source-data handling conditional: remove the generic --data_root assumption, add an opt-in resolve_source_local_path helper, preserve source argument names, and distinguish source-relative, absolute, per-site, Hub, URL, and no-path inputs
- keep Hugging Face dependency inventory separate from optional cache/filesystem discovery, defer artifact availability checks to the maintained resolver, and make separately necessary missing-path probes exit zero
- add focused eval fixtures and deterministic regression coverage for trigger selection, reference ordering, Recipe construction, product-owned distributed rank behavior, source-path resolution, dependency-probe isolation, per-site overrides, and alternate caller working directories

## Validation
- `python3 -m pytest tests/unit_test/app_opt/hf -q` — 112 passed, 8 skipped
- `python3 -m pytest tests/unit_test/tool/agent_skill_checks -q` — 491 passed, 37 skipped
- `./runtest.sh -s` — Black, isort, Flake8, and agent-skill lint passed
- pre-push agent-skill lint — 0 errors, 0 warnings, 0 informational findings