### PR TITLE
[2.7] Handle configure job log with no connected clients

### DIFF
--- a/nvflare/private/fed/server/job_cmds.py
+++ b/nvflare/private/fed/server/job_cmds.py
@@ -306,10 +306,10 @@ class JobCommandModule(CommandModule, CommandUtil, BinaryTransfer):
             message = new_message(conn, topic=TrainingTopic.CONFIGURE_JOB_LOG, body=config, require_authz=False)
             message.set_header(RequestHeader.JOB_ID, str(job_id))
             replies = self.send_request_to_clients(conn, message)
-            self.process_replies_to_table(conn, replies)
+            client_replies = replies or []
+            self.process_replies_to_table(conn, client_replies)
 
             client_errors = []
-            client_replies = replies or []
             received_tokens = {client_reply.client_token for client_reply in client_replies}
             expected_clients = conn.get_prop(self.TARGET_CLIENTS, {}) or {}
             for client_token, client_name in expected_clients.items():

--- a/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
+++ b/tests/unit_test/private/fed/server/job_cmds_configure_log_test.py
@@ -131,7 +131,7 @@ def test_configure_job_log_success_does_not_set_error_meta(monkeypatch):
 
 
 def test_configure_job_log_all_with_no_clients_remains_successful(monkeypatch):
-    conn, engine = _run_client_config(monkeypatch, [], target_type="all")
+    conn, engine = _run_client_config(monkeypatch, None, target_type="all")
 
     engine.configure_job_log.assert_called_once_with("job-1", "DEBUG")
     assert MetaKey.STATUS not in conn.buffer.meta


### PR DESCRIPTION
## Summary
- backport #5217 to the 2.7 release branch
- normalize a missing client reply collection before rendering the `configure_job_log` response
- preserve successful server log configuration and the existing no-response output when `all` has no connected clients
- tighten the branch-specific regression to exercise the actual `None` reply collection

## Validation
- `python3 -m pytest tests/unit_test/private/fed/server/job_cmds_configure_log_test.py -q` (7 passed)
- `./runtest.sh -s`