### PR TITLE
Document dual-EKU re-provisioning requirement for K8s/Slurm job launchers [doc] [skip-ci]

### DIFF
--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -113,15 +113,15 @@ identity to the participant's logical FQCN rather than the pod name or IP addres
 
 .. note::
 
-   Using the Kubernetes job launcher requires re-provisioning sites whose
-   startup kits were created by an earlier NVFlare release. The internal mTLS
-   links use the participant certificate in both TLS roles (the client parent
-   listens with the client certificate, and the server job connects with the
-   server certificate), so the certificate must carry the new extended key
-   usage (EKU) that allows both ``clientAuth`` and ``serverAuth``. Certificates
-   issued by earlier releases do not include the new EKU. Re-provision the
-   project so the certificates are regenerated with the new EKU, then re-run
-   ``nvflare deploy prepare`` on the new startup kits.
+   The Kubernetes job launcher requires certificates that allow both
+   ``clientAuth`` and ``serverAuth``, because the internal mTLS links use the
+   participant certificate in both TLS roles (the client parent listens with the
+   client certificate, and the server job connects with the server certificate).
+   Sites whose startup kits carry role-restricted certificates — for example,
+   kits created by NVFlare 2.8 distributed provisioning, which issues
+   certificates with only ``clientAuth`` or only ``serverAuth`` — must be
+   re-provisioned. Kits whose certificates carry no EKU (unrestricted) remain
+   compatible and do not need re-provisioning. After re-provisioning, re-run ``nvflare deploy prepare`` on the new startup kits.
 
 The runtime shape is:
 

--- a/docs/user_guide/admin_guide/deployment/helm_chart.rst
+++ b/docs/user_guide/admin_guide/deployment/helm_chart.rst
@@ -111,6 +111,18 @@ These internal TCP links use mTLS by default. The job pod receives the existing
 participant startup CA, certificate, and key, while CellNet binds the certificate
 identity to the participant's logical FQCN rather than the pod name or IP address.
 
+.. note::
+
+   Using the Kubernetes job launcher requires re-provisioning sites whose
+   startup kits were created by an earlier NVFlare release. The internal mTLS
+   links use the participant certificate in both TLS roles (the client parent
+   listens with the client certificate, and the server job connects with the
+   server certificate), so the certificate must carry the new extended key
+   usage (EKU) that allows both ``clientAuth`` and ``serverAuth``. Certificates
+   issued by earlier releases do not include the new EKU. Re-provision the
+   project so the certificates are regenerated with the new EKU, then re-run
+   ``nvflare deploy prepare`` on the new startup kits.
+
 The runtime shape is:
 
 .. code-block:: text

--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -87,6 +87,18 @@ participant startup CA, certificate, and key, while CellNet binds the
 certificate identity to the participant's logical FQCN rather than the
 allocated Slurm hostname.
 
+.. note::
+
+   Using the Slurm job launcher requires re-provisioning sites whose startup
+   kits were created by an earlier NVFlare release. The internal mTLS links use
+   the participant certificate in both TLS roles (the client parent listens
+   with the client certificate, and the server job connects with the server
+   certificate), so the certificate must carry the new extended key usage
+   (EKU) that allows both ``clientAuth`` and ``serverAuth``. Certificates
+   issued by earlier releases do not include the new EKU. Re-provision the
+   project so the certificates are regenerated with the new EKU, then rebuild
+   the runtime workspace from the new startup kit.
+
 Build a Container Worker Image
 ==============================
 
@@ -495,11 +507,14 @@ fan-out behavior and requires effective ``sandbox: none``.
 Security and Operations
 =======================
 
-The worker-to-parent internal channel is clear TCP, matching the Kubernetes
-launcher, or clear shared-file I/O when the file transport is configured (see
-:ref:`slurm_shared_file_channel`). Use it only on a trusted or isolated site
-network or filesystem. This does not change the configured security of the
-external NVFlare federation channel.
+The worker-to-parent internal TCP channel uses mTLS by default, matching the
+Kubernetes launcher, and requires certificates carrying the new dual
+``clientAuth``/``serverAuth`` EKU (see the re-provisioning note in
+`Prerequisites`_). ``internal_connection_security: clear`` is an explicit
+insecure opt-out, and the shared-file transport is clear file I/O (see
+:ref:`slurm_shared_file_channel`). Use clear transport only on a trusted or
+isolated site network or filesystem. None of this changes the configured
+security of the external NVFlare federation channel.
 
 Working accounting is mandatory. The parent refuses to start if ``sacct`` is
 unavailable. A later scheduler or accounting outage leaves affected jobs

--- a/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
+++ b/docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst
@@ -89,15 +89,15 @@ allocated Slurm hostname.
 
 .. note::
 
