### PR TITLE
Fix concurrent job lifecycle accounting

### DIFF
--- a/nvflare/apis/utils/job_utils.py
+++ b/nvflare/apis/utils/job_utils.py
@@ -18,7 +18,8 @@ import os
 from typing import Optional
 from zipfile import ZipFile
 
-from nvflare.apis.fl_constant import JobConstants
+from nvflare.apis.fl_constant import FLContextKey, JobConstants
+from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import ALL_SITES, JobMetaKey
 from nvflare.fuel.utils.config import ConfigFormat
 from nvflare.fuel.utils.config_factory import ConfigFactory
@@ -105,3 +106,18 @@ def load_job_def_bytes(from_path: str, def_name: str) -> bytes:
     # zip the job folder
     data = zip_directory_to_bytes(from_path, def_name)
     return convert_legacy_zipped_app_to_job(data)
+
+
+def get_event_job_id(fl_ctx: FLContext) -> Optional[str]:
+    """Get the ID of the job that originated a job lifecycle event.
+
+    Prefers the explicit job ID published in the event data, which is immune to
+    concurrent changes of the sticky CURRENT_JOB_ID context property. Falls back
+    to CURRENT_JOB_ID for event publishers that do not attach event data.
+    """
+    event_data = fl_ctx.get_prop(FLContextKey.EVENT_DATA)
+    if isinstance(event_data, dict):
+        job_id = event_data.get(JobMetaKey.JOB_ID.value)
+        if job_id:
+            return job_id
+    return fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)

--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -25,6 +25,7 @@ from nvflare.apis.job_def import ALL_SITES, SERVER_SITE_NAME, Job, JobMetaKey, R
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec
 from nvflare.apis.job_scheduler_spec import DispatchInfo, JobSchedulerSpec
 from nvflare.apis.server_engine_spec import ServerEngineSpec
+from nvflare.apis.utils.job_utils import get_event_job_id
 from nvflare.private.fed.utils.fed_utils import extract_participants
 from nvflare.security.study_registry import StudyRegistryService
 from nvflare.utils.job_launcher_utils import get_resource_manager_spec
@@ -273,24 +274,15 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.JOB_STARTED:
-            job_id = self._get_event_job_id(fl_ctx)
+            job_id = get_event_job_id(fl_ctx)
             with self.lock:
                 if job_id not in self.scheduled_jobs:
                     self.scheduled_jobs.append(job_id)
         elif event_type == EventType.JOB_COMPLETED or event_type == EventType.JOB_ABORTED:
-            job_id = self._get_event_job_id(fl_ctx)
+            job_id = get_event_job_id(fl_ctx)
             with self.lock:
                 if job_id in self.scheduled_jobs:
                     self.scheduled_jobs.remove(job_id)
