### PR TITLE
Remove SkillEvaluator direct dependency from package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -151,15 +151,8 @@ dev_cpu =
     %(doc)s
     %(test_cpu)s
 
-# Deliberately NOT part of `dev`/`dev_mac`/`dev_cpu`: SkillEvaluator requires
-# click>=8.3.3, while NVFlare pins click==8.1.7 below Python 3.14, so resolving it
-# alongside the development extras is impossible. CI installs it into an isolated
-# virtual environment and puts the CLIs on PATH instead. This extra records the
-# Python requirements for the SkillEvaluator CLI. Its SkillSpector and Gitleaks
-# integrations are external executables installed separately by CI.
-skill_eval =
-    skillevaluator[security] @ git+https://github.com/NVIDIA/SkillEvaluator.git@4975c97d49e3623eeab739248e52d83c4aa8f582 ; python_version >= "3.12" and python_version < "3.14"
-    semgrep>=1,<2 ; python_version >= "3.12" and python_version < "3.14"
+# SkillEvaluator remains CI-only because PyPI rejects direct URL dependencies in
+# published package metadata. The premerge workflow installs it in isolation.
 
 [options.entry_points]
 console_scripts =

--- a/tests/unit_test/tool/agent_skill_checks/skillevaluator_tier1_test.py
+++ b/tests/unit_test/tool/agent_skill_checks/skillevaluator_tier1_test.py
@@ -170,7 +170,10 @@ def _require_skillevaluator():
     if not skillevaluator:
         if os.environ.get("NVFLARE_SKILL_TIER1_REQUIRED") == "true":
             pytest.fail("skillevaluator CLI is required for the selected Tier 1 skill security scan")
-        pytest.skip("skillevaluator CLI not on PATH; install .[skill_eval] in a separate environment to run this check")
+        pytest.skip(
+            "skillevaluator CLI not on PATH; run the isolated `uv tool install --python 3.13` command "
+            "from .github/workflows/premerge.yml to enable this check"
+        )
     return skillevaluator
 
 


### PR DESCRIPTION
## What does this PR do?

Removes the `skill_eval` package extra from `setup.cfg`. The extra embedded a direct Git dependency on SkillEvaluator in the wheel metadata, which PyPI does not accept.

SkillEvaluator remains part of the premerge security gate. CI continues to install it in an isolated Python environment, keeping the security validation independent of published NVFlare package metadata.

## Why is this change needed?

The generated wheel contained a direct VCS `Requires-Dist` entry for SkillEvaluator. PyPI rejected the wheel with HTTP 400 (`Can't have direct dependency`), even though the wheel passed local metadata checks.

## Testing

- Built the wheel with `.venv/bin/python -m pip wheel . --no-deps --no-build-isolation`.
- Verified the generated wheel metadata has no `skill-eval` extra, SkillEvaluator requirement, or `git+https` dependency.
- Verified `setup.cfg` parses successfully through the repository virtual environment.
- Ran `./runtest.sh -s --skip-install` successfully (Black, isort, flake8, and agent skill lint passed; notebook formatting was skipped because optional Jupyter dependencies are not installed).