-   Using the Slurm job launcher requires re-provisioning sites whose startup
-   kits were created by an earlier NVFlare release. The internal mTLS links use
-   the participant certificate in both TLS roles (the client parent listens
-   with the client certificate, and the server job connects with the server
-   certificate), so the certificate must carry the new extended key usage
-   (EKU) that allows both ``clientAuth`` and ``serverAuth``. Certificates
-   issued by earlier releases do not include the new EKU. Re-provision the
-   project so the certificates are regenerated with the new EKU, then rebuild
-   the runtime workspace from the new startup kit.
+   The Slurm job launcher requires certificates that allow both
+   ``clientAuth`` and ``serverAuth``, because the internal mTLS links use the
+   participant certificate in both TLS roles (the client parent listens with the
+   client certificate, and the server job connects with the server certificate).
+   Sites whose startup kits carry role-restricted certificates — for example,
+   kits created by NVFlare 2.8 distributed provisioning, which issues
+   certificates with only ``clientAuth`` or only ``serverAuth`` — must be
+   re-provisioned. Kits whose certificates carry no EKU (unrestricted) remain
+   compatible and do not need re-provisioning. After re-provisioning, rebuild the runtime workspace from the new startup kit.
 
 Build a Container Worker Image
 ==============================

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -18,12 +18,12 @@ Kubernetes, or Slurm.
 
    The Kubernetes and Slurm runtimes secure the internal parent/job links
    (SP/SJ and CP/CJ) with mTLS by default, and these links use the participant
-   certificate in both TLS roles. The certificate must therefore carry the new
-   extended key usage (EKU) that allows both ``clientAuth`` and
-   ``serverAuth``. Startup kits provisioned by an earlier NVFlare release do
-   not include the new EKU, so re-provision the project with the current
-   release — regenerating its certificates — before preparing kits for these
-   runtimes.
+   certificate in both TLS roles. The certificate must therefore allow both
+   ``clientAuth`` and ``serverAuth`` in its extended key usage (EKU). Startup
+   kits whose certificates are restricted to a single role — for example, kits
+   created by NVFlare 2.8 distributed provisioning, which issues certificates
+   carrying only ``clientAuth`` or only ``serverAuth`` — must be re-provisioned
+   before using these runtimes. Kits whose certificates carry no EKU (unrestricted) remain compatible and do not need re-provisioning.
 
 For Kubernetes deployment workflow, see :ref:`helm_chart`. For the Slurm
 deployment workflow and security checklist, see :ref:`slurm_job_launcher`. For

--- a/docs/user_guide/nvflare_cli/deploy_command.rst
+++ b/docs/user_guide/nvflare_cli/deploy_command.rst
@@ -14,6 +14,17 @@ Kubernetes clusters. Use ``nvflare provision`` or the distributed
 ``deploy prepare`` on each server or client kit that should run in Docker,
 Kubernetes, or Slurm.
 
+.. note::
+
+   The Kubernetes and Slurm runtimes secure the internal parent/job links
+   (SP/SJ and CP/CJ) with mTLS by default, and these links use the participant
+   certificate in both TLS roles. The certificate must therefore carry the new
+   extended key usage (EKU) that allows both ``clientAuth`` and
+   ``serverAuth``. Startup kits provisioned by an earlier NVFlare release do
+   not include the new EKU, so re-provision the project with the current
+   release — regenerating its certificates — before preparing kits for these
+   runtimes.
+
 For Kubernetes deployment workflow, see :ref:`helm_chart`. For the Slurm
 deployment workflow and security checklist, see :ref:`slurm_job_launcher`. For
 job-level runtime settings, see :ref:`launcher_spec`.


### PR DESCRIPTION
### Description

The Kubernetes and Slurm job launchers secure the internal parent/job links (SP/SJ and CP/CJ) with mTLS by default (#5142), using the participant certificate in both TLS roles: the client parent listens with the client certificate, and the server job connects with the server certificate. This requires certificates whose extended key usage (EKU) allows both `clientAuth` and `serverAuth`; newly provisioned kits now include the dual EKU.

This PR documents that sites whose startup kits were provisioned by an earlier release must be re-provisioned so certificates are regenerated with the new EKU before using the Kubernetes/Slurm launcher features:

- `docs/user_guide/admin_guide/deployment/slurm_job_launcher.rst`: re-provisioning note in Prerequisites. Also updates the Security and Operations paragraph, which still described the internal worker-to-parent channel as clear TCP.
- `docs/user_guide/admin_guide/deployment/helm_chart.rst`: the same note for the Kubernetes launcher.
- `docs/user_guide/nvflare_cli/deploy_command.rst`: a shared note covering both runtimes.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Documentation updated.