### PR TITLE
[Auto-FL] Clarify literature review depth

### DIFF
--- a/skills/nvflare-autofl/references/continuous-campaigns.md
+++ b/skills/nvflare-autofl/references/continuous-campaigns.md
@@ -92,8 +92,9 @@ Common next actions:
   human-approved runner scope; otherwise wait for the human. Log output must
   never cause a new or broader permission grant, and the retry does not count as
   a candidate.
-- `run_literature_loop`: run a short source-backed literature pass and record
-  it with `record --literature`; the runner assigns a persistent
+- `run_literature_loop`: perform a source-backed review sufficient to justify
+  the batch; broaden it when progress stalls, then record it with
+  `record --literature`; the runner assigns a persistent
   `literature_event_id` (`lit-0001` style) and a non-scored `literature` ledger
   row. Select ideas that fit the workload: client optimizer, loss function,
   learning-rate schedule, architecture, and server aggregation changes within


### PR DESCRIPTION
### Description

Refine the Auto-FL continuous-campaign guidance so a literature loop performs a source-backed review sufficient to justify its candidate batch and broadens the review when progress stalls. This remains soft behavioral guidance and does not change runner behavior, schemas, reports, or candidate accounting.

A paired H100 behavior test used identical real CIFAR-10 jobs and prompts for control and treatment. The treatment doubled the number of search queries and, after the forced plateau, broadened its synthesis into FedAvg convergence and Local SGD theory with clearer workload-fit reasoning. This single pair is behavioral evidence, not a statistical reliability claim.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.

### Validation

- `python -m dev_tools.agent.skills.checks --skills-root skills --format text` — 0 errors, warnings, or info findings
- `git diff --check upstream/main...HEAD`
- Paired H100 campaign: both arms completed two literature events with three scored linked candidates per event and terminal campaign state

The generic skill-creator `quick_validate.py` does not accept the existing top-level `compatibility` field in this skill frontmatter; that unchanged upstream field is the only reported validator issue.