### PR TITLE
Handle configure job log with no connected clients

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -397,10 +397,10 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             message = new_message(conn, topic=TrainingTopic.CONFIGURE_JOB_LOG, body=config, require_authz=False)
             message.set_header(RequestHeader.JOB_ID, str(job_id))
             replies = self.send_request_to_clients(conn, message)
-            self.process_replies_to_table(conn, replies)
+            client_replies = replies or []
+            self.process_replies_to_table(conn, client_replies)
 
             client_errors = []
-            client_replies = replies or []
             received_tokens = {client_reply.client_token for client_reply in client_replies}
             expected_clients = conn.get_prop(self.TARGET_CLIENTS, {}) or {}
             for client_token, client_name in expected_clients.items():

--- a/tests/unit_test/private/fed/server/job_cmds_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_test.py
@@ -1713,6 +1713,26 @@ def test_configure_job_log_all_targets_server_and_clients(tmp_path, monkeypatch)
     assert not conn.meta
 
 
+def test_configure_job_log_all_handles_no_connected_clients(tmp_path, monkeypatch):
+    monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)
+    workspace = _FakeWorkspace(tmp_path)
+    engine = _FakeServerEngine(workspace)
+    engine.job_def_manager.get_job.return_value = _FakeListedJob({JobMetaKey.STATUS.value: RunStatus.RUNNING.value})
+    conn = _MockConnection(
+        app_ctx=engine,
+        props={JobCommandModule.TARGET_CLIENT_TOKENS: [], JobCommandModule.TARGET_CLIENTS: {}},
+    )
+
+    JobCommandModule().configure_job_log(conn, ["configure_job_log", "job-1", "all", "DEBUG"])
+
+    engine.configure_job_log.assert_called_once_with("job-1", "DEBUG")
+    assert ("no responses from clients", None) in conn.strings
+    assert len(conn.tables) == 1
+    assert conn.tables[0].rows == []
+    assert not conn.errors
+    assert not conn.meta
+
+
 def test_configure_job_log_specific_client_target_is_honored(tmp_path, monkeypatch):
     monkeypatch.setattr(cmd_utils_module, "ServerEngineSpec", object)
     monkeypatch.setattr(job_cmds_module, "ServerEngine", _FakeServerEngine)


### PR DESCRIPTION
## Summary
- normalize a missing client reply collection before rendering the `configure_job_log` response
- preserve successful server log configuration and the existing no-response output when `all` has no connected clients
- add regression coverage for the zero-connected-client edge case

This is the non-blocking follow-up identified after #5205.

## Validation
- `python3 -m pytest tests/unit_test/private/fed/server/job_cmds_test.py -q` (99 passed)
- `./runtest.sh -s`