### PR TITLE
Finalize failed jobs with missing client outcomes

### DIFF
--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -437,8 +437,18 @@ class JobRunner(FLComponent):
                 if job_id not in engine.run_processes.keys():
                     job = self.running_jobs.get(job_id)
                     if job:
+                        with engine.lock:
+                            exception_process = engine.exception_run_processes.get(job_id)
+                        server_failed = (
+                            exception_process is not None
+                            and exception_process.get(RunProcessKey.PROCESS_RETURN_CODE) != JobReturnCode.ABORTED
+                        )
                         with self.lock:
                             pending = self._pending_client_outcomes.get(job_id)
+                            if server_failed:
+                                if pending:
+                                    pending.clear()
+                                self._client_outcome_deadlines.pop(job_id, None)
                             if pending and not job.run_aborted:
                                 now = time.monotonic()
                                 deadline = self._client_outcome_deadlines.setdefault(

--- a/nvflare/private/fed/server/job_runner.py
+++ b/nvflare/private/fed/server/job_runner.py
@@ -439,16 +439,22 @@ class JobRunner(FLComponent):
                     if job:
                         with engine.lock:
                             exception_process = engine.exception_run_processes.get(job_id)
-                        server_failed = (
-                            exception_process is not None
-                            and exception_process.get(RunProcessKey.PROCESS_RETURN_CODE) != JobReturnCode.ABORTED
+                            server_status = self._classify_finished_job_status(exception_process)
+                        server_failed = server_status in (
+                            RunStatus.FINISHED_EXECUTION_EXCEPTION,
+                            RunStatus.FINISHED_ABNORMAL,
                         )
                         with self.lock:
                             pending = self._pending_client_outcomes.get(job_id)
                             if server_failed:
                                 if pending:
-                                    pending.clear()
+                                    self.logger.info(
+                                        f"Server failure for job ({job_id}); "
+                                        f"skipping client outcome wait for: {sorted(pending)}"
+                                    )
+                                self._pending_client_outcomes.pop(job_id, None)
                                 self._client_outcome_deadlines.pop(job_id, None)
+                                pending = None
                             if pending and not job.run_aborted:
                                 now = time.monotonic()
                                 deadline = self._client_outcome_deadlines.setdefault(
@@ -526,11 +532,41 @@ class JobRunner(FLComponent):
                     engine.remove_exception_process(job_id)
             time.sleep(1.0)
 
+    @staticmethod
+    def _classify_finished_job_status(run_process):
+        if run_process is None:
+            return RunStatus.FINISHED_COMPLETED
+
+        finished = run_process.get(RunProcessKey.PROCESS_FINISHED, False)
+        process_return_code = run_process.get(RunProcessKey.PROCESS_RETURN_CODE)
+        if process_return_code == ProcessExitCode.INFRASTRUCTURE_ERROR:
+            return RunStatus.FINISHED_ABNORMAL
+        if process_return_code == JobReturnCode.ABORTED:
+            return RunStatus.FINISHED_ABORTED
+        if process_return_code in (
+            ProcessExitCode.CONFIG_ERROR,
+            ProcessExitCode.EXCEPTION,
+            ProcessExitCode.UNSAFE_COMPONENT,
+            JobReturnCode.EXECUTION_ERROR,
+        ):
+            # An external failure (e.g. launcher resource timeout) marked
+            # the run as exception. Preserve that even if the SJ later
+            # reported a clean shutdown via UPDATE_RUN_STATUS.
+            return RunStatus.FINISHED_EXECUTION_EXCEPTION
+        if finished:
+            # job status is already reported from the Job cell!
+            if run_process.get(RunProcessKey.PROCESS_EXE_ERROR, False):
+                return RunStatus.FINISHED_EXECUTION_EXCEPTION
+            return RunStatus.FINISHED_COMPLETED
+        # never got job status report from job cell
+        if process_return_code == -9:
+            return RunStatus.FINISHED_ABNORMAL
+        return RunStatus.FINISHED_EXECUTION_EXCEPTION
+
     def _get_finished_job_status(self, engine, job, fl_ctx):
-        exception_run_processes = engine.exception_run_processes
-        if job.job_id in exception_run_processes:
+        run_process = engine.exception_run_processes.get(job.job_id)
+        if run_process is not None:
             self.log_info(fl_ctx, f"Try to abort job ({job.job_id}) on clients ...")
-            run_process = exception_run_processes[job.job_id]
 
             # stop client run
             participants: Dict[str, Client] = run_process.get(RunProcessKey.PARTICIPANTS)
@@ -538,39 +574,7 @@ class JobRunner(FLComponent):
                 connected_clients=engine.client_manager.clients, participants=participants
             )
             self.abort_client_run(job.job_id, active_client_sites_names, fl_ctx)
-
-            finished = run_process.get(RunProcessKey.PROCESS_FINISHED, False)
-            process_return_code = run_process.get(RunProcessKey.PROCESS_RETURN_CODE)
-            if process_return_code == ProcessExitCode.INFRASTRUCTURE_ERROR:
-                status = RunStatus.FINISHED_ABNORMAL
-            elif process_return_code == JobReturnCode.ABORTED:
-                status = RunStatus.FINISHED_ABORTED
-            elif process_return_code in (
-                ProcessExitCode.CONFIG_ERROR,
-                ProcessExitCode.EXCEPTION,
-                ProcessExitCode.UNSAFE_COMPONENT,
-                JobReturnCode.EXECUTION_ERROR,
-            ):
-                # An external failure (e.g. launcher resource timeout) marked
-                # the run as exception. Preserve that even if the SJ later
-                # reported a clean shutdown via UPDATE_RUN_STATUS.
-                status = RunStatus.FINISHED_EXECUTION_EXCEPTION
-            elif finished:
-                # job status is already reported from the Job cell!
-                exe_err = run_process.get(RunProcessKey.PROCESS_EXE_ERROR, False)
-                if exe_err:
-                    status = RunStatus.FINISHED_EXECUTION_EXCEPTION
-                else:
-                    status = RunStatus.FINISHED_COMPLETED
-            else:
-                # never got job status report from job cell
-                if process_return_code == -9:
-                    status = RunStatus.FINISHED_ABNORMAL
-                else:
-                    status = RunStatus.FINISHED_EXECUTION_EXCEPTION
-        else:
-            status = RunStatus.FINISHED_COMPLETED
-        return status
+        return self._classify_finished_job_status(run_process)
 
     def _save_workspace(self, fl_ctx: FLContext, finished_state: _FinishedJobState | None = None):
         job_id = fl_ctx.get_prop(FLContextKey.CURRENT_JOB_ID)
@@ -797,25 +801,32 @@ class JobRunner(FLComponent):
 
     def fail_run(self, job_id: str, process_return_code: int, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
-        with engine.lock:
-            # Keep this synchronized with ServerEngine.wait_for_complete(), which
-            # may record the SJ's own exit code at the same time.
-            run_process = engine.exception_run_processes.get(job_id)
-            if run_process is None:
-                run_process = engine.run_processes.get(job_id)
-            if run_process is None:
-                run_process = {RunProcessKey.PARTICIPANTS: {}}
-            existing_code = run_process.get(RunProcessKey.PROCESS_RETURN_CODE)
-            if existing_code != ProcessExitCode.INFRASTRUCTURE_ERROR and (
-                existing_code is None or process_return_code != JobReturnCode.ABORTED
-            ):
-                run_process[RunProcessKey.PROCESS_RETURN_CODE] = process_return_code
-            engine.exception_run_processes[job_id] = run_process
-        # fail_run establishes an authoritative terminal failure. Remaining
-        # client reports cannot change that status and must not hold terminal
-        # publication behind the normal outcome grace period (900 seconds by
-        # default); _stop_run below drives their cleanup independently.
         with self.lock:
+            with engine.lock:
+                if job_id not in self.running_jobs and job_id not in engine.run_processes:
+                    job_is_active = False
+                else:
+                    job_is_active = True
+                    # Keep this synchronized with ServerEngine.wait_for_complete(), which
+                    # may record the SJ's own exit code at the same time.
+                    run_process = engine.exception_run_processes.get(job_id)
+                    if run_process is None:
+                        run_process = engine.run_processes.get(job_id)
+                    if run_process is None:
+                        run_process = {RunProcessKey.PARTICIPANTS: {}}
+                    existing_code = run_process.get(RunProcessKey.PROCESS_RETURN_CODE)
+                    if existing_code != ProcessExitCode.INFRASTRUCTURE_ERROR and (
+                        existing_code is None or process_return_code != JobReturnCode.ABORTED
+                    ):
+                        run_process[RunProcessKey.PROCESS_RETURN_CODE] = process_return_code
+                    engine.exception_run_processes[job_id] = run_process
+            if not job_is_active:
+                self.log_info(fl_ctx, f"Job {job_id} is not running. It can not be failed.")
+                return f"Job {job_id} is not running."
+            # fail_run establishes an authoritative terminal failure. Remaining
+            # client reports cannot change that status and must not hold terminal
+            # publication behind the normal outcome grace period (900 seconds by
+            # default); _stop_run below drives their cleanup independently.
             self._pending_client_outcomes.pop(job_id, None)
             self._client_outcome_deadlines.pop(job_id, None)
         self._stop_run(job_id, fl_ctx)

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -928,7 +928,7 @@ def test_job_complete_process_releases_client_outcome_barrier_after_server_failu
     with _patch_job_runner_sleep(_stop_after_first_pass):
         runner._job_complete_process(engine)
 
-    runner._save_workspace.assert_called_once_with(completion_ctx, ANY)
+    runner._save_workspace.assert_called_once_with(completion_ctx, ANY, "job-1")
     job_manager.set_status.assert_called_once_with("job-1", RunStatus.FINISHED_EXECUTION_EXCEPTION, completion_ctx)
     runner.fire_event.assert_called_once_with(EventType.JOB_COMPLETED, completion_ctx)
     engine.remove_exception_process.assert_called_once_with("job-1")

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -823,6 +823,51 @@ def test_fail_run_releases_client_outcome_barrier():
     runner._stop_run.assert_called_once_with("job-1", fl_ctx)
 
 
+def test_job_complete_process_releases_client_outcome_barrier_after_server_failure():
+    runner = JobRunner(workspace_root="/tmp")
+    runner.fire_event = MagicMock()
+    runner.log_debug = MagicMock()
+    runner.log_info = MagicMock()
+    runner.abort_client_run = MagicMock()
+    runner._save_workspace = MagicMock()
+    runner.ask_to_stop = False
+
+    engine = MagicMock()
+    engine.run_processes = {}
+    engine.client_manager.clients = {}
+    engine.exception_run_processes = {
+        "job-1": {
+            RunProcessKey.PARTICIPANTS: {},
+            RunProcessKey.PROCESS_RETURN_CODE: ProcessExitCode.EXCEPTION,
+        }
+    }
+
+    job_manager = MagicMock()
+    engine.get_component.return_value = job_manager
+
+    completion_ctx = MagicMock()
+    engine.new_context.return_value = nullcontext(completion_ctx)
+
+    job = MagicMock(job_id="job-1", run_aborted=False)
+    runner.running_jobs = {"job-1": job}
+    runner._pending_client_outcomes = {"job-1": {"site-1"}}
+    runner._client_outcome_deadlines = {"job-1": 123.0}
+
+    def _stop_after_first_pass(_):
+        runner.ask_to_stop = True
+
+    with _patch_job_runner_sleep(_stop_after_first_pass):
+        runner._job_complete_process(engine)
+
+    runner._save_workspace.assert_called_once_with(completion_ctx, ANY)
+    job_manager.set_status.assert_called_once_with("job-1", RunStatus.FINISHED_EXECUTION_EXCEPTION, completion_ctx)
+    runner.fire_event.assert_called_once_with(EventType.JOB_COMPLETED, completion_ctx)
+    engine.remove_exception_process.assert_called_once_with("job-1")
+    assert "job-1" not in runner.running_jobs
+    assert "job-1" not in runner._pending_client_outcomes
+    assert "job-1" not in runner._client_outcome_deadlines
+
+
 def test_job_complete_process_fires_job_aborted_for_aborted_launcher_return_code():
     runner = JobRunner(workspace_root="/tmp")
     runner.fire_event = MagicMock()

--- a/tests/unit_test/private/fed/server/job_runner_test.py
+++ b/tests/unit_test/private/fed/server/job_runner_test.py
@@ -778,13 +778,15 @@ def test_mark_run_aborted_logs_info_when_job_not_running():
     runner.log_info.assert_called_once_with(fl_ctx, "Job job-1 is not running. It can not be stopped.")
 
 
-def test_fail_run_logs_info_when_job_not_running():
+def test_fail_run_ignores_job_already_finalized():
     runner = JobRunner(workspace_root="/tmp")
     runner.log_info = MagicMock()
     runner._stop_run = MagicMock()
 
     engine = MagicMock()
     engine.lock = MagicMock()
+    engine.run_processes = {}
+    engine.exception_run_processes = {}
     fl_ctx = MagicMock()
     fl_ctx.get_engine.return_value = engine
     runner.running_jobs = {}
@@ -793,7 +795,8 @@ def test_fail_run_logs_info_when_job_not_running():
 
     assert msg == "Job job-1 is not running."
     runner.log_info.assert_called_once_with(fl_ctx, "Job job-1 is not running. It can not be failed.")
-    runner._stop_run.assert_called_once_with("job-1", fl_ctx)
+    runner._stop_run.assert_not_called()
+    assert "job-1" not in engine.exception_run_processes
 
 
 def test_fail_run_releases_client_outcome_barrier():
@@ -823,8 +826,24 @@ def test_fail_run_releases_client_outcome_barrier():
     runner._stop_run.assert_called_once_with("job-1", fl_ctx)
 
 
-def test_job_complete_process_releases_client_outcome_barrier_after_server_failure():
+@pytest.mark.parametrize(
+    "failure_process",
+    [
+        {
+            RunProcessKey.PARTICIPANTS: {},
+            RunProcessKey.PROCESS_RETURN_CODE: ProcessExitCode.EXCEPTION,
+        },
+        {
+            RunProcessKey.PARTICIPANTS: {},
+            RunProcessKey.PROCESS_FINISHED: True,
+            RunProcessKey.PROCESS_EXE_ERROR: True,
+        },
+    ],
+    ids=["failure-return-code", "execution-error-without-return-code"],
+)
+def test_job_complete_process_releases_client_outcome_barrier_after_server_failure(failure_process):
     runner = JobRunner(workspace_root="/tmp")
+    runner.logger = MagicMock()
     runner.fire_event = MagicMock()
     runner.log_debug = MagicMock()
     runner.log_info = MagicMock()
@@ -835,12 +854,7 @@ def test_job_complete_process_releases_client_outcome_barrier_after_server_failu
     engine = MagicMock()
     engine.run_processes = {}
     engine.client_manager.clients = {}
-    engine.exception_run_processes = {
-        "job-1": {
-            RunProcessKey.PARTICIPANTS: {},
-            RunProcessKey.PROCESS_RETURN_CODE: ProcessExitCode.EXCEPTION,
-        }
-    }
+    engine.exception_run_processes = {"job-1": failure_process}
 
     job_manager = MagicMock()
     engine.get_component.return_value = job_manager
@@ -866,6 +880,38 @@ def test_job_complete_process_releases_client_outcome_barrier_after_server_failu
     assert "job-1" not in runner.running_jobs
     assert "job-1" not in runner._pending_client_outcomes
     assert "job-1" not in runner._client_outcome_deadlines
+    runner.logger.info.assert_called_once_with(
+        "Server failure for job (job-1); skipping client outcome wait for: ['site-1']"
+    )
+
+
+def test_job_complete_process_keeps_client_outcome_barrier_for_clean_unknown_return_code():
+    runner = JobRunner(workspace_root="/tmp")
+    runner.ask_to_stop = False
+
+    engine = MagicMock()
+    engine.run_processes = {}
+    engine.exception_run_processes = {
+        "job-1": {
+            RunProcessKey.PROCESS_RETURN_CODE: JobReturnCode.UNKNOWN,
+            RunProcessKey.PROCESS_FINISHED: True,
+            RunProcessKey.PROCESS_EXE_ERROR: False,
+        }
+    }
+    job_manager = MagicMock()
+    engine.get_component.return_value = job_manager
+
+    runner.running_jobs = {"job-1": MagicMock(job_id="job-1", run_aborted=False)}
+    runner._pending_client_outcomes = {"job-1": {"site-1"}}
+
+    def _stop_after_first_pass(_):
+        runner.ask_to_stop = True
+
+    with _patch_job_runner_sleep(_stop_after_first_pass):
+        runner._job_complete_process(engine)
+
+    job_manager.set_status.assert_not_called()
+    assert runner._pending_client_outcomes["job-1"] == {"site-1"}
 
 
 def test_job_complete_process_fires_job_aborted_for_aborted_launcher_return_code():


### PR DESCRIPTION
## Summary

- release pending client outcomes when a stopped server job already has an authoritative non-`ABORTED` failure
- preserve the existing outcome barrier for normal completion and launcher `ABORTED` precedence
- add focused regression coverage for a server execution failure with a pending client outcome

## Root cause

The completion loop checked the pending-client outcome barrier before evaluating an already-recorded server-process failure. A client that became unreachable could therefore keep a known failed job in `RUNNING` until the normal outcome or heartbeat timeout expired.

## Validation

- `176 passed` across focused server/client lifecycle tests
- `./runtest.sh -s`
- `git diff --check`

Fixes #5220.