-
-    @staticmethod
-    def _get_event_job_id(fl_ctx: FLContext):
-        event_data = fl_ctx.get_prop(FLContextKey.EVENT_DATA)
-        if isinstance(event_data, dict):
-            job_id = event_data.get(JobMetaKey.JOB_ID.value)
-            if job_id:
-                return job_id
-        return fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
 
     def schedule_job(
         self, job_manager: JobDefManagerSpec, job_candidates: List[Job], fl_ctx: FLContext

--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -274,14 +274,23 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.JOB_STARTED:
             with self.lock:
-                job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+                job_id = self._get_event_job_id(fl_ctx)
                 if job_id not in self.scheduled_jobs:
                     self.scheduled_jobs.append(job_id)
         elif event_type == EventType.JOB_COMPLETED or event_type == EventType.JOB_ABORTED:
             with self.lock:
-                job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+                job_id = self._get_event_job_id(fl_ctx)
                 if job_id in self.scheduled_jobs:
                     self.scheduled_jobs.remove(job_id)
+
+    @staticmethod
+    def _get_event_job_id(fl_ctx: FLContext):
+        event_data = fl_ctx.get_prop(FLContextKey.EVENT_DATA)
+        if isinstance(event_data, dict):
+            job_id = event_data.get(JobMetaKey.JOB_ID.value)
+            if job_id:
+                return job_id
+        return fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
 
     def schedule_job(
         self, job_manager: JobDefManagerSpec, job_candidates: List[Job], fl_ctx: FLContext

--- a/nvflare/app_common/job_schedulers/job_scheduler.py
+++ b/nvflare/app_common/job_schedulers/job_scheduler.py
@@ -273,13 +273,13 @@ class DefaultJobScheduler(JobSchedulerSpec, FLComponent):
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
         if event_type == EventType.JOB_STARTED:
+            job_id = self._get_event_job_id(fl_ctx)
             with self.lock:
-                job_id = self._get_event_job_id(fl_ctx)
                 if job_id not in self.scheduled_jobs:
                     self.scheduled_jobs.append(job_id)
         elif event_type == EventType.JOB_COMPLETED or event_type == EventType.JOB_ABORTED:
+            job_id = self._get_event_job_id(fl_ctx)
             with self.lock:
-                job_id = self._get_event_job_id(fl_ctx)
                 if job_id in self.scheduled_jobs:
                     self.scheduled_jobs.remove(job_id)
 

--- a/nvflare/edge/widgets/etd.py
+++ b/nvflare/edge/widgets/etd.py
@@ -21,6 +21,7 @@ from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.job_def import JobMetaKey
+from nvflare.apis.utils.job_utils import get_event_job_id
 from nvflare.edge.constants import (
     EdgeApiStatus,
     EdgeConfigFile,
@@ -180,9 +181,9 @@ class EdgeTaskDispatcher(Widget):
 
     def _handle_job_done(self, event_type: str, fl_ctx: FLContext):
         self.logger.debug(f"handling event {event_type}")
-        job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+        job_id = get_event_job_id(fl_ctx)
         if not job_id:
-            self.logger.error(f"missing {FLContextKey.CURRENT_JOB_ID} from fl_ctx for event {event_type}")
+            self.logger.error(f"missing job ID from fl_ctx for event {event_type}")
         else:
             self._remove_job(job_id)
 

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -477,7 +477,7 @@ class JobRunner(FLComponent):
                             # Publish terminal status only after artifacts are ready for download.
                             if not finished_state.workspace_archival_complete:
                                 try:
-                                    self._save_workspace(completion_ctx, finished_state)
+                                    self._save_workspace(completion_ctx, finished_state, job.job_id)
                                 except Exception as e:
                                     now = time.monotonic()
                                     if finished_state.workspace_save_started_at is None:
@@ -570,8 +570,11 @@ class JobRunner(FLComponent):
             status = RunStatus.FINISHED_COMPLETED
         return status
 
-    def _save_workspace(self, fl_ctx: FLContext, finished_state: _FinishedJobState | None = None):
-        job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
+    def _save_workspace(
+        self, fl_ctx: FLContext, finished_state: _FinishedJobState | None = None, job_id: str | None = None
+    ):
+        if job_id is None:
+            job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
         if finished_state and finished_state.workspace_archive_written:
             ws_dirs = list(finished_state.workspace_archive_sources)
         else:

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -361,7 +361,15 @@ class JobRunner(FLComponent):
         display_sites = ",".join(active_client_sites)
 
         self.log_info(fl_ctx, f"Started run: {job_id} for clients: {display_sites}")
-        self.fire_event(EventType.JOB_STARTED, fl_ctx)
+        self._fire_job_lifecycle_event(EventType.JOB_STARTED, job_id, fl_ctx)
+
+    def _fire_job_lifecycle_event(self, event_type: str, job_id: str, fl_ctx: FLContext):
+        self.fire_event_with_data(
+            event_type,
+            fl_ctx,
+            FLContextKey.EVENT_DATA,
+            {JobMetaKey.JOB_ID.value: job_id},
+        )
 
     def _stop_run(self, job_id, fl_ctx: FLContext):
         """Stop the application
@@ -510,8 +518,8 @@ class JobRunner(FLComponent):
                                 self._pending_client_outcomes.pop(job_id, None)
                                 self._client_outcome_deadlines.pop(job_id, None)
                             if status == RunStatus.FINISHED_ABORTED:
-                                self.fire_event(EventType.JOB_ABORTED, completion_ctx)
-                            self.fire_event(EventType.JOB_COMPLETED, completion_ctx)
+                                self._fire_job_lifecycle_event(EventType.JOB_ABORTED, job_id, completion_ctx)
+                            self._fire_job_lifecycle_event(EventType.JOB_COMPLETED, job_id, completion_ctx)
                             self.log_debug(completion_ctx, f"Finished running job:{job.job_id}")
                     engine.remove_exception_process(job_id)
             time.sleep(1.0)
@@ -700,7 +708,7 @@ class JobRunner(FLComponent):
                                     ready_job.job_id, {JobMetaKey.JOB_DEPLOY_DETAIL.value: deploy_detail}, fl_ctx
                                 )
 
-                            self.fire_event(EventType.JOB_ABORTED, fl_ctx)
+                            self._fire_job_lifecycle_event(EventType.JOB_ABORTED, ready_job.job_id, fl_ctx)
                             self.log_error(
                                 fl_ctx, f"Failed to run the Job ({ready_job.job_id}): {secure_format_exception(e)}"
                             )

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -343,34 +343,33 @@ def setup_and_teardown(request):
 
 
 class TestDefaultJobScheduler:
-    def test_lifecycle_event_uses_explicit_job_id_when_sticky_job_id_changes(self):
+    def test_lifecycle_event_uses_explicit_job_id_over_sticky_job_id(self):
         scheduler = DefaultJobScheduler(max_jobs=20)
-        fl_ctx_manager = FLContextManager()
-        starting_ctx = fl_ctx_manager.new_context()
-        starting_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "starting-job")
-
-        completion_ctx = fl_ctx_manager.new_context()
-        completion_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "completed-job")
-        assert starting_ctx.get_prop(FLContextKey.CURRENT_JOB_ID) == "completed-job"
-
-        starting_ctx.set_prop(
+        fl_ctx = FLContext()
+        fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "wrong-job")
+        fl_ctx.set_prop(
             FLContextKey.EVENT_DATA,
-            {JobMetaKey.JOB_ID.value: "starting-job"},
+            {JobMetaKey.JOB_ID.value: "right-job"},
             private=True,
             sticky=False,
         )
-        scheduler.handle_event(EventType.JOB_STARTED, starting_ctx)
-        assert scheduler.scheduled_jobs == ["starting-job"]
 
-        completion_ctx.set_prop(
-            FLContextKey.EVENT_DATA,
-            {JobMetaKey.JOB_ID.value: "completed-job"},
-            private=True,
-            sticky=False,
-        )
-        scheduler.scheduled_jobs.append("completed-job")
-        scheduler.handle_event(EventType.JOB_COMPLETED, completion_ctx)
-        assert scheduler.scheduled_jobs == ["starting-job"]
+        scheduler.handle_event(EventType.JOB_STARTED, fl_ctx)
+        assert scheduler.scheduled_jobs == ["right-job"]
+
+        scheduler.handle_event(EventType.JOB_COMPLETED, fl_ctx)
+        assert scheduler.scheduled_jobs == []
+
+    def test_lifecycle_event_falls_back_to_sticky_job_id_without_event_data(self):
+        scheduler = DefaultJobScheduler(max_jobs=20)
+        fl_ctx = FLContext()
+        fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "sticky-job")
+
+        scheduler.handle_event(EventType.JOB_STARTED, fl_ctx)
+        assert scheduler.scheduled_jobs == ["sticky-job"]
+
+        scheduler.handle_event(EventType.JOB_ABORTED, fl_ctx)
+        assert scheduler.scheduled_jobs == []
 
     def test_weird_deploy_map(self, setup_and_teardown):
         servers, scheduler, num_sites, job_manager = setup_and_teardown

--- a/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
+++ b/tests/unit_test/app_common/job_schedulers/job_scheduler_test.py
@@ -19,6 +19,8 @@ import pytest
 
 import nvflare.app_common.job_schedulers.job_scheduler as job_scheduler_module
 from nvflare.apis.client import Client
+from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext, FLContextManager
 from nvflare.apis.job_def import ALL_SITES, Job, JobMetaKey, RunStatus
 from nvflare.apis.job_def_manager_spec import JobDefManagerSpec
@@ -341,6 +343,35 @@ def setup_and_teardown(request):
 
 
 class TestDefaultJobScheduler:
+    def test_lifecycle_event_uses_explicit_job_id_when_sticky_job_id_changes(self):
+        scheduler = DefaultJobScheduler(max_jobs=20)
+        fl_ctx_manager = FLContextManager()
+        starting_ctx = fl_ctx_manager.new_context()
+        starting_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "starting-job")
+
+        completion_ctx = fl_ctx_manager.new_context()
+        completion_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "completed-job")
+        assert starting_ctx.get_prop(FLContextKey.CURRENT_JOB_ID) == "completed-job"
+
+        starting_ctx.set_prop(
+            FLContextKey.EVENT_DATA,
+            {JobMetaKey.JOB_ID.value: "starting-job"},
+            private=True,
+            sticky=False,
+        )
+        scheduler.handle_event(EventType.JOB_STARTED, starting_ctx)
+        assert scheduler.scheduled_jobs == ["starting-job"]
+
+        completion_ctx.set_prop(
+            FLContextKey.EVENT_DATA,
+            {JobMetaKey.JOB_ID.value: "completed-job"},
+            private=True,
+            sticky=False,
+        )
+        scheduler.scheduled_jobs.append("completed-job")
+        scheduler.handle_event(EventType.JOB_COMPLETED, completion_ctx)
+        assert scheduler.scheduled_jobs == ["starting-job"]
+
     def test_weird_deploy_map(self, setup_and_teardown):
         servers, scheduler, num_sites, job_manager = setup_and_teardown
         candidate = create_job(

--- a/tests/unit_test/edge/widgets/etd_test.py
+++ b/tests/unit_test/edge/widgets/etd_test.py
@@ -95,6 +95,22 @@ def test_job_lifecycle_handlers_validate_context(tmp_path):
     assert not dispatcher._job_exists("job-1")
 
 
+def test_job_done_prefers_explicit_event_job_id_over_sticky_id(tmp_path):
+    dispatcher = EdgeTaskDispatcher()
+    workspace = MagicMock()
+    workspace.get_app_config_dir.return_value = str(tmp_path)
+    fl_ctx = _context()
+    fl_ctx.set_prop(FLContextKey.WORKSPACE_OBJECT, workspace, private=True, sticky=False)
+    fl_ctx.set_prop(FLContextKey.JOB_META, _job_meta(), private=True, sticky=False)
+    dispatcher._handle_job_launched("launched", fl_ctx)
+    assert dispatcher._job_exists("job-1")
+
+    fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "wrong-job", private=True, sticky=False)
+    fl_ctx.set_prop(FLContextKey.EVENT_DATA, {JobMetaKey.JOB_ID.value: "job-1"}, private=True, sticky=False)
+    dispatcher._handle_job_done("done", fl_ctx)
+    assert not dispatcher._job_exists("job-1")
+
+
 def test_edge_job_request_returns_invalid_no_job_and_match(monkeypatch):
     dispatcher = EdgeTaskDispatcher()
     monkeypatch.setattr(dispatcher.logger, "error", MagicMock())

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -94,17 +94,31 @@ def _make_workspace_save_inputs(run_dir, result_root, log_root, audit_root):
 # ---------------------------------------------------------------------------
 
 
+def test_fire_job_lifecycle_event_includes_job_id():
+    runner = JobRunner(workspace_root="/tmp")
+    runner.fire_event_with_data = MagicMock()
+    fl_ctx = MagicMock()
+
+    runner._fire_job_lifecycle_event(EventType.JOB_STARTED, "job-1", fl_ctx)
+
+    runner.fire_event_with_data.assert_called_once_with(
+        EventType.JOB_STARTED, fl_ctx, FLContextKey.EVENT_DATA, {JobMetaKey.JOB_ID.value: "job-1"}
+    )
+
+
 @patch("nvflare.private.fed.server.job_runner.check_client_replies")
 @patch("nvflare.private.fed.server.job_runner.ConfigService.get_bool_var", return_value=False)
 def test_start_run_passes_strict_false_when_flag_disabled(mock_get_bool, mock_check_replies):
     mock_check_replies.return_value = []  # no timeouts
     runner, fl_ctx, _engine, job, client_sites = _make_runner_inputs()
+    runner._fire_job_lifecycle_event = MagicMock()
 
     runner._start_run(job_id=job.job_id, job=job, client_sites=client_sites, fl_ctx=fl_ctx)
 
     mock_get_bool.assert_called_once()
     mock_check_replies.assert_called_once()
     assert mock_check_replies.call_args.kwargs["strict"] is False
+    runner._fire_job_lifecycle_event.assert_called_once_with(EventType.JOB_STARTED, "job-1", fl_ctx)
 
 
 @patch("nvflare.private.fed.server.job_runner.check_client_replies")
@@ -486,7 +500,7 @@ def test_job_complete_process_publishes_status_after_persistent_cleanup_failure(
 
 def test_job_complete_process_saves_workspace_before_publishing_aborted_status():
     runner = JobRunner(workspace_root="/tmp")
-    runner.fire_event = MagicMock()
+    runner._fire_job_lifecycle_event = MagicMock()
     runner.log_debug = MagicMock()
     runner._save_workspace = MagicMock()
     runner.ask_to_stop = False
@@ -509,7 +523,7 @@ def test_job_complete_process_saves_workspace_before_publishing_aborted_status()
     parent = MagicMock()
     parent.attach_mock(runner._save_workspace, "save_workspace")
     parent.attach_mock(job_manager.set_status, "set_status")
-    parent.attach_mock(runner.fire_event, "fire_event")
+    parent.attach_mock(runner._fire_job_lifecycle_event, "fire_job_lifecycle_event")
 
     def _stop_after_first_pass(_):
         runner.ask_to_stop = True
@@ -521,8 +535,8 @@ def test_job_complete_process_saves_workspace_before_publishing_aborted_status()
     assert parent.mock_calls == [
         call.save_workspace(completion_ctx, ANY),
         call.set_status("job-1", RunStatus.FINISHED_ABORTED, completion_ctx),
-        call.fire_event(EventType.JOB_ABORTED, completion_ctx),
-        call.fire_event(EventType.JOB_COMPLETED, completion_ctx),
+        call.fire_job_lifecycle_event(EventType.JOB_ABORTED, "job-1", completion_ctx),
+        call.fire_job_lifecycle_event(EventType.JOB_COMPLETED, "job-1", completion_ctx),
     ]
     engine.remove_exception_process.assert_called_once_with("job-1")
     assert "job-1" not in runner.running_jobs

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -533,7 +533,7 @@ def test_job_complete_process_saves_workspace_before_publishing_aborted_status()
 
     completion_ctx.set_prop.assert_called_once_with(FLContextKey.CURRENT_JOB_ID, "job-1")
     assert parent.mock_calls == [
-        call.save_workspace(completion_ctx, ANY),
+        call.save_workspace(completion_ctx, ANY, "job-1"),
         call.set_status("job-1", RunStatus.FINISHED_ABORTED, completion_ctx),
         call.fire_job_lifecycle_event(EventType.JOB_ABORTED, "job-1", completion_ctx),
         call.fire_job_lifecycle_event(EventType.JOB_COMPLETED, "job-1", completion_ctx),
@@ -880,7 +880,7 @@ def test_job_complete_process_fires_job_aborted_for_aborted_launcher_return_code
     with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
-    runner._save_workspace.assert_called_once_with(completion_ctx, ANY)
+    runner._save_workspace.assert_called_once_with(completion_ctx, ANY, "job-1")
     job_manager.set_status.assert_called_once_with("job-1", RunStatus.FINISHED_ABORTED, completion_ctx)
     assert runner.fire_event.call_args_list == [
         call(EventType.JOB_ABORTED, completion_ctx),
@@ -964,7 +964,7 @@ def test_job_complete_process_keeps_processing_jobs_when_save_workspace_fails():
     with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
-    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY), call(second_ctx, ANY)]
+    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY, "job-1"), call(second_ctx, ANY, "job-2")]
     runner.log_exception.assert_called_once()
     job_manager.set_status.assert_called_once_with("job-2", RunStatus.FINISHED_ABORTED, second_ctx)
     assert runner.fire_event.call_args_list == [
@@ -1019,7 +1019,7 @@ def test_job_complete_process_retries_save_without_recomputing_finished_status()
     with _patch_job_runner_sleep(_stop_after_second_pass):
         runner._job_complete_process(engine)
 
-    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY), call(second_ctx, ANY)]
+    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY, "job-1"), call(second_ctx, ANY, "job-1")]
     runner.abort_client_run.assert_called_once_with("job-1", [], first_ctx)
     runner.log_exception.assert_called_once()
     job_manager.set_status.assert_called_once_with("job-1", RunStatus.FINISHED_ABORTED, second_ctx)
@@ -1079,7 +1079,7 @@ def test_job_complete_process_publishes_terminal_status_after_workspace_save_gra
     ):
         runner._job_complete_process(engine)
 
-    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY), call(second_ctx, ANY)]
+    assert runner._save_workspace.call_args_list == [call(first_ctx, ANY, "job-1"), call(second_ctx, ANY, "job-1")]
     runner.abort_client_run.assert_called_once_with("job-1", [], first_ctx)
     runner.log_exception.assert_called_once()
     runner.log_error.assert_called_once()
@@ -1126,7 +1126,7 @@ def test_job_complete_process_retries_status_publish_without_resaving_workspace(
     with _patch_job_runner_sleep(_stop_after_second_pass):
         runner._job_complete_process(engine)
 
-    runner._save_workspace.assert_called_once_with(first_ctx, ANY)
+    runner._save_workspace.assert_called_once_with(first_ctx, ANY, "job-1")
     assert job_manager.set_status.call_args_list == [
         call("job-1", RunStatus.FINISHED_ABORTED, first_ctx),
         call("job-1", RunStatus.FINISHED_ABORTED, second_ctx),

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -19,8 +19,11 @@ import pytest
 
 from nvflare.apis.event_type import EventType
 from nvflare.apis.fl_constant import FLContextKey, RunProcessKey
+from nvflare.apis.fl_context import FLContextManager
 from nvflare.apis.job_def import JobMetaKey, RunStatus
 from nvflare.apis.job_launcher_spec import JobReturnCode
+from nvflare.apis.utils.event import fire_event_to_components
+from nvflare.app_common.job_schedulers.job_scheduler import DefaultJobScheduler
 from nvflare.fuel.common.exit_codes import ProcessExitCode
 from nvflare.private.admin_defs import Message, MsgHeader, ReturnCode
 from nvflare.private.fed.server.job_runner import JobRunner, _FinishedJobState
@@ -104,6 +107,25 @@ def test_fire_job_lifecycle_event_includes_job_id():
     runner.fire_event_with_data.assert_called_once_with(
         EventType.JOB_STARTED, fl_ctx, FLContextKey.EVENT_DATA, {JobMetaKey.JOB_ID.value: "job-1"}
     )
+
+
+def test_lifecycle_event_delivers_explicit_job_id_to_scheduler():
+    scheduler = DefaultJobScheduler(max_jobs=5)
+    runner = JobRunner(workspace_root="/tmp")
+
+    engine = MagicMock()
+    engine.fire_event.side_effect = lambda event_type, ctx: fire_event_to_components(event_type, [scheduler], ctx)
+    fl_ctx = FLContextManager(engine=engine).new_context()
+    fl_ctx.set_prop(FLContextKey.CURRENT_JOB_ID, "wrong-job")  # racy sticky value
+
+    runner._fire_job_lifecycle_event(EventType.JOB_STARTED, "job-1", fl_ctx)
+
+    assert scheduler.scheduled_jobs == ["job-1"]
+    assert fl_ctx.get_prop(FLContextKey.EVENT_DATA) is None  # cleaned up after the fire
+
+    runner._fire_job_lifecycle_event(EventType.JOB_COMPLETED, "job-1", fl_ctx)
+
+    assert scheduler.scheduled_jobs == []
 
 
 @patch("nvflare.private.fed.server.job_runner.check_client_replies")
@@ -392,6 +414,25 @@ def test_save_workspace_retries_remaining_cleanup_after_earlier_source_was_remov
     )
     assert not run_dir.exists()
     assert not result_root.exists()
+
+
+def test_save_workspace_uses_explicit_job_id_over_sticky_context_id(tmp_path):
+    job_a_dir = tmp_path / "job-A"
+    job_a_dir.mkdir()
+    job_b_dir = tmp_path / "job-B"
+    job_b_dir.mkdir()
+
+    runner, fl_ctx, job_manager = _make_workspace_save_inputs("", "", "", "")
+    fl_ctx.get_prop.return_value = "job-B"  # racy sticky CURRENT_JOB_ID points at another job
+    workspace = fl_ctx.get_workspace.return_value
+    for getter in (workspace.get_run_dir, workspace.get_result_root, workspace.get_log_root, workspace.get_audit_root):
+        getter.side_effect = lambda job_id: str(tmp_path / job_id)
+
+    runner._save_workspace(fl_ctx, job_id="job-A")
+
+    job_manager.save_workspace.assert_called_once_with("job-A", [str(job_a_dir)], fl_ctx)
+    assert not job_a_dir.exists()
+    assert job_b_dir.exists()
 
 
 def test_job_complete_process_retries_cleanup_without_resaving_workspace(tmp_path):


### PR DESCRIPTION
## Summary

- publish the originating job ID as non-sticky data on server job lifecycle events
- make `DefaultJobScheduler` prefer the explicit event job ID while preserving the existing sticky-ID fallback
- add regression coverage for sticky context changes and start/completion/abort publication

## Problem

Concurrent job launch and completion processing can replace the sticky `CURRENT_JOB_ID` before a lifecycle event handler reads it. The scheduler can then account a start, completion, or abort against the wrong job, leaving stale entries in `scheduled_jobs`. Once those entries reach `max_jobs`, valid admissions can be blocked even though execution capacity is available.

## Validation

- `72 passed` in the focused scheduler and JobRunner unit-test suites
- Black, isort, and Flake8 passed for all four changed files
- `git diff --check` passed
- a 100-job, one-server/two-client validation with `max_jobs=20` completed all jobs successfully, with each job scheduled exactly once and no stale-accounting serial tail

Fixes #5215
