### PR TITLE
Add Collaboration API and Agent Skills guides

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -146,6 +146,7 @@ New to FLARE (ML Practitioners)
 
 Start here if you want to federate an existing training script.
 
+- :doc:`Agent Skills <user_guide/agent_skills/index>` -- Use coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
 - :doc:`Welcome <welcome>` -- What FLARE is and what it supports
 - :doc:`Installation <installation>` -- Install FLARE and set up your environment
 - :doc:`Quick Start <quickstart>` -- Run a Hello World example and convert your ML code

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,11 +30,10 @@ NVIDIA FLARE
 
    Choose an API Path <user_guide/data_scientist_guide/api_selection>
    user_guide/data_scientist_guide/client_api_usage
-   HuggingFace Client API <user_guide/data_scientist_guide/hf_client_api>
+   Collaboration API (Technical Preview) <user_guide/data_scientist_guide/collab_api>
    user_guide/data_scientist_guide/job_recipe
    user_guide/data_scientist_guide/recipe_api
    user_guide/data_scientist_guide/available_recipes
-   Collaboration API (Technical Preview) <user_guide/data_scientist_guide/collab_api>
    user_guide/data_scientist_guide/flare_api
    user_guide/data_scientist_guide/flower_integration/flower_integration
    programming_guide/experiment_tracking

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -146,12 +146,12 @@ New to FLARE (ML Practitioners)
 
 Start here if you want to federate an existing training script.
 
-- :doc:`Agent Skills <user_guide/agent_skills/index>` -- Use coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
+- :doc:`Agent Skills <user_guide/agent_skills/index>` -- Optional coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
 - :doc:`Welcome <welcome>` -- What FLARE is and what it supports
 - :doc:`Installation <installation>` -- Install FLARE and set up your environment
 - :doc:`Quick Start <quickstart>` -- Run a Hello World example and convert your ML code
 - :ref:`Client API <client_api>` -- Recommended high-level API for federated training
-- :ref:`Collaboration API <collab_api>` -- Technical Preview: agent-to-agent style calls between server and clients
+- :ref:`Collaboration API (Technical Preview) <collab_api>` -- Agent-to-agent style calls between server and clients
 - :ref:`Job Recipe API <job_recipe>` -- Pre-built recipes for common FL workflows
 - :doc:`Migration Guide <migration_guide>` -- Upgrade between FLARE versions
 - :ref:`Examples & Tutorials <example_applications>` -- End-to-end examples and tutorials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ NVIDIA FLARE
    :hidden:
    :caption: User Guide
 
+   Agent Skills <user_guide/agent_skills/index>
    Choose an API Path <user_guide/data_scientist_guide/api_selection>
    user_guide/data_scientist_guide/client_api_usage
    Collaboration API (Technical Preview) <user_guide/data_scientist_guide/collab_api>
@@ -39,7 +40,6 @@ NVIDIA FLARE
    programming_guide/experiment_tracking
    Federated XGBoost <user_guide/data_scientist_guide/federated_xgboost/federated_xgboost>
    user_guide/data_scientist_guide/data_preparation
-   Agent Skills <user_guide/agent_skills/index>
    CLI Tools <user_guide/nvflare_cli/nvflare_cli>
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ Start here if you want to federate an existing training script.
 - :doc:`Installation <installation>` -- Install FLARE and set up your environment
 - :doc:`Quick Start <quickstart>` -- Run a Hello World example and convert your ML code
 - :ref:`Client API <client_api>` -- Recommended high-level API for federated training
+- :ref:`Collaboration API <collab_api>` -- Technical Preview: agent-to-agent style calls between server and clients
 - :ref:`Job Recipe API <job_recipe>` -- Pre-built recipes for common FL workflows
 - :doc:`Migration Guide <migration_guide>` -- Upgrade between FLARE versions
 - :ref:`Examples & Tutorials <example_applications>` -- End-to-end examples and tutorials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -146,10 +146,10 @@ New to FLARE (ML Practitioners)
 
 Start here if you want to federate an existing training script.
 
-- :doc:`Agent Skills <user_guide/agent_skills/index>` -- Optional coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
 - :doc:`Welcome <welcome>` -- What FLARE is and what it supports
 - :doc:`Installation <installation>` -- Install FLARE and set up your environment
 - :doc:`Quick Start <quickstart>` -- Run a Hello World example and convert your ML code
+- :doc:`Agent Skills <user_guide/agent_skills/index>` -- Optional coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
 - :ref:`Client API <client_api>` -- Recommended high-level API for federated training
 - :ref:`Collaboration API (Technical Preview) <collab_api>` -- Agent-to-agent style calls between server and clients
 - :ref:`Job Recipe API <job_recipe>` -- Pre-built recipes for common FL workflows

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,7 +151,7 @@ Start here if you want to federate an existing training script.
 - :doc:`Quick Start <quickstart>` -- Run a Hello World example and convert your ML code
 - :doc:`Agent Skills <user_guide/agent_skills/index>` -- Optional coding-agent workflows to learn NVFLARE, create federated jobs, optimize with AutoFL, and report results
 - :ref:`Client API <client_api>` -- Recommended high-level API for federated training
-- :ref:`Collaboration API (Technical Preview) <collab_api>` -- Agent-to-agent style calls between server and clients
+- :ref:`Collaboration API (Technical Preview) <collab_api>` -- Remote Python method calls between server and clients and among peer clients
 - :ref:`Job Recipe API <job_recipe>` -- Pre-built recipes for common FL workflows
 - :doc:`Migration Guide <migration_guide>` -- Upgrade between FLARE versions
 - :ref:`Examples & Tutorials <example_applications>` -- End-to-end examples and tutorials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ NVIDIA FLARE
    user_guide/data_scientist_guide/job_recipe
    user_guide/data_scientist_guide/recipe_api
    user_guide/data_scientist_guide/available_recipes
+   Collaboration API (Technical Preview) <user_guide/data_scientist_guide/collab_api>
    user_guide/data_scientist_guide/flare_api
    user_guide/data_scientist_guide/flower_integration/flower_integration
    programming_guide/experiment_tracking

--- a/docs/industry_use_cases.rst
+++ b/docs/industry_use_cases.rst
@@ -179,7 +179,7 @@ FLARE Day is an annual event showcasing real-world federated learning deployment
 healthcare, finance, autonomous driving, and more. These talks feature practitioners sharing
 production experiences and lessons learned.
 
-- **FLARE Day 2026** -- *Coming September 2026*
+- `FLARE Day 2026 <https://events.nvidia.com/flare-day-2026>`_ -- *Coming September 2026*
 - `FLARE Day 2025 <https://developer.nvidia.com/flare-day-2025>`_ -- Real-world FL applications in healthcare, finance, autonomous driving, and more
 - `FLARE Day 2024 <https://nvidia.github.io/NVFlare/flareDay>`_ -- Talks and demos featuring real-world FL deployments at NVIDIA, healthcare institutions, and industry partners
 

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -4,50 +4,53 @@
 Agent Conversion Skills
 #######################
 
-NVFLARE Agent Conversion Skills help a coding agent adapt an existing
-single-site training project into a reviewable, multi-site NVFLARE job. The
-agent inspects the project's existing training and evaluation code, chooses a
-compatible NVFLARE recipe, generates the integration files, and validates the
-result locally.
+NVFLARE Agent Conversion Skills help a coding agent create a reviewable,
+multi-site NVFLARE job from an existing single-site training project or a
+federated data-summary request. The agent inspects the source project or data,
+chooses a compatible NVFLARE recipe, generates the integration files, and
+validates the result locally.
 
 The skills are coding-agent workflows, not NVFLARE runtime commands or an
 automatic production migration service. You review and own the generated code
 and configuration.
 
-Supported Training Frameworks
-=============================
+Supported Workflows
+===================
 
-The conversion skills support three PyTorch-family training styles:
+You can use Agent Skills for four job-creation workflows:
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 50
+   :widths: 30 70
 
-   * - Starting project
-     - Skill
-     - Supported integration
-   * - Plain PyTorch
-     - ``nvflare-convert-pytorch``
-     - Manual training loops built with ``nn.Module``, optimizers,
-       ``DataLoader``, and ``state_dict`` exchange. The generated client uses
-       the NVFLARE Client API and preserves source-backed training and
-       evaluation behavior.
-   * - PyTorch Lightning
-     - ``nvflare-convert-lightning``
-     - A Lightning-owned workflow with ``LightningModule`` and ``Trainer``.
-       The generated client patches the existing ``Trainer`` and keeps
-       evaluation, metrics, callbacks, and checkpoint behavior in Lightning.
-   * - Hugging Face
-     - ``nvflare-convert-huggingface``
-     - ``Trainer``, ``Seq2SeqTrainer``, TRL ``SFTTrainer``, or a compatible
-       ``Trainer`` subclass. Full-model and PEFT/LoRA fine-tuning are
-       supported, including single-process and replicated distributed
-       training when the process rank is unambiguous.
+   * - Starting input
+     - What the skill creates
+   * - An existing plain PyTorch training project
+     - A multi-site NVFLARE training job that preserves the project's model,
+       local training loop, training budget, and evaluation behavior.
+   * - An existing PyTorch Lightning project
+     - A multi-site NVFLARE training job that retains the Lightning trainer,
+       validation metrics, callbacks, and checkpoint behavior.
+   * - An existing Hugging Face Trainer project
+     - A multi-site NVFLARE training job that retains the Trainer workflow,
+       datasets, metrics, callbacks, and checkpoints. Full-model and PEFT/LoRA
+       fine-tuning are supported.
+   * - Tabular or image data
+     - A federated statistics job and aggregate results. Tabular inputs include
+       CSV, Parquet, and other pandas-readable data. Image inputs include
+       common image folders and DICOM or NIfTI when the matching loader is
+       available. Existing statistics selections declared in a script or
+       README can also be preserved.
 
-All three skills target horizontal federated learning with the PyTorch recipe
-family. FedAvg is the standard conversion path when requested. Other
-PyTorch-family recipes are used only when the requested workflow is compatible
-with a recipe exposed by the installed NVFLARE version.
+The three model-training skills target horizontal federated learning with the
+PyTorch recipe family. FedAvg is the standard conversion path when requested.
+Other PyTorch-family recipes are used only when the requested workflow is
+compatible with a recipe exposed by the installed NVFLARE version.
+
+The federated statistics skill generates a separate ``FedStatsRecipe`` job. It
+supports count, sum, mean, standard deviation, variance, histogram, quantile,
+and noise-protected minimum and maximum for numeric tabular features. For image
+data, it supports image count, failure count, and pixel-intensity histograms.
 
 Install the Skills
 ==================
@@ -63,11 +66,13 @@ Generated jobs require NVFLARE 2.9.0 or later in the Python environment used
 by the coding agent. The skills are installed from the source tree; they are
 not installed by the NVFLARE Python package.
 
-Request a Conversion
-====================
+Request a Job
+=============
 
-Open the existing training project in the coding agent and describe the
-federated outcome. Include the source location, framework, algorithm when you
+Open the existing training project or data directory in the coding agent and
+describe the federated outcome.
+
+For model training, include the source location, framework, algorithm when you
 have a preference, client count, round count, local training budget, and
 whether to run a local simulation. For example:
 
@@ -77,13 +82,30 @@ whether to run a local simulation. For example:
    NVFLARE FedAvg job for 3 sites and 3 rounds. Preserve its validation metric
    and local training budget, and validate the result with a local simulation.
 
+For federated statistics, identify the per-site data or the flat source data,
+the site count when it cannot be inferred, and any required statistics. When
+no statistics are named, the skill reports and applies its supported defaults.
+For example:
+
+.. code-block:: text
+
+   Create an NVFLARE federated statistics job for the per-site CSV files under
+   ./data. Compute count, mean, standard deviation, histogram, and median for
+   the numeric features, and validate the job with a local simulation.
+
 You do not need to name a skill. The agent selects a converter only when the
 request expresses federated or cross-site collaborative training intent and
 the source has one supported training owner. A request to add local DDP,
 profile a trainer, run inference, or debug ordinary training is not a
 conversion request.
 
-During conversion, the agent:
+A request for statistics across sites selects the federated statistics
+workflow rather than a model-training converter. If a request combines
+statistics and model training conversion, the agent treats them as two
+independent jobs and asks which workflow to run first; it does not merge or
+automatically chain them.
+
+During model-training conversion, the agent:
 
 #. Inspects the source statically to identify the model, constructor arguments,
    training owner, data inputs, local training budget, evaluation path,
@@ -104,15 +126,36 @@ The agent asks a focused question, or stops, when a required semantic choice
 cannot be recovered safely from the source. Examples include an ambiguous
 model constructor, aggregation rule, or best-model metric direction.
 
+For a federated statistics job, the agent:
+
+#. Inspects the data deterministically to identify modality, site layout,
+   feature names, data types, row counts, and schema agreement.
+#. Maps requested or declared statistics to the supported set and reports any
+   exclusions before generating code. When none are declared, it uses and
+   reports the default selection.
+#. Generates a data-loading client and ``job.py`` backed by
+   ``FedStatsRecipe``. Statistics are computed by NVFLARE rather than copied
+   from a source script.
+#. Preserves existing per-site data layout or creates deterministic partitions
+   for explicitly authorized flat demonstration data.
+#. Runs staged validation and verifies that the result JSON contains every
+   configured statistic for each feature, site, and the global aggregate.
+#. Reports applied privacy parameters, missing-data rates, aggregate summaries,
+   and the result path without exposing raw rows or cell values.
+
 Data and Artifacts
 ==================
 
-Training data remains external to the generated NVFLARE job and is passed to
+Source data remains external to the generated NVFLARE job and is passed to
 clients through configurable arguments. Existing site partitions are
 preserved. When a demonstration requires generated partitions, the agent uses
 a deterministic source-backed split and reports its policy, seed, and site
 count. It does not pool private records or silently derive preprocessing
 artifacts from multiple sites.
+
+Federated statistics output contains per-site and global aggregates, not raw
+records. Feature names must come from the data header or a user-supplied
+schema; they are never invented for ambiguous headerless data.
 
 Relative source-data paths are resolved against the source project before the
 job runs from NVFLARE's per-site runtime directories. Real deployments must
@@ -141,28 +184,39 @@ The conversion skills deliberately stop at the following boundaries:
 * **Framework coverage:** TensorFlow, XGBoost, scikit-learn, NeMo, inference-only
   pipelines, serving, and generic training repair are outside these conversion
   skills. Use the corresponding NVFLARE workflow or documentation instead.
-* **Hugging Face distributed strategies:** DeepSpeed and FSDP are outside the
-  Hugging Face converter's current scope. It supports one persistent
+* **Hugging Face Client API limitation:** The current NVFLARE Hugging Face
+  Client API does not support DeepSpeed or FSDP, so the conversion skill cannot
+  generate jobs that use those strategies. It supports one persistent
   ``Trainer`` per process and rejects an unresolved multi-process global rank.
-* **Privacy mechanisms:** A conversion does not add homomorphic encryption,
-  differential privacy, privacy filters, or a disclosure policy. Ask for those
-  requirements as a separate security and privacy design step; do not treat a
-  successful simulation as privacy approval.
+  DeepSpeed and FSDP support is planned for a future release.
+* **Federated statistics coverage:** Categorical counts, unique-value counts,
+  correlations, custom aggregations, and hierarchical statistics are not
+  supported. Requested minimum and maximum values are returned only as
+  noise-protected estimates. Missing feature names, inconsistent site schemas,
+  or an unknown site count for flat data cause the workflow to stop rather than
+  guess.
+* **Statistics validation:** The skill validates execution and result
+  completeness, but exact numeric parity is a separate test responsibility.
+* **Privacy mechanisms:** Model conversion does not add homomorphic encryption,
+  differential privacy, privacy filters, or a disclosure policy. The federated
+  statistics job retains its recipe's built-in privacy filters, but that does
+  not establish an approved disclosure policy. Do not treat a successful
+  simulation as privacy approval.
 * **Production deployment:** Provisioning, POC submission, Kubernetes or Slurm
   deployment, production policy, and operational approval are separate from
   conversion. Local simulation verifies the generated job path, not production
   readiness.
-* **Other workflows:** Federated statistics, AutoFL experiment search, failed-job
-  diagnosis, and general source modernization have their own skills or guides.
-  A combined request is handled as separate workflows rather than one blended
-  job.
+* **Other workflows:** AutoFL experiment search, failed-job diagnosis, and
+  general source modernization have their own skills or guides. Statistics and
+  model conversion are also kept as separate jobs rather than one blended
+  workflow.
 
 Try the Examples
 ================
 
 The :github_nvflare_link:`Agent Skills runnable examples
-<examples/hello-world/agent-skills>` include small plain PyTorch, Lightning, and
-Hugging Face starting projects with exact prompts and synthetic data. Start
-with :ref:`Agent Skills Quickstart <agent_skills_quickstart>`, then review the
-generated changes and validation evidence before applying the workflow to a
-real project.
+<examples/hello-world/agent-skills>` include small plain PyTorch, Lightning,
+Hugging Face, tabular statistics, and image statistics starting projects with
+exact prompts and synthetic data. Start with :ref:`Agent Skills Quickstart
+<agent_skills_quickstart>`, then review the generated changes and validation
+evidence before applying the workflow to a real project.

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -36,7 +36,7 @@ learning job:
      - What the skill creates
    * - An existing plain PyTorch training project
      - A multi-site NVFLARE training job that preserves the project's model,
-       local training loop, training budget, and evaluation behavior.
+       local training loop, local epochs/steps, and evaluation behavior.
    * - An existing PyTorch Lightning project
      - A multi-site NVFLARE training job that retains the Lightning trainer,
        validation metrics, callbacks, and checkpoint behavior.
@@ -55,14 +55,13 @@ How to Request Training-Code Conversion
 
 Open the existing training project in the coding agent. Include the source
 location, framework, algorithm when you have a preference, client count, round
-count, local training budget, and whether to run a local simulation. For
-example:
+count, local epochs/steps, and whether to run a local simulation. For example:
 
 .. code-block:: text
 
-   I have an existing PyTorch Lightning project in ./source. Convert it to an
-   NVFLARE FedAvg job for 3 sites and 3 rounds. Preserve its validation metric
-   and local training budget, and validate the result with a local simulation.
+   Here is my PyTorch Lightning training code. Convert it to a FLARE federated
+   job, run it with 3 simulated sites using FedAvg for 3 rounds, and show me
+   validation results.
 
 The request must express federated or cross-site collaborative training intent
 and the source must have one supported training owner. A request to add local
@@ -72,8 +71,8 @@ conversion request.
 During conversion, the agent:
 
 #. Inspects the source statically to identify the model, constructor arguments,
-   training owner, data inputs, local training budget, evaluation path,
-   metrics, checkpoints, and callbacks.
+   training owner, data inputs, local epochs/steps, evaluation path, metrics,
+   checkpoints, and callbacks.
 #. Confirms the requested algorithm against the recipes available in the
    installed NVFLARE version.
 #. Preserves the source project's framework-native training and evaluation

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -63,16 +63,14 @@ count, local epochs/steps, and whether to run a local simulation. For example:
    job, run it with 3 simulated sites using FedAvg for 3 rounds, and show me
    validation results.
 
-The request must express federated or cross-site collaborative training intent
-and the source must have one supported training owner. A request to add local
-DDP, profile a trainer, run inference, or debug ordinary training is not a
-conversion request.
+What to Expect from Training-Code Conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During conversion, the agent:
+For a training-code conversion, the agent:
 
 #. Inspects the source statically to identify the model, constructor arguments,
-   training owner, data inputs, local epochs/steps, evaluation path, metrics,
-   checkpoints, and callbacks.
+   active training entry point, data inputs, local epochs/steps, evaluation
+   path, metrics, checkpoints, and callbacks.
 #. Confirms the requested algorithm against the recipes available in the
    installed NVFLARE version.
 #. Preserves the source project's framework-native training and evaluation
@@ -85,8 +83,8 @@ During conversion, the agent:
 #. Reports the generated files, data and partition assumptions, metrics,
    simulation evidence, and output artifact locations.
 
-The agent asks a focused question, or stops, when a required semantic choice
-cannot be recovered safely from the source. Examples include an ambiguous
+If the source does not make an important choice clear, the agent asks you a
+focused question or stops instead of guessing. Examples include an ambiguous
 model constructor, aggregation rule, or best-model metric direction.
 
 2. Federated Statistics Job Generation
@@ -126,14 +124,16 @@ applies its supported defaults. For example:
 
 .. code-block:: text
 
-   Create an NVFLARE federated statistics job for the per-site CSV files under
-   ./data. Compute count, mean, standard deviation, histogram, and median for
-   the numeric features, and validate the job with a local simulation.
+   I have tabular data from multiple sites in ./data. Calculate federated
+   statistics for it and validate the result locally.
 
-The agent:
+What to Expect from Federated Statistics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Inspects the data deterministically to identify modality, site layout,
-   feature names, data types, row counts, and schema agreement.
+For a federated statistics request, the agent:
+
+#. Examines the sample data to identify modality, site layout, feature names,
+   data types, row counts, and schema agreement.
 #. Maps requested or declared statistics to the supported set and reports any
    exclusions before generating code. When none are declared, it uses and
    reports the default selection.
@@ -147,9 +147,9 @@ The agent:
 #. Reports applied privacy parameters, missing-data rates, aggregate summaries,
    and the result path without exposing raw rows or cell values.
 
-If one request combines federated statistics and model-training conversion,
-the agent treats them as two independent jobs and asks which workflow to run
-first. It does not merge or automatically chain them.
+Request federated statistics and model-training conversion as separate jobs.
+If you ask for both at once, the agent asks which job to create first; it does
+not merge or automatically chain them.
 
 Data and Artifacts
 ==================
@@ -162,11 +162,11 @@ count. It does not pool private records or silently derive preprocessing
 artifacts from multiple sites.
 
 Federated statistics output contains per-site and global aggregates, not raw
-records. Feature names must come from the data header or a user-supplied
-schema; they are never invented for ambiguous headerless data.
+records. For headerless data, provide a schema with the feature names. The
+skill does not invent names for ambiguous columns.
 
 Relative source-data paths are resolved against the source project before the
-job runs from NVFLARE's per-site runtime directories. Real deployments must
+job runs from NVFLARE's per-site runtime directories. For a real deployment,
 configure a valid data location at each site. Hugging Face Hub identifiers and
 URLs are not treated as local filesystem paths.
 
@@ -180,9 +180,9 @@ Limitations
 
 The conversion skills deliberately stop at the following boundaries:
 
-* **One supported training owner:** A project must have one identifiable plain
-  PyTorch, Lightning, or Hugging Face training path. Mixed active framework
-  owners require the user to choose the intended path.
+* **One supported training path:** A project must have one identifiable plain
+  PyTorch, Lightning, or Hugging Face training path. If multiple frameworks or
+  training entry points are active, choose the path you want to convert.
 * **Statically reconstructable model:** Required model and trainer constructor
   values must be available from the source. The skills do not guess missing
   architecture values or execute untrusted project text as instructions.
@@ -206,8 +206,8 @@ The conversion skills deliberately stop at the following boundaries:
   noise-protected estimates. Missing feature names, inconsistent site schemas,
   or an unknown site count for flat data cause the workflow to stop rather than
   guess.
-* **Statistics validation:** The skill validates execution and result
-  completeness, but exact numeric parity is a separate test responsibility.
+* **Statistics validation:** Validation confirms that the job executes and the
+  result is complete; it does not independently verify every numeric value.
 * **Privacy mechanisms:** Model conversion does not add homomorphic encryption,
   differential privacy, privacy filters, or a disclosure policy. The federated
   statistics job retains its recipe's built-in privacy filters, but that does
@@ -217,10 +217,9 @@ The conversion skills deliberately stop at the following boundaries:
   deployment, production policy, and operational approval are separate from
   conversion. Local simulation verifies the generated job path, not production
   readiness.
-* **Other workflows:** AutoFL experiment search, failed-job diagnosis, and
-  general source modernization have their own skills or guides. Statistics and
-  model conversion are also kept as separate jobs rather than one blended
-  workflow.
+* **Other workflows:** AutoFL optimization is a separate workflow. Federated
+  statistics and model conversion are also created as separate jobs rather
+  than one blended workflow.
 
 Try the Examples
 ================

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -204,6 +204,9 @@ The conversion skills deliberately stop at the following boundaries:
 * **Framework coverage:** TensorFlow, XGBoost, scikit-learn, NeMo, inference-only
   pipelines, serving, and generic training repair are outside these conversion
   skills. Use the corresponding NVFLARE workflow or documentation instead.
+* **Target API path:** Deep learning training-code conversion uses the
+  :ref:`Client API <client_api>` and :ref:`Job Recipe API <job_recipe>`. It
+  does not convert training code to the :ref:`Collaboration API <collab_api>`.
 * **Hugging Face Client API limitation:** The current NVFLARE Hugging Face
   Client API does not support DeepSpeed or FSDP, so the conversion skill cannot
   generate jobs that use those strategies. It supports one persistent

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -4,20 +4,25 @@
 Agent Conversion Skills
 #######################
 
-NVFLARE Agent Conversion Skills help a coding agent create a reviewable,
-multi-site NVFLARE job from an existing single-site training project or a
-federated data-summary request. The agent inspects the source project or data,
-chooses a compatible NVFLARE recipe, generates the integration files, and
-validates the result locally.
+NVFLARE Agent Conversion Skills support two user workflows: converting
+existing deep learning training code into federated learning training code,
+and generating a federated statistics job from a sample tabular or image
+dataset. The agent inspects the supplied code or data, generates a reviewable
+NVFLARE job, and validates the result locally.
 
 The skills are coding-agent workflows, not NVFLARE runtime commands or an
 automatic production migration service. You review and own the generated code
 and configuration.
 
-Supported Workflows
-===================
+Supported Workflow Groups
+=========================
 
-You can use Agent Skills for four job-creation workflows:
+1. Deep Learning Training Code Conversion
+-----------------------------------------
+
+Provide an existing single-site deep learning training project. The skill
+converts its training and evaluation workflow into a multi-site federated
+learning job:
 
 .. list-table::
    :header-rows: 1
@@ -35,22 +40,38 @@ You can use Agent Skills for four job-creation workflows:
      - A multi-site NVFLARE training job that retains the Trainer workflow,
        datasets, metrics, callbacks, and checkpoints. Full-model and PEFT/LoRA
        fine-tuning are supported.
-   * - Tabular or image data
-     - A federated statistics job and aggregate results. Tabular inputs include
-       CSV, Parquet, and other pandas-readable data. Image inputs include
-       common image folders and DICOM or NIfTI when the matching loader is
-       available. Existing statistics selections declared in a script or
-       README can also be preserved.
 
 The three model-training skills target horizontal federated learning with the
 PyTorch recipe family. FedAvg is the standard conversion path when requested.
 Other PyTorch-family recipes are used only when the requested workflow is
 compatible with a recipe exposed by the installed NVFLARE version.
 
-The federated statistics skill generates a separate ``FedStatsRecipe`` job. It
-supports count, sum, mean, standard deviation, variance, histogram, quantile,
-and noise-protected minimum and maximum for numeric tabular features. For image
-data, it supports image count, failure count, and pixel-intensity histograms.
+2. Federated Statistics Job Generation
+--------------------------------------
+
+Provide a sample dataset that represents the tabular or image data available
+at the participating sites. The skill uses the sample to determine the data
+layout and generate a separate federated statistics job:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Sample dataset
+     - What the skill creates
+   * - Tabular data
+     - A federated statistics job for CSV, Parquet, or other pandas-readable
+       data, plus per-site and global aggregate results.
+   * - Image data
+     - A federated statistics job for common image folders, or DICOM and NIfTI
+       data when the matching loader is available, plus per-site and global
+       image statistics.
+
+For numeric tabular features, the generated job supports count, sum, mean,
+standard deviation, variance, histogram, quantile, and noise-protected minimum
+and maximum. For image data, it supports image count, failure count, and
+pixel-intensity histograms. Existing statistics selections declared in a
+script or README can also be preserved.
 
 Install the Skills
 ==================

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -1,0 +1,168 @@
+.. _agent_conversion_skills:
+
+#######################
+Agent Conversion Skills
+#######################
+
+NVFLARE Agent Conversion Skills help a coding agent adapt an existing
+single-site training project into a reviewable, multi-site NVFLARE job. The
+agent inspects the project's existing training and evaluation code, chooses a
+compatible NVFLARE recipe, generates the integration files, and validates the
+result locally.
+
+The skills are coding-agent workflows, not NVFLARE runtime commands or an
+automatic production migration service. You review and own the generated code
+and configuration.
+
+Supported Training Frameworks
+=============================
+
+The conversion skills support three PyTorch-family training styles:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Starting project
+     - Skill
+     - Supported integration
+   * - Plain PyTorch
+     - ``nvflare-convert-pytorch``
+     - Manual training loops built with ``nn.Module``, optimizers,
+       ``DataLoader``, and ``state_dict`` exchange. The generated client uses
+       the NVFLARE Client API and preserves source-backed training and
+       evaluation behavior.
+   * - PyTorch Lightning
+     - ``nvflare-convert-lightning``
+     - A Lightning-owned workflow with ``LightningModule`` and ``Trainer``.
+       The generated client patches the existing ``Trainer`` and keeps
+       evaluation, metrics, callbacks, and checkpoint behavior in Lightning.
+   * - Hugging Face
+     - ``nvflare-convert-huggingface``
+     - ``Trainer``, ``Seq2SeqTrainer``, TRL ``SFTTrainer``, or a compatible
+       ``Trainer`` subclass. Full-model and PEFT/LoRA fine-tuning are
+       supported, including single-process and replicated distributed
+       training when the process rank is unambiguous.
+
+All three skills target horizontal federated learning with the PyTorch recipe
+family. FedAvg is the standard conversion path when requested. Other
+PyTorch-family recipes are used only when the requested workflow is compatible
+with a recipe exposed by the installed NVFLARE version.
+
+Install the Skills
+==================
+
+From an NVFLARE source checkout, install the complete skill set for Codex,
+Claude Code, or both:
+
+.. code-block:: shell
+
+   npx skills add ./skills --skill '*' -a codex -a claude-code -y
+
+Generated jobs require NVFLARE 2.9.0 or later in the Python environment used
+by the coding agent. The skills are installed from the source tree; they are
+not installed by the NVFLARE Python package.
+
+Request a Conversion
+====================
+
+Open the existing training project in the coding agent and describe the
+federated outcome. Include the source location, framework, algorithm when you
+have a preference, client count, round count, local training budget, and
+whether to run a local simulation. For example:
+
+.. code-block:: text
+
+   I have an existing PyTorch Lightning project in ./source. Convert it to an
+   NVFLARE FedAvg job for 3 sites and 3 rounds. Preserve its validation metric
+   and local training budget, and validate the result with a local simulation.
+
+You do not need to name a skill. The agent selects a converter only when the
+request expresses federated or cross-site collaborative training intent and
+the source has one supported training owner. A request to add local DDP,
+profile a trainer, run inference, or debug ordinary training is not a
+conversion request.
+
+During conversion, the agent:
+
+#. Inspects the source statically to identify the model, constructor arguments,
+   training owner, data inputs, local training budget, evaluation path,
+   metrics, checkpoints, and callbacks.
+#. Confirms the requested algorithm against the recipes available in the
+   installed NVFLARE version.
+#. Preserves the source project's framework-native training and evaluation
+   behavior while adding the appropriate NVFLARE model exchange.
+#. Generates project-local integration files, such as a client entry point and
+   ``job.py``, without overwriting non-generated source files.
+#. Validates the generated target in stages and stops at the first failed
+   stage. When requested and authorized, the final stage runs a completed
+   local simulation.
+#. Reports the generated files, data and partition assumptions, metrics,
+   simulation evidence, and output artifact locations.
+
+The agent asks a focused question, or stops, when a required semantic choice
+cannot be recovered safely from the source. Examples include an ambiguous
+model constructor, aggregation rule, or best-model metric direction.
+
+Data and Artifacts
+==================
+
+Training data remains external to the generated NVFLARE job and is passed to
+clients through configurable arguments. Existing site partitions are
+preserved. When a demonstration requires generated partitions, the agent uses
+a deterministic source-backed split and reports its policy, seed, and site
+count. It does not pool private records or silently derive preprocessing
+artifacts from multiple sites.
+
+Relative source-data paths are resolved against the source project before the
+job runs from NVFLARE's per-site runtime directories. Real deployments must
+configure a valid data location at each site. Hugging Face Hub identifiers and
+URLs are not treated as local filesystem paths.
+
+The agent does not download data or model artifacts, enable remote experiment
+tracking, or upload callbacks unless the request explicitly authorizes that
+effect. Review generated files and reported artifacts before accepting them or
+using real data.
+
+Limitations
+===========
+
+The conversion skills deliberately stop at the following boundaries:
+
+* **One supported training owner:** A project must have one identifiable plain
+  PyTorch, Lightning, or Hugging Face training path. Mixed active framework
+  owners require the user to choose the intended path.
+* **Statically reconstructable model:** Required model and trainer constructor
+  values must be available from the source. The skills do not guess missing
+  architecture values or execute untrusted project text as instructions.
+* **Source-backed evaluation:** Existing evaluation and metric semantics are
+  preserved. The skills do not invent a validation dataset, metric, or
+  best-model direction.
+* **Framework coverage:** TensorFlow, XGBoost, scikit-learn, NeMo, inference-only
+  pipelines, serving, and generic training repair are outside these conversion
+  skills. Use the corresponding NVFLARE workflow or documentation instead.
+* **Hugging Face distributed strategies:** DeepSpeed and FSDP are outside the
+  Hugging Face converter's current scope. It supports one persistent
+  ``Trainer`` per process and rejects an unresolved multi-process global rank.
+* **Privacy mechanisms:** A conversion does not add homomorphic encryption,
+  differential privacy, privacy filters, or a disclosure policy. Ask for those
+  requirements as a separate security and privacy design step; do not treat a
+  successful simulation as privacy approval.
+* **Production deployment:** Provisioning, POC submission, Kubernetes or Slurm
+  deployment, production policy, and operational approval are separate from
+  conversion. Local simulation verifies the generated job path, not production
+  readiness.
+* **Other workflows:** Federated statistics, AutoFL experiment search, failed-job
+  diagnosis, and general source modernization have their own skills or guides.
+  A combined request is handled as separate workflows rather than one blended
+  job.
+
+Try the Examples
+================
+
+The :github_nvflare_link:`Agent Skills runnable examples
+<examples/hello-world/agent-skills>` include small plain PyTorch, Lightning, and
+Hugging Face starting projects with exact prompts and synthetic data. Start
+with :ref:`Agent Skills Quickstart <agent_skills_quickstart>`, then review the
+generated changes and validation evidence before applying the workflow to a
+real project.

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -15,19 +15,8 @@ automatic production migration service. You review and own the generated code
 and configuration. You do not need to know or name an internal skill; describe
 one of the two outcomes below and provide the corresponding input.
 
-Install the Skills
-==================
-
-From an NVFLARE source checkout, install the complete skill set for Codex,
-Claude Code, or both:
-
-.. code-block:: shell
-
-   npx skills add ./skills --skill '*' -a codex -a claude-code -y
-
-Generated jobs require NVFLARE 2.9.0 or later in the Python environment used
-by the coding agent. The skills are installed from the source tree; they are
-not installed by the NVFLARE Python package.
+Before using these workflows, complete :ref:`Agent Skills installation
+<agent_skills_install>`, including the NVFLARE runtime setup described there.
 
 Supported Workflow Groups
 =========================

--- a/docs/user_guide/agent_skills/conversion_skills.rst
+++ b/docs/user_guide/agent_skills/conversion_skills.rst
@@ -12,7 +12,22 @@ NVFLARE job, and validates the result locally.
 
 The skills are coding-agent workflows, not NVFLARE runtime commands or an
 automatic production migration service. You review and own the generated code
-and configuration.
+and configuration. You do not need to know or name an internal skill; describe
+one of the two outcomes below and provide the corresponding input.
+
+Install the Skills
+==================
+
+From an NVFLARE source checkout, install the complete skill set for Codex,
+Claude Code, or both:
+
+.. code-block:: shell
+
+   npx skills add ./skills --skill '*' -a codex -a claude-code -y
+
+Generated jobs require NVFLARE 2.9.0 or later in the Python environment used
+by the coding agent. The skills are installed from the source tree; they are
+not installed by the NVFLARE Python package.
 
 Supported Workflow Groups
 =========================
@@ -46,6 +61,46 @@ PyTorch recipe family. FedAvg is the standard conversion path when requested.
 Other PyTorch-family recipes are used only when the requested workflow is
 compatible with a recipe exposed by the installed NVFLARE version.
 
+How to Request Training-Code Conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open the existing training project in the coding agent. Include the source
+location, framework, algorithm when you have a preference, client count, round
+count, local training budget, and whether to run a local simulation. For
+example:
+
+.. code-block:: text
+
+   I have an existing PyTorch Lightning project in ./source. Convert it to an
+   NVFLARE FedAvg job for 3 sites and 3 rounds. Preserve its validation metric
+   and local training budget, and validate the result with a local simulation.
+
+The request must express federated or cross-site collaborative training intent
+and the source must have one supported training owner. A request to add local
+DDP, profile a trainer, run inference, or debug ordinary training is not a
+conversion request.
+
+During conversion, the agent:
+
+#. Inspects the source statically to identify the model, constructor arguments,
+   training owner, data inputs, local training budget, evaluation path,
+   metrics, checkpoints, and callbacks.
+#. Confirms the requested algorithm against the recipes available in the
+   installed NVFLARE version.
+#. Preserves the source project's framework-native training and evaluation
+   behavior while adding the appropriate NVFLARE model exchange.
+#. Generates project-local integration files, such as a client entry point and
+   ``job.py``, without overwriting non-generated source files.
+#. Validates the generated target in stages and stops at the first failed
+   stage. When requested and authorized, the final stage runs a completed
+   local simulation.
+#. Reports the generated files, data and partition assumptions, metrics,
+   simulation evidence, and output artifact locations.
+
+The agent asks a focused question, or stops, when a required semantic choice
+cannot be recovered safely from the source. Examples include an ambiguous
+model constructor, aggregation rule, or best-model metric direction.
+
 2. Federated Statistics Job Generation
 --------------------------------------
 
@@ -73,40 +128,13 @@ and maximum. For image data, it supports image count, failure count, and
 pixel-intensity histograms. Existing statistics selections declared in a
 script or README can also be preserved.
 
-Install the Skills
-==================
+How to Request a Federated Statistics Job
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-From an NVFLARE source checkout, install the complete skill set for Codex,
-Claude Code, or both:
-
-.. code-block:: shell
-
-   npx skills add ./skills --skill '*' -a codex -a claude-code -y
-
-Generated jobs require NVFLARE 2.9.0 or later in the Python environment used
-by the coding agent. The skills are installed from the source tree; they are
-not installed by the NVFLARE Python package.
-
-Request a Job
-=============
-
-Open the existing training project or data directory in the coding agent and
-describe the federated outcome.
-
-For model training, include the source location, framework, algorithm when you
-have a preference, client count, round count, local training budget, and
-whether to run a local simulation. For example:
-
-.. code-block:: text
-
-   I have an existing PyTorch Lightning project in ./source. Convert it to an
-   NVFLARE FedAvg job for 3 sites and 3 rounds. Preserve its validation metric
-   and local training budget, and validate the result with a local simulation.
-
-For federated statistics, identify the per-site data or the flat source data,
-the site count when it cannot be inferred, and any required statistics. When
-no statistics are named, the skill reports and applies its supported defaults.
-For example:
+Open the sample data directory in the coding agent. Identify the per-site data
+or flat source data, the site count when it cannot be inferred, and any
+required statistics. When no statistics are named, the skill reports and
+applies its supported defaults. For example:
 
 .. code-block:: text
 
@@ -114,40 +142,7 @@ For example:
    ./data. Compute count, mean, standard deviation, histogram, and median for
    the numeric features, and validate the job with a local simulation.
 
-You do not need to name a skill. The agent selects a converter only when the
-request expresses federated or cross-site collaborative training intent and
-the source has one supported training owner. A request to add local DDP,
-profile a trainer, run inference, or debug ordinary training is not a
-conversion request.
-
-A request for statistics across sites selects the federated statistics
-workflow rather than a model-training converter. If a request combines
-statistics and model training conversion, the agent treats them as two
-independent jobs and asks which workflow to run first; it does not merge or
-automatically chain them.
-
-During model-training conversion, the agent:
-
-#. Inspects the source statically to identify the model, constructor arguments,
-   training owner, data inputs, local training budget, evaluation path,
-   metrics, checkpoints, and callbacks.
-#. Confirms the requested algorithm against the recipes available in the
-   installed NVFLARE version.
-#. Preserves the source project's framework-native training and evaluation
-   behavior while adding the appropriate NVFLARE model exchange.
-#. Generates project-local integration files, such as a client entry point and
-   ``job.py``, without overwriting non-generated source files.
-#. Validates the generated target in stages and stops at the first failed
-   stage. When requested and authorized, the final stage runs a completed
-   local simulation.
-#. Reports the generated files, data and partition assumptions, metrics,
-   simulation evidence, and output artifact locations.
-
-The agent asks a focused question, or stops, when a required semantic choice
-cannot be recovered safely from the source. Examples include an ambiguous
-model constructor, aggregation rule, or best-model metric direction.
-
-For a federated statistics job, the agent:
+The agent:
 
 #. Inspects the data deterministically to identify modality, site layout,
    feature names, data types, row counts, and schema agreement.
@@ -163,6 +158,10 @@ For a federated statistics job, the agent:
    configured statistic for each feature, site, and the global aggregate.
 #. Reports applied privacy parameters, missing-data rates, aggregate summaries,
    and the result path without exposing raw rows or cell values.
+
+If one request combines federated statistics and model-training conversion,
+the agent treats them as two independent jobs and asks which workflow to run
+first. It does not merge or automatically chain them.
 
 Data and Artifacts
 ==================

--- a/docs/user_guide/agent_skills/index.rst
+++ b/docs/user_guide/agent_skills/index.rst
@@ -11,4 +11,5 @@ through the coding agent rather than by invoking its private scripts directly.
    :maxdepth: 1
 
    quickstart
+   conversion_skills
    autofl_skill

--- a/docs/user_guide/agent_skills/index.rst
+++ b/docs/user_guide/agent_skills/index.rst
@@ -2,10 +2,11 @@
 Agent Skills
 ############
 
-NVFlare-owned agent skills package repeatable coding-agent workflows with
-deterministic helpers and reviewable contracts. Install the skill set through
-the standard ``npx skills add`` workflow; interact with an installed skill
-through the coding agent rather than by invoking its private scripts directly.
+NVFLARE Agent Skills let you use a coding agent to understand NVFLARE, create
+federated jobs, and optimize existing jobs. Install the skill set through the
+standard ``npx skills add`` workflow, then describe your goal to the coding
+agent in natural language. The following guides explain the supported
+workflows, expected results, and current limitations.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user_guide/agent_skills/quickstart.rst
+++ b/docs/user_guide/agent_skills/quickstart.rst
@@ -34,9 +34,9 @@ Understand Where to Start
 -------------------------
 
 Use the orientation workflow when you are new to NVFLARE, are unsure which API
-or workflow fits a project, or have source code with more than one possible
-training owner. It inspects the supplied project read-only and recommends one
-next workflow without editing files or starting a job.
+or workflow fits a project, or have source code with more than one training
+framework or entry point. It inspects the supplied project read-only and
+recommends one next workflow without editing files or starting a job.
 
 Create a Federated Job
 ----------------------
@@ -57,8 +57,8 @@ Optimize an Existing Job
 Use AutoFL when you already have a runnable NVFLARE ``job.py`` and want to
 improve a measured objective through reproducible candidate experiments. State
 the metric, execution environment (simulation, POC, or production), and any
-candidate limit. AutoFL does not convert standalone training code or diagnose a
-failure-only request.
+candidate limit. AutoFL optimizes an existing job; it does not convert
+standalone training code.
 
 See :ref:`NVFlare Auto-FL Agent Skill <autofl_skill>` for campaign behavior,
 permissions, comparison rules, and outputs.

--- a/docs/user_guide/agent_skills/quickstart.rst
+++ b/docs/user_guide/agent_skills/quickstart.rst
@@ -4,11 +4,13 @@
 Agent Skills Quickstart
 #######################
 
-The :github_nvflare_link:`Agent Skills runnable examples
-<examples/hello-world/agent-skills>` provide five small, standalone projects for trying
-NVFLARE Agent Skills with Codex or Claude Code. Each one includes the starting
-source or synthetic data, an exact natural-language prompt, and a local
-validation path.
+NVFLARE Agent Skills provide guided workflows for understanding NVFLARE,
+creating jobs, optimizing an existing job, and reporting AutoFL results. You
+describe the goal in natural language; the coding agent selects the appropriate
+installed skill from the request and available source files.
+
+Install the Skills
+==================
 
 Install all skills from an NVFLARE checkout:
 
@@ -20,14 +22,63 @@ The generated jobs also require NVFLARE 2.9.0 or later in the Python
 environment used by the coding agent. Install the package from PyPI or use an
 editable NVFLARE checkout.
 
-Then open one example directory in your coding agent and paste its prompt. The
-agent chooses the relevant installed skill from the request and source files;
-you do not need to select or name a skill. The examples cover plain PyTorch,
-PyTorch Lightning, Hugging Face Trainer, tabular federated statistics, and
-image federated statistics. Review the agent's proposed changes before running
-a simulation or applying a workflow to real data.
+Choose a Workflow
+=================
 
-For framework coverage, conversion behavior, data handling, and current
-limitations, see :ref:`Agent Conversion Skills <agent_conversion_skills>`.
-To optimize an existing NVFLARE ``job.py`` through agent-guided experiment
-search, see :ref:`NVFlare Auto-FL Agent Skill <autofl_skill>`.
+You do not need to know or name the internal skill. Choose the goal that
+matches your task and provide the relevant project, data, job, or evidence.
+
+Understand Where to Start
+-------------------------
+
+Use the orientation workflow when you are new to NVFLARE, are unsure which API
+or workflow fits a project, or have source code with more than one possible
+training owner. It inspects the supplied project read-only and recommends one
+next workflow without editing files or starting a job.
+
+Create a Federated Job
+----------------------
+
+Use the job-creation workflows for either of these goals:
+
+* Convert existing plain PyTorch, PyTorch Lightning, or Hugging Face Trainer
+  code into a federated learning training job.
+* Given a sample tabular or image dataset, generate a federated statistics job.
+
+See :ref:`Agent Conversion Skills <agent_conversion_skills>` for supported
+inputs, example prompts, generated results, validation behavior, and
+limitations.
+
+Optimize an Existing Job
+------------------------
+
+Use AutoFL when you already have a runnable NVFLARE ``job.py`` and want to
+improve a measured objective through reproducible candidate experiments. State
+the metric, execution environment (simulation, POC, or production), and any
+candidate limit. AutoFL does not convert standalone training code or diagnose a
+failure-only request.
+
+See :ref:`NVFlare Auto-FL Agent Skill <autofl_skill>` for campaign behavior,
+permissions, comparison rules, and outputs.
+
+Report a Completed AutoFL Campaign
+----------------------------------
+
+Use AutoFL reporting after a campaign has stopped, reached its candidate cap,
+or been explicitly interrupted. It turns the recorded campaign evidence into
+a reproducible Markdown report, JSON summary, and progress plot without
+changing campaign results.
+
+Try the Runnable Examples
+=========================
+
+The :github_nvflare_link:`Agent Skills runnable examples
+<examples/hello-world/agent-skills>` provide five small, standalone projects
+for trying NVFLARE Agent Skills with Codex or Claude Code. Each includes
+starting source or synthetic data, an exact natural-language prompt, and a
+local validation path.
+
+Open one example directory in your coding agent and paste its prompt. The
+examples cover plain PyTorch, PyTorch Lightning, Hugging Face Trainer, tabular
+federated statistics, and image federated statistics. Review the proposed
+changes before running a simulation or applying a workflow to real data.

--- a/docs/user_guide/agent_skills/quickstart.rst
+++ b/docs/user_guide/agent_skills/quickstart.rst
@@ -29,3 +29,5 @@ a simulation or applying a workflow to real data.
 
 For framework coverage, conversion behavior, data handling, and current
 limitations, see :ref:`Agent Conversion Skills <agent_conversion_skills>`.
+To optimize an existing NVFLARE ``job.py`` through agent-guided experiment
+search, see :ref:`NVFlare Auto-FL Agent Skill <autofl_skill>`.

--- a/docs/user_guide/agent_skills/quickstart.rst
+++ b/docs/user_guide/agent_skills/quickstart.rst
@@ -1,3 +1,5 @@
+.. _agent_skills_quickstart:
+
 #######################
 Agent Skills Quickstart
 #######################
@@ -24,3 +26,6 @@ you do not need to select or name a skill. The examples cover plain PyTorch,
 PyTorch Lightning, Hugging Face Trainer, tabular federated statistics, and
 image federated statistics. Review the agent's proposed changes before running
 a simulation or applying a workflow to real data.
+
+For framework coverage, conversion behavior, data handling, and current
+limitations, see :ref:`Agent Conversion Skills <agent_conversion_skills>`.

--- a/docs/user_guide/agent_skills/quickstart.rst
+++ b/docs/user_guide/agent_skills/quickstart.rst
@@ -9,6 +9,8 @@ creating jobs, optimizing an existing job, and reporting AutoFL results. You
 describe the goal in natural language; the coding agent selects the appropriate
 installed skill from the request and available source files.
 
+.. _agent_skills_install:
+
 Install the Skills
 ==================
 

--- a/docs/user_guide/data_scientist_guide/api_selection.rst
+++ b/docs/user_guide/data_scientist_guide/api_selection.rst
@@ -6,8 +6,9 @@
 Choose an NVFLARE API Path
 ##########################
 
-NVFLARE offers two high-level ways to build federated applications. They serve
-different goals and are complementary, not interchangeable defaults.
+NVFLARE offers two high-level ways to build federated applications, plus
+lower-level Controller and Executor APIs for advanced customization. They
+serve different goals and are complementary, not interchangeable defaults.
 
 Choose Collaboration API (Technical Preview) for Research
 ==========================================================
@@ -80,16 +81,40 @@ must still be enabled and operated for the target environment.
 Start with :ref:`client_api_usage`, :ref:`job_recipe`, and
 :ref:`available_recipes`.
 
+Choose Controller + Executor APIs for Maximum Control
+=====================================================
+
+Use the lower-level :ref:`Controller <controllers>` and :ref:`Executor
+<executor>` APIs when an application needs explicit control over FLARE's task
+and component runtime. A Controller defines server-side workflow orchestration,
+including custom task scheduling and dispatch, response handling, timeouts, and
+failure policy. An Executor implements the corresponding client-side task
+contract. This path also exposes lower-level facilities such as
+``Shareable``/DXO payloads, task and result filters, events, and custom
+components.
+
+This path provides the most flexibility and control, but requires more code
+and configuration tied to NVFLARE's component APIs. The application owns the
+task contract, workflow state, aggregation and failure semantics, and
+integration testing.
+Choose it when the supported Recipes do not provide the required workflow or
+when direct runtime control is more important than the simpler high-level
+programming models.
+
+Start with :ref:`controllers`, :ref:`executor`, and
+:ref:`component_configuration`.
+
 Shared Platform Capabilities
 ============================
 
-Both high-level paths create normal FLARE jobs and can use the same simulation,
-POC, or provisioned deployment environments. Secure provisioning,
-authentication, authorization, site isolation, and operational lifecycle
-controls are platform and deployment capabilities, not benefits exclusive to
-one API. The choice is between a research-oriented programming model with
-researcher-defined workflow behavior and a production-oriented path with a
-supported Client API training contract and Job Recipe workflow.
+All three paths create normal FLARE jobs and can use the same simulation, POC,
+or provisioned deployment environments. Secure provisioning, authentication,
+authorization, site isolation, and operational lifecycle controls are platform
+and deployment capabilities, not benefits exclusive to one API. The choice is
+among a research-oriented programming model with researcher-defined behavior,
+a production-oriented path with a supported Client API training contract and
+Job Recipe workflow, and lower-level component APIs for complete task and
+runtime control.
 
 At a Glance
 ===========
@@ -116,7 +141,13 @@ At a Glance
      - **Client API + Job Recipe**
      - A supported workflow and a deployment-oriented job contract; retain and
        adapt the validated local training logic from the prototype.
+   * - Implement a custom workflow or task contract with maximum runtime control
+     - :ref:`Controller <controllers>` + :ref:`Executor <executor>` APIs
+     - Explicit server-side task orchestration and client-side task execution,
+       with direct access to filters, events, payloads, and custom components.
 
 When in doubt, start with Client API + Job Recipe. Choose Collaboration API
 only when the research problem requires control beyond the supported Recipe
-workflows.
+workflows. Choose Controller + Executor only when the application requires
+lower-level task, filter, event, or component control that the high-level APIs
+do not provide.

--- a/docs/user_guide/data_scientist_guide/api_selection.rst
+++ b/docs/user_guide/data_scientist_guide/api_selection.rst
@@ -9,15 +9,15 @@ Choose an NVFLARE API Path
 NVFLARE offers two high-level ways to build federated applications. They serve
 different goals and are complementary, not interchangeable defaults.
 
-Choose Collaboration API for Research
-=====================================
+Choose Collaboration API (Technical Preview) for Research
+==========================================================
 
-Use the Collaboration API when you are a researcher exploring a new federated
-algorithm, communication pattern, or analysis workflow. Annotate client
-functions with ``@collab.publish``, express the coordinating algorithm as
-ordinary Python, and use ``CollabRecipe`` to run it. This keeps experimentation
-close to the algorithm and avoids writing Controllers, Executors, Shareables,
-or ``FLModel`` exchange code.
+Use the :ref:`Collaboration API <collab_api>` when you are a researcher
+exploring a new federated algorithm, communication pattern, or analysis
+workflow. Annotate client functions with ``@collab.publish``, express the
+coordinating algorithm as ordinary Python, and use ``CollabRecipe`` to run it.
+This keeps experimentation close to the algorithm and avoids writing
+Controllers, Executors, Shareables, or ``FLModel`` exchange code.
 
 The Collaboration API is the right starting point when the primary goal is to
 quickly test algorithmic ideas. It gives the researcher broad control over what
@@ -29,7 +29,15 @@ deployment security controls configured for that environment. Collaboration API
 does not prescribe a model-training lifecycle, aggregation strategy, or
 recipe-specific resource policy; the researcher owns those choices.
 
-Start with the :github_nvflare_link:`Hello Collab example
+Before selecting this path, review the current
+:ref:`Collaboration API limitations <collab_api_limitations>`. In particular,
+all participating sites must run a compatible NVFLARE version and authorize
+BYOC, and the standard task/result filter pipeline is not available. These
+constraints can make Client API + Job Recipe the more appropriate choice even
+for a custom application.
+
+Start with the :ref:`Collaboration API guide <collab_api>`, the
+:github_nvflare_link:`Hello Collab example
 <examples/hello-world/hello-collab>` or the :github_nvflare_link:`advanced
 Collaboration examples <examples/advanced/collab>`.
 
@@ -94,7 +102,8 @@ At a Glance
      - Start with
      - What you get
    * - Explore a new FL algorithm or communication pattern
-     - **Collaboration API** (Collab annotations + ``CollabRecipe``)
+     - :ref:`Collaboration API (Technical Preview) <collab_api>`
+       (Collab annotations + ``CollabRecipe``)
      - Direct Python expression of server coordination and client calls, with
        maximum algorithmic flexibility.
    * - Federate an existing training application for production use

--- a/docs/user_guide/data_scientist_guide/client_api_usage.rst
+++ b/docs/user_guide/data_scientist_guide/client_api_usage.rst
@@ -211,3 +211,8 @@ Learn More
 * :ref:`client_api_attach` - Connect a trainer owned by an external system
 * :mod:`nvflare.client.api` - Complete API reference documentation
 * :mod:`nvflare.app_opt.lightning.api` - PyTorch Lightning integration
+
+.. toctree::
+   :hidden:
+
+   hf_client_api

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -82,6 +82,8 @@ itself:
        valid = dict(client_results)
        for client_id, error in client_results.failures.items():
            print(f"Warning: {client_id} failed: {error}")
+       if not valid:
+           raise RuntimeError(f"all {len(client_results.failures)} client calls failed")
        all_weights = [result[0] for result in valid.values()]
        avg_weights = {k: sum(w[k] for w in all_weights) / len(all_weights) for k in all_weights[0]}
        avg_loss = sum(result[1] for result in valid.values()) / len(valid)

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -109,6 +109,7 @@ PyTorch model, data, and FedAvg implementation.
 
 
    def aggregate(client_results):
+       # Per-site call exceptions are available in client_results.failures.
        successful = list(dict(client_results).values())
        if len(successful) < MIN_CLIENTS:
            raise RuntimeError(f"only {len(successful)} client calls succeeded")
@@ -242,8 +243,9 @@ An individual ``Proxy`` call failure raises ``CollabCallError`` (site,
 function name, and cause) unless ``optional=True`` was set. A group call does
 not raise for a per-site call failure: it returns the successful results and
 records each failure in the result collection's ``failures`` dict (site name
-to ``CollabCallError``), as in ``weighted_avg`` above. Callers must check both
-``failures`` and whether any successful results remain before aggregating.
+to ``CollabCallError``). Callers must inspect ``failures`` and enforce their
+required successful-response quorum before aggregating; ``aggregate`` above
+shows the minimum quorum guard.
 For a nonblocking group call, outcomes continue to populate the live stream
 and its ``failures`` dict in the background. Iterate the stream to exhaustion
 before inspecting the complete failure set or making a final aggregation

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -10,13 +10,15 @@ Collaboration API (Technical Preview)
    in NVFlare 2.9.0. The API surface documented here may still change in a
    future release.
 
-The Collab API lets you write a federated workflow as direct, agent-to-agent
-style function calls between server and client objects, instead of the
+The Collab API lets you write a federated workflow as remote Python method
+calls between server and client objects and among peer clients, instead of the
 task/\ ``Shareable`` exchange used by the :ref:`Client API <client_api>` and
 :ref:`Job Recipe API <job_recipe>`. A server method calls a decorated client
 method as if it were local, and clients can call published methods on other
-clients in the same way. Calls return ordinary Python objects -- no manual
-``Shareable``/``DXO``/``FLModel`` packing.
+clients in the same way. Peer calls may be routed through a coordinator; this
+programming model does not imply a direct network connection. Calls return
+ordinary Python objects -- no manual ``Shareable``/``DXO``/``FLModel``
+packing.
 
 Use the Collab API when your workflow's control flow is naturally expressed
 as calls and return values -- for example fan-out/fan-in patterns with custom

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -14,8 +14,9 @@ The Collab API lets you write a federated workflow as direct, agent-to-agent
 style function calls between server and client objects, instead of the
 task/\ ``Shareable`` exchange used by the :ref:`Client API <client_api>` and
 :ref:`Job Recipe API <job_recipe>`. A server method calls a decorated client
-method as if it were local, and gets back whatever Python objects the client
-method returns -- no manual ``Shareable``/``DXO``/``FLModel`` packing.
+method as if it were local, and clients can call published methods on other
+clients in the same way. Calls return ordinary Python objects -- no manual
+``Shareable``/``DXO``/``FLModel`` packing.
 
 Use the Collab API when your workflow's control flow is naturally expressed
 as calls and return values -- for example fan-out/fan-in patterns with custom
@@ -30,20 +31,25 @@ A Collab job defines a **server object** and a **client object**. Both are
 plain Python classes (or plain module-level functions); NVFlare does not
 require them to subclass anything.
 
-* ``@collab.publish`` marks a client method as callable from the server. Its
+Decorators
+^^^^^^^^^^
+
+* ``@collab.publish`` marks a method as remotely callable through a client
+  proxy. It supports both server-to-client and client-to-client calls. Its
   parameters must be fixed (no ``*args``/``**kwargs``).
 * ``@collab.main`` marks the server's single entry point. Every Collab
   server object or module must define exactly one.
+* ``@collab.init`` / ``@collab.final`` mark methods to run once at object
+  setup and teardown.
+
+Facade Members
+^^^^^^^^^^^^^^
+
 * ``collab.clients.<method>(...)`` calls the named ``@collab.publish``
   method on every client in parallel and returns a result collection you can
   iterate as ``(client_id, result)`` pairs; a client that raises is recorded
   in ``client_results.failures`` (keyed by client ID) instead of failing the
   whole call.
-* ``CollabRecipe`` builds the job from the server and client objects, the
-  same way a concrete recipe builds a job from a model and script.
-
-Additional facade members are available inside a running Collab function:
-
 * ``collab.site_name`` -- the current site's identity.
 * ``collab.caller`` / ``collab.callee`` -- who invoked this call, and who
   it's calling.
@@ -53,8 +59,6 @@ Additional facade members are available inside a running Collab function:
   configuration.
 * ``collab.get_prop()`` / ``collab.set_prop()`` -- sharing data within a
   single call context.
-* ``@collab.init`` / ``@collab.final`` -- mark methods to run once at
-  object setup and teardown.
 
 A Minimal Example
 ------------------

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -282,6 +282,8 @@ Collab calls carry a versioned authorization envelope that only 2.9.0+ peers
 produce and accept, so there is no mixed-version compatibility path for
 Collab jobs specifically (other job types are unaffected).
 
+.. _collab_api_limitations:
+
 Limitations
 -----------
 

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -1,0 +1,174 @@
+
+.. _collab_api:
+
+Collaboration API (Technical Preview)
+======================================
+
+.. note::
+
+   The Collaboration API ("Collab API") is a **Technical Preview** introduced
+   in NVFlare 2.9.0. The API surface documented here may still change in a
+   future release.
+
+The Collab API lets you write a federated workflow as direct, agent-to-agent
+style function calls between server and client objects, instead of the
+task/\ ``Shareable`` exchange used by the :ref:`Client API <client_api>` and
+:ref:`Job Recipe API <job_recipe>`. A server method calls a decorated client
+method as if it were local, and gets back whatever Python objects the client
+method returns -- no manual ``Shareable``/``DXO``/``FLModel`` packing.
+
+Use the Collab API when your workflow's control flow is naturally expressed
+as calls and return values -- for example fan-out/fan-in patterns with custom
+per-call logic, split learning, swarm learning with client-to-client calls,
+or asynchronous aggregation. For standard FedAvg-shaped training, the
+:ref:`Job Recipe API <job_recipe>` remains the simplest path.
+
+Core Concepts
+-------------
+
+A Collab job defines a **server object** and a **client object**. Both are
+plain Python classes (or plain module-level functions); NVFlare does not
+require them to subclass anything.
+
+* ``@collab.publish`` marks a client method as callable from the server. Its
+  parameters must be fixed (no ``*args``/``**kwargs``).
+* ``@collab.main`` marks the server's single entry point. Every Collab
+  server object or module must define exactly one.
+* ``collab.clients.<method>(...)`` calls the named ``@collab.publish``
+  method on every client in parallel and returns a result collection you can
+  iterate as ``(client_id, result)`` pairs; a client that raises is recorded
+  in ``client_results.failures`` (keyed by client ID) instead of failing the
+  whole call.
+* ``CollabRecipe`` builds the job from the server and client objects, the
+  same way a concrete recipe builds a job from a model and script.
+
+Additional facade members are available inside a running Collab function,
+including ``collab.site_name``, ``collab.caller``/``collab.callee``,
+``collab.other_clients``/``collab.child_clients``/``collab.leaf_clients``,
+``collab.get_app_prop()``/``collab.set_app_prop()`` for per-site
+configuration, and ``collab.get_prop()``/``collab.set_prop()`` for sharing
+data within a single call context. ``@collab.init`` and ``@collab.final``
+mark methods to run once at object setup and teardown.
+
+A Minimal Example
+------------------
+
+This is the server and client from the runnable
+:github_nvflare_link:`Hello FedAvg with the Collab API
+<examples/hello-world/hello-collab>` example, trimmed to the FedAvg loop
+itself:
+
+.. code-block:: python
+
+   from nvflare.collab import CollabRecipe, collab, simple_logging
+   from nvflare.recipe import SimEnv
+
+
+   class Trainer:
+       @collab.publish
+       def train(self, weights=None):
+           local_epochs = collab.get_app_prop("local_epochs", 5)
+           # ... local training using `weights` as the starting point ...
+           return updated_weights, loss
+
+
+   def weighted_avg(client_results):
+       valid = dict(client_results)
+       for client_id, error in client_results.failures.items():
+           print(f"Warning: {client_id} failed: {error}")
+       all_weights = [result[0] for result in valid.values()]
+       avg_weights = {k: sum(w[k] for w in all_weights) / len(all_weights) for k in all_weights[0]}
+       avg_loss = sum(result[1] for result in valid.values()) / len(valid)
+       return avg_weights, avg_loss
+
+
+   class FedAvg:
+       def __init__(self, num_rounds=3):
+           self.num_rounds = num_rounds
+
+       @collab.main
+       def run(self):
+           global_weights = None
+           for _round_num in range(self.num_rounds):
+               client_results = collab.clients.train(global_weights)
+               global_weights, global_loss = weighted_avg(client_results)
+           return global_weights
+
+
+   simple_logging()
+   recipe = CollabRecipe(job_name="hello_fedavg", server=FedAvg(), client=Trainer(), min_clients=2)
+   run = recipe.execute(SimEnv(clients=recipe.configured_sites()))
+
+See the full, runnable example (real PyTorch model, per-site epoch
+configuration, argument parsing) at the link above.
+
+Server and client objects do not have to be classes -- ``@collab.main`` and
+``@collab.publish`` also work on plain module-level functions. When
+``server``/``client`` are omitted from ``CollabRecipe``, it uses the calling
+module's own ``@collab.main``/``@collab.publish`` functions.
+
+CollabRecipe
+------------
+
+``CollabRecipe`` is a :ref:`Recipe <recipe_api>` like any other: it exposes
+``export()``/``execute()``, accepts the standard execution environments
+(``SimEnv``, ``PocEnv``, ``ProdEnv`` from ``nvflare.recipe``), and returns the
+same ``Run`` handle. Constructor arguments a user is expected to set:
+
+* ``job_name`` -- the job's name.
+* ``server`` / ``client`` -- the server and client objects (or ``None`` to
+  auto-discover module-level ``@collab.main``/``@collab.publish``
+  functions).
+* ``min_clients`` -- minimum number of clients required for the job to run.
+* ``sync_task_timeout`` -- timeout, in seconds, for the underlying
+  synchronization task each Collab call rides on.
+* ``server_objects`` / ``client_objects`` -- additional named objects (for
+  example a model-selector or a strategy object) that a server or client
+  method needs to call into beyond the main server/client object.
+
+Because a Collab job runs your own server and client classes, it is
+inherently bring-your-own-code (BYOC): ``CollabRecipe`` packages the objects'
+source into the job automatically, and each receiving site must have BYOC
+authorized.
+
+Use ``recipe.set_per_site_config({site: {name: value}})`` (inherited from the
+base ``Recipe``) to deliver different values to different clients; a client
+reads its own value with ``collab.get_app_prop(name)``, as in the example
+above.
+
+Versioning and Authorization
+-----------------------------
+
+The Collaboration API is new in NVFlare 2.9.0. Every site participating in a
+Collab job -- server and all clients -- must run NVFlare 2.9.0 or newer:
+Collab calls carry a versioned authorization envelope that only 2.9.0+ peers
+produce and accept, so there is no mixed-version compatibility path for
+Collab jobs specifically (other job types are unaffected).
+
+Examples
+--------
+
+* :github_nvflare_link:`Hello FedAvg with the Collab API
+  <examples/hello-world/hello-collab>` -- the minimal example above, complete
+  and runnable.
+* :github_nvflare_link:`Advanced Collab examples <examples/advanced/collab>`
+  -- a table of further examples, including:
+
+  * ``simple_split_learning`` -- split learning on MNIST, with a client-side
+    bottom model and server-side top model exchanging activations and
+    gradients directly.
+  * ``async_aggregation`` -- in-time aggregation using a response callback.
+  * ``swarm`` -- decentralized swarm learning with client-to-client calls.
+  * ``pt_cifar10`` -- synchronous PyTorch FedAvg, FedProx, and SCAFFOLD
+    variants with direct client calls.
+  * ``pt_async_cifar10`` -- asynchronous PyTorch CIFAR-10 training with
+    prepared logical-client shards.
+  * ``pt_llm_sft`` -- full-parameter Hugging Face SFT with frequent direct
+    PyTorch tensor exchange and server-side FedAvg.
+
+For the design rationale behind the API, see the
+:github_nvflare_link:`Collab API design doc
+<docs/design/collab_api_design.md>`; for a step-by-step migration from local
+training code, see the
+:github_nvflare_link:`migration tutorial
+<docs/design/collab_api_migration_tutorial.md>`.

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -101,6 +101,7 @@ PyTorch model, data, and FedAvg implementation.
 
 
    class Trainer:
+       # Publish this client method under the remote name "train".
        @collab.publish
        def train(self, weights=None):
            local_epochs = collab.get_app_prop("local_epochs", 5)
@@ -126,6 +127,8 @@ PyTorch model, data, and FedAvg implementation.
        def run(self):
            global_weights = 0.0
            for _round_num in range(self.num_rounds):
+               # Invoke Trainer.train(global_weights) on every client. The
+               # argument becomes `weights`; return values are collected by site.
                client_results = collab.clients.train(global_weights)
                global_weights = aggregate(client_results)
            return global_weights
@@ -134,7 +137,7 @@ PyTorch model, data, and FedAvg implementation.
    recipe = CollabRecipe(
        job_name="collab_core",
        server=Coordinator(),
-       client=Trainer(),
+       client=Trainer(),  # supplies the published train() method to each client
        min_clients=MIN_CLIENTS,
    )
    recipe.execute(SimEnv(num_clients=MIN_CLIENTS))

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -84,74 +84,59 @@ before training calls begin.
 A Minimal Example
 ------------------
 
-This is the server and client from the runnable
+This core pattern is derived from the runnable
 :github_nvflare_link:`Hello FedAvg with the Collab API
-<examples/hello-world/hello-collab>` example, trimmed to the FedAvg loop
-itself. The placeholder local trainer keeps the snippet executable while the
-linked example contains real PyTorch training. For brevity, this version
-assumes every successful client contributes the same number of examples and
-therefore uses equal client weighting. If site dataset sizes differ, return
-each site's sample count and weight its update and loss by that count.
+<examples/hello-world/hello-collab>` example, reduced to the core Collab API
+pattern. It uses a scalar toy update so the snippet is self-contained; replace
+that line with application training. The linked example contains the complete
+PyTorch model, data, and FedAvg implementation.
 
 .. code-block:: python
 
-   from nvflare.collab import CollabRecipe, collab, simple_logging
+   from nvflare.collab import CollabRecipe, collab
    from nvflare.recipe import SimEnv
 
 
    MIN_CLIENTS = 2
 
 
-   def run_local_training(weights, local_epochs):
-       """Replace this no-op placeholder with the application's training loop."""
-       updated_weights = dict(weights or {"weight": 0.0})
-       for _epoch in range(local_epochs):
-           pass  # run one local training epoch and update `updated_weights`
-       return updated_weights, 0.0
-
-
    class Trainer:
        @collab.publish
        def train(self, weights=None):
            local_epochs = collab.get_app_prop("local_epochs", 5)
-           return run_local_training(weights, local_epochs)
+           # Replace this scalar update with application-specific local training.
+           return (weights or 0.0) + local_epochs
 
 
-   def simple_avg(client_results, min_successes):
-       valid = dict(client_results)
-       for client_id, error in client_results.failures.items():
-           print(f"Warning: {client_id} failed: {error}")
-       total_clients = len(valid) + len(client_results.failures)
-       if len(valid) < min_successes:
-           raise RuntimeError(f"only {len(valid)} of {total_clients} client calls succeeded")
-       all_weights = [result[0] for result in valid.values()]
-       avg_weights = {k: sum(w[k] for w in all_weights) / len(all_weights) for k in all_weights[0]}
-       avg_loss = sum(result[1] for result in valid.values()) / len(valid)
-       return avg_weights, avg_loss
+   def aggregate(client_results):
+       successful = list(dict(client_results).values())
+       if len(successful) < MIN_CLIENTS:
+           raise RuntimeError(f"only {len(successful)} client calls succeeded")
+       # Equal averaging is sufficient for this scalar illustration. Real FedAvg
+       # weights each update by the site's number of training examples.
+       return sum(successful) / len(successful)
 
 
-   class FedAvg:
-       def __init__(self, num_rounds=3, min_successes=MIN_CLIENTS):
+   class Coordinator:
+       def __init__(self, num_rounds=3):
            self.num_rounds = num_rounds
-           self.min_successes = min_successes
 
        @collab.main
        def run(self):
-           global_weights = None
+           global_weights = 0.0
            for _round_num in range(self.num_rounds):
                client_results = collab.clients.train(global_weights)
-               global_weights, _global_loss = simple_avg(client_results, self.min_successes)
+               global_weights = aggregate(client_results)
            return global_weights
 
 
-   simple_logging()
    recipe = CollabRecipe(
-       job_name="hello_fedavg",
-       server=FedAvg(min_successes=MIN_CLIENTS),
+       job_name="collab_core",
+       server=Coordinator(),
        client=Trainer(),
        min_clients=MIN_CLIENTS,
    )
-   run = recipe.execute(SimEnv(num_clients=MIN_CLIENTS))
+   recipe.execute(SimEnv(num_clients=MIN_CLIENTS))
 
 See the full, runnable example (real PyTorch model, per-site epoch
 configuration, argument parsing) at the link above.
@@ -175,7 +160,7 @@ same ``Run`` handle. Constructor arguments a user is expected to set:
   functions).
 * ``min_clients`` -- minimum number of clients required for the job to start.
   It does not enforce a successful-response quorum for each group call; the
-  application must check that, as ``simple_avg`` does above.
+  application must check that, as ``aggregate`` does above.
 * ``sync_task_timeout`` -- timeout, in seconds, for the startup client
   synchronization and setup tasks. It does not control remote method calls;
   set their ``timeout`` through the per-call options described below.

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -142,6 +142,66 @@ base ``Recipe``) to deliver different values to different clients; a client
 reads its own value with ``collab.get_app_prop(name)``, as in the example
 above.
 
+Advanced Usage
+--------------
+
+``collab.clients.train(...)`` above uses default call behavior: call every
+client, wait for every result, and raise if any client fails. Real
+workflows often need more control over who is called and how the call
+behaves.
+
+**Selecting clients**
+
+* ``collab.get_clients(["site-1", "site-2"])`` calls out to a named subset
+  instead of every client; it returns a ``ProxyList`` you call the same way
+  as ``collab.clients``.
+* ``collab.clients[0]`` (or any index/slice) returns individual client
+  proxies. A single proxy's method call goes to that one site only and
+  returns its result directly -- no ``(site_name, result)`` collection to
+  unwrap.
+* ``collab.other_clients``, ``collab.child_clients``, and
+  ``collab.leaf_clients`` scope a call to a topology-based subset (see
+  `Core Concepts`_ above); each also supports indexing into an individual
+  proxy.
+
+**Call options**
+
+Both ``ProxyList`` (group calls) and an individual ``Proxy`` (single-site
+calls) accept call options by calling them before the method name, for
+example ``collab.clients(blocking=False, timeout=30).train(weights)``:
+
+* ``blocking`` (group calls only, default ``True``) -- ``True`` waits for
+  every result and returns a re-iterable snapshot; ``False`` returns
+  immediately with a live, single-pass result stream you iterate as
+  results arrive.
+* ``expect_result`` (default ``True``) -- ``False`` is fire-and-forget: the
+  call returns ``None`` immediately without waiting on the remote method at
+  all.
+* ``timeout`` (default 60s) -- maximum seconds to wait for each result.
+* ``optional`` (default ``False``) -- ``True`` turns a per-site failure
+  into a logged warning and a ``None`` result instead of raising
+  ``CollabCallError``.
+* ``secure`` (default ``False``) -- routes the call over point-to-point
+  secure messaging; the site's Cell must be configured with certificates,
+  or a secure call raises.
+* ``target`` -- name of a specific collab object at the remote site to
+  call, for a site that registers more than one (via
+  ``server_objects``/``client_objects`` on ``CollabRecipe``).
+* ``parallel`` (group calls only, default unlimited) -- caps how many
+  calls may be in flight for that group call at once.
+* ``process_resp_cb`` (group calls only) -- a callback invoked as each
+  response arrives, useful for streaming/in-time aggregation instead of
+  waiting for the whole group. See the ``async_aggregation`` example
+  below.
+
+**Error handling**
+
+A failed call raises ``CollabCallError`` (site, function name, and cause)
+unless ``optional=True`` was set. For a group call, a per-site failure is
+recorded in the result collection's ``failures`` dict (site name to
+``CollabCallError``) instead of failing the other sites' results, as in
+``weighted_avg`` in the example above.
+
 Versioning and Authorization
 -----------------------------
 
@@ -150,6 +210,31 @@ Collab job -- server and all clients -- must run NVFlare 2.9.0 or newer:
 Collab calls carry a versioned authorization envelope that only 2.9.0+ peers
 produce and accept, so there is no mixed-version compatibility path for
 Collab jobs specifically (other job types are unaffected).
+
+Limitations
+-----------
+
+As a Technical Preview, the Collab API has a smaller feature set than the
+Client API / Job Recipe API path:
+
+* **No mixed-version jobs.** See `Versioning and Authorization`_ above --
+  every site must run 2.9.0 or newer.
+* **No task/result filter pipeline.** Standard NVFlare task and result
+  filters (for example differential privacy or homomorphic encryption
+  filters) attach to the ``Shareable``/``Task`` exchange, which Collab
+  calls bypass entirely. Apply any needed data transformation explicitly
+  inside your server/client methods instead.
+* **Fixed client roster.** The set of participating clients is established
+  once, when the job starts (from the execution environment's site list
+  and ``min_clients``); Collab does not support clients dynamically
+  joining or leaving mid-run.
+* **No automatic retry.** A failed call raises ``CollabCallError``
+  immediately (or is swallowed if ``optional=True``); there is no built-in
+  retry, backoff, or resume-from-checkpoint for a failed or interrupted
+  call. Retry logic, if needed, is the application's responsibility.
+* **``secure=True`` requires certificates.** A secure call needs the
+  site's Cell configured with certificates; without that, the call raises
+  rather than falling back to a non-secure transport.
 
 Examples
 --------

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -59,6 +59,16 @@ Facade Members
   call, and the receiving app or named object at the current site. The callee
   is a fully qualified target such as ``site-1`` or ``site-1.selector``; it is
   not a downstream target.
+
+  For example, inside a published method on the named ``selector`` object at
+  ``site-1``:
+
+  .. code-block:: python
+
+     collab.caller     # "server"
+     collab.callee     # "site-1.selector" (receiving object, not the method name)
+     collab.site_name  # "site-1"
+
 * ``collab.other_clients`` / ``collab.child_clients`` / ``collab.leaf_clients``
   -- site-topology lookups, for calls that fan out beyond the server.
 * ``collab.get_app_prop()`` / ``collab.set_app_prop()`` -- per-site

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -40,19 +40,23 @@ Decorators
 * ``@collab.main`` marks the server's single entry point. Every Collab
   server object or module must define exactly one.
 * ``@collab.init`` / ``@collab.final`` mark methods to run once at object
-  setup and teardown.
+  setup and teardown; see `Lifecycle Decorators`_ below.
 
 Facade Members
 ^^^^^^^^^^^^^^
 
-* ``collab.clients.<method>(...)`` calls the named ``@collab.publish``
-  method on every client in parallel and returns a result collection you can
-  iterate as ``(client_id, result)`` pairs; a client that raises is recorded
-  in ``client_results.failures`` (keyed by client ID) instead of failing the
-  whole call.
+* ``collab.clients`` is a ``ProxyList``. Call a method directly to use default
+  options (``collab.clients.train(weights)``), or call the ``ProxyList`` first
+  to set options (``collab.clients(timeout=30).train(weights)``). Both forms
+  call the named ``@collab.publish`` method on every client in parallel and
+  return a result collection you can iterate as ``(client_id, result)`` pairs;
+  a client that raises is recorded in ``client_results.failures`` (keyed by
+  client ID) instead of failing the whole call.
 * ``collab.site_name`` -- the current site's identity.
-* ``collab.caller`` / ``collab.callee`` -- who invoked this call, and who
-  it's calling.
+* ``collab.caller`` / ``collab.callee`` -- the site that invoked the current
+  call, and the receiving app or named object at the current site. The callee
+  is a fully qualified target such as ``site-1`` or ``site-1.selector``; it is
+  not a downstream target.
 * ``collab.other_clients`` / ``collab.child_clients`` / ``collab.leaf_clients``
   -- site-topology lookups, for calls that fan out beyond the server.
 * ``collab.get_app_prop()`` / ``collab.set_app_prop()`` -- per-site
@@ -60,13 +64,34 @@ Facade Members
 * ``collab.get_prop()`` / ``collab.set_prop()`` -- sharing data within a
   single call context.
 
+Lifecycle Decorators
+^^^^^^^^^^^^^^^^^^^^
+
+``@collab.init`` runs once after a site's Collab app is set up and before its
+main or published methods are called. ``@collab.final`` runs during Collab app
+teardown after normal execution or controlled end-run cleanup; a hard process
+termination cannot guarantee that finalization code runs. A lifecycle method
+may take no arguments or declare a ``context`` parameter to receive the active
+Collab call context. The runtime invokes lifecycle methods on the primary
+server/client object and on every named object registered through
+``server_objects`` or ``client_objects``.
+
+See the runnable :github_nvflare_link:`LLM SFT client
+<examples/advanced/collab/pt_llm_sft/client.py>` for an ``@collab.init`` method
+that prepares site-local data, model, trainer, dataloader, and optimizer once
+before training calls begin.
+
 A Minimal Example
 ------------------
 
 This is the server and client from the runnable
 :github_nvflare_link:`Hello FedAvg with the Collab API
 <examples/hello-world/hello-collab>` example, trimmed to the FedAvg loop
-itself:
+itself. The placeholder local trainer keeps the snippet executable while the
+linked example contains real PyTorch training. For brevity, this version
+assumes every successful client contributes the same number of examples and
+therefore uses equal client weighting. If site dataset sizes differ, return
+each site's sample count and weight its update and loss by that count.
 
 .. code-block:: python
 
@@ -74,20 +99,31 @@ itself:
    from nvflare.recipe import SimEnv
 
 
+   MIN_CLIENTS = 2
+
+
+   def run_local_training(weights, local_epochs):
+       """Replace this no-op placeholder with the application's training loop."""
+       updated_weights = dict(weights or {"weight": 0.0})
+       for _epoch in range(local_epochs):
+           pass  # run one local training epoch and update `updated_weights`
+       return updated_weights, 0.0
+
+
    class Trainer:
        @collab.publish
        def train(self, weights=None):
            local_epochs = collab.get_app_prop("local_epochs", 5)
-           # ... local training using `weights` as the starting point ...
-           return updated_weights, loss
+           return run_local_training(weights, local_epochs)
 
 
-   def weighted_avg(client_results):
+   def simple_avg(client_results, min_successes):
        valid = dict(client_results)
        for client_id, error in client_results.failures.items():
            print(f"Warning: {client_id} failed: {error}")
-       if not valid:
-           raise RuntimeError(f"all {len(client_results.failures)} client calls failed")
+       total_clients = len(valid) + len(client_results.failures)
+       if len(valid) < min_successes:
+           raise RuntimeError(f"only {len(valid)} of {total_clients} client calls succeeded")
        all_weights = [result[0] for result in valid.values()]
        avg_weights = {k: sum(w[k] for w in all_weights) / len(all_weights) for k in all_weights[0]}
        avg_loss = sum(result[1] for result in valid.values()) / len(valid)
@@ -95,21 +131,27 @@ itself:
 
 
    class FedAvg:
-       def __init__(self, num_rounds=3):
+       def __init__(self, num_rounds=3, min_successes=MIN_CLIENTS):
            self.num_rounds = num_rounds
+           self.min_successes = min_successes
 
        @collab.main
        def run(self):
            global_weights = None
            for _round_num in range(self.num_rounds):
                client_results = collab.clients.train(global_weights)
-               global_weights, global_loss = weighted_avg(client_results)
+               global_weights, _global_loss = simple_avg(client_results, self.min_successes)
            return global_weights
 
 
    simple_logging()
-   recipe = CollabRecipe(job_name="hello_fedavg", server=FedAvg(), client=Trainer(), min_clients=2)
-   run = recipe.execute(SimEnv(clients=recipe.configured_sites()))
+   recipe = CollabRecipe(
+       job_name="hello_fedavg",
+       server=FedAvg(min_successes=MIN_CLIENTS),
+       client=Trainer(),
+       min_clients=MIN_CLIENTS,
+   )
+   run = recipe.execute(SimEnv(num_clients=MIN_CLIENTS))
 
 See the full, runnable example (real PyTorch model, per-site epoch
 configuration, argument parsing) at the link above.
@@ -131,9 +173,12 @@ same ``Run`` handle. Constructor arguments a user is expected to set:
 * ``server`` / ``client`` -- the server and client objects (or ``None`` to
   auto-discover module-level ``@collab.main``/``@collab.publish``
   functions).
-* ``min_clients`` -- minimum number of clients required for the job to run.
-* ``sync_task_timeout`` -- timeout, in seconds, for the underlying
-  synchronization task each Collab call rides on.
+* ``min_clients`` -- minimum number of clients required for the job to start.
+  It does not enforce a successful-response quorum for each group call; the
+  application must check that, as ``simple_avg`` does above.
+* ``sync_task_timeout`` -- timeout, in seconds, for the startup client
+  synchronization and setup tasks. It does not control remote method calls;
+  set their ``timeout`` through the per-call options described below.
 * ``server_objects`` / ``client_objects`` -- additional named objects (for
   example a model-selector or a strategy object) that a server or client
   method needs to call into beyond the main server/client object.
@@ -146,7 +191,10 @@ authorized.
 Use ``recipe.set_per_site_config({site: {name: value}})`` (inherited from the
 base ``Recipe``) to deliver different values to different clients; a client
 reads its own value with ``collab.get_app_prop(name)``, as in the example
-above.
+above. ``recipe.configured_sites()`` is also inherited from ``Recipe`` and
+returns the site names supplied through per-site configuration. It does not
+infer clients from an execution environment; when no per-site configuration
+is set, provide ``num_clients`` or ``clients`` directly to ``SimEnv``.
 
 Advanced Usage
 --------------
@@ -161,10 +209,11 @@ need more control over who is called and how the call behaves.
 * ``collab.get_clients(["site-1", "site-2"])`` calls out to a named subset
   instead of every client; it returns a ``ProxyList`` you call the same way
   as ``collab.clients``.
-* ``collab.clients[0]`` (or any index/slice) returns individual client
-  proxies. A single proxy's method call goes to that one site only and
-  returns its result directly -- no ``(site_name, result)`` collection to
-  unwrap.
+* Integer indexing such as ``collab.clients[0]`` returns an individual client
+  proxy. A single proxy's method call goes to that one site only and returns
+  its result directly -- no ``(site_name, result)`` collection to unwrap. A
+  slice returns a plain Python list, not a callable ``ProxyList``; use
+  ``collab.get_clients([...])`` for a callable subset.
 * ``collab.other_clients``, ``collab.child_clients``, and
   ``collab.leaf_clients`` scope a call to a topology-based subset (see
   `Core Concepts`_ above); each also supports indexing into an individual
@@ -241,6 +290,10 @@ Client API / Job Recipe API path:
 
 * **No mixed-version jobs.** See `Versioning and Authorization`_ above --
   every site must run 2.9.0 or newer.
+* **BYOC authorization required.** ``CollabRecipe`` packages the supplied
+  server, client, and named-object source into the job. Every receiving site
+  must authorize BYOC for the submitting user or the job cannot run. See
+  :ref:`BYOC authorization <troubleshooting_byoc>` for deployment details.
 * **No task/result filter pipeline.** Standard NVFlare task and result
   filters (for example differential privacy or homomorphic encryption
   filters) attach to the ``Shareable``/``Task`` exchange, which Collab

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -148,9 +148,9 @@ Advanced Usage
 --------------
 
 ``collab.clients.train(...)`` above uses default call behavior: call every
-client, wait for every result, and raise if any client fails. Real
-workflows often need more control over who is called and how the call
-behaves.
+client, wait for every outcome, and return the successful results while
+recording per-client failures in the result collection. Real workflows often
+need more control over who is called and how the call behaves.
 
 **Selecting clients**
 
@@ -180,9 +180,10 @@ example ``collab.clients(blocking=False, timeout=30).train(weights)``:
   call returns ``None`` immediately without waiting on the remote method at
   all.
 * ``timeout`` (default 60s) -- maximum seconds to wait for each result.
-* ``optional`` (default ``False``) -- ``True`` turns a per-site failure
-  into a logged warning and a ``None`` result instead of raising
-  ``CollabCallError``.
+* ``optional`` (default ``False``) -- for an individual ``Proxy`` call,
+  ``True`` turns a failure into a logged warning and a ``None`` result instead
+  of raising ``CollabCallError``. Group calls report per-site failures through
+  the returned result collection as described below.
 * ``secure`` (default ``False``) -- routes the call over point-to-point
   secure messaging; the site's Cell must be configured with certificates,
   or a secure call raises.
@@ -198,11 +199,12 @@ example ``collab.clients(blocking=False, timeout=30).train(weights)``:
 
 **Error handling**
 
-A failed call raises ``CollabCallError`` (site, function name, and cause)
-unless ``optional=True`` was set. For a group call, a per-site failure is
-recorded in the result collection's ``failures`` dict (site name to
-``CollabCallError``) instead of failing the other sites' results, as in
-``weighted_avg`` in the example above.
+An individual ``Proxy`` call failure raises ``CollabCallError`` (site,
+function name, and cause) unless ``optional=True`` was set. A group call does
+not raise for a per-site call failure: it returns the successful results and
+records each failure in the result collection's ``failures`` dict (site name
+to ``CollabCallError``), as in ``weighted_avg`` above. Callers must check both
+``failures`` and whether any successful results remain before aggregating.
 
 Versioning and Authorization
 -----------------------------

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -232,10 +232,12 @@ Client API / Job Recipe API path:
   once, when the job starts (from the execution environment's site list
   and ``min_clients``); Collab does not support clients dynamically
   joining or leaving mid-run.
-* **No automatic retry.** A failed call raises ``CollabCallError``
-  immediately (or is swallowed if ``optional=True``); there is no built-in
-  retry, backoff, or resume-from-checkpoint for a failed or interrupted
-  call. Retry logic, if needed, is the application's responsibility.
+* **No automatic retry.** A failed individual call raises
+  ``CollabCallError`` immediately (or returns ``None`` if ``optional=True``),
+  while a failed group call records the per-site error in the result
+  collection's ``failures`` dict. There is no built-in retry, backoff, or
+  resume-from-checkpoint for a failed or interrupted call. Retry logic, if
+  needed, is the application's responsibility.
 * **``secure=True`` requires certificates.** A secure call needs the
   site's Cell configured with certificates; without that, the call raises
   rather than falling back to a non-secure transport.

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -291,10 +291,11 @@ Client API / Job Recipe API path:
   filters) attach to the ``Shareable``/``Task`` exchange, which Collab
   calls bypass entirely. Apply any needed data transformation explicitly
   inside your server/client methods instead.
-* **Fixed client roster.** The set of participating clients is established
-  once, when the job starts (from the execution environment's site list
-  and ``min_clients``); Collab does not support clients dynamically
-  joining or leaving mid-run.
+* **Fixed client roster.** Collab setup captures all clients assigned to the
+  running job and uses that set for the job's lifetime; clients cannot
+  dynamically join or leave the roster mid-run. ``min_clients`` is only the
+  minimum readiness threshold for starting the job and does not select the
+  roster.
 * **No automatic retry.** A failed individual call raises
   ``CollabCallError`` immediately (or returns ``None`` if ``optional=True``),
   while a failed group call records the per-site error in the result

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -179,7 +179,8 @@ example ``collab.clients(blocking=False, timeout=30).train(weights)``:
 * ``blocking`` (group calls only, default ``True``) -- ``True`` waits for
   every result and returns a re-iterable snapshot; ``False`` returns
   immediately with a live, single-pass result stream you iterate as
-  results arrive.
+  results arrive. Exhaust the stream before treating its ``failures``
+  collection as complete.
 * ``expect_result`` (default ``True``) -- ``False`` is fire-and-forget: the
   call returns ``None`` immediately without waiting on the remote method at
   all.
@@ -209,6 +210,19 @@ not raise for a per-site call failure: it returns the successful results and
 records each failure in the result collection's ``failures`` dict (site name
 to ``CollabCallError``), as in ``weighted_avg`` above. Callers must check both
 ``failures`` and whether any successful results remain before aggregating.
+For a nonblocking group call, outcomes continue to populate the live stream
+and its ``failures`` dict in the background. Iterate the stream to exhaustion
+before inspecting the complete failure set or making a final aggregation
+decision:
+
+.. code-block:: python
+
+   client_results = collab.clients(blocking=False).train(weights)
+   valid = dict(client_results)  # drains the stream and waits for every outcome
+   for client_id, error in client_results.failures.items():
+       print(f"Warning: {client_id} failed: {error}")
+   if not valid:
+       raise RuntimeError("all client calls failed")
 
 Versioning and Authorization
 -----------------------------

--- a/docs/user_guide/data_scientist_guide/collab_api.rst
+++ b/docs/user_guide/data_scientist_guide/collab_api.rst
@@ -42,13 +42,19 @@ require them to subclass anything.
 * ``CollabRecipe`` builds the job from the server and client objects, the
   same way a concrete recipe builds a job from a model and script.
 
-Additional facade members are available inside a running Collab function,
-including ``collab.site_name``, ``collab.caller``/``collab.callee``,
-``collab.other_clients``/``collab.child_clients``/``collab.leaf_clients``,
-``collab.get_app_prop()``/``collab.set_app_prop()`` for per-site
-configuration, and ``collab.get_prop()``/``collab.set_prop()`` for sharing
-data within a single call context. ``@collab.init`` and ``@collab.final``
-mark methods to run once at object setup and teardown.
+Additional facade members are available inside a running Collab function:
+
+* ``collab.site_name`` -- the current site's identity.
+* ``collab.caller`` / ``collab.callee`` -- who invoked this call, and who
+  it's calling.
+* ``collab.other_clients`` / ``collab.child_clients`` / ``collab.leaf_clients``
+  -- site-topology lookups, for calls that fan out beyond the server.
+* ``collab.get_app_prop()`` / ``collab.set_app_prop()`` -- per-site
+  configuration.
+* ``collab.get_prop()`` / ``collab.set_prop()`` -- sharing data within a
+  single call context.
+* ``@collab.init`` / ``@collab.final`` -- mark methods to run once at
+  object setup and teardown.
 
 A Minimal Example
 ------------------

--- a/docs/user_guide/data_scientist_guide/hf_client_api.rst
+++ b/docs/user_guide/data_scientist_guide/hf_client_api.rst
@@ -210,6 +210,12 @@ NumPy server.
 Distributed Training
 ====================
 
+The current HuggingFace Client API supports replicated
+``torch.distributed`` training. It does not support DeepSpeed or FSDP. This is
+a product API limitation that also applies to jobs produced by
+:ref:`Agent Conversion Skills <agent_conversion_skills>`; support for these
+strategies is planned for a future release.
+
 For multi-GPU or multi-node HuggingFace training, launch the script with
 ``torchrun`` or another launcher that initializes ``torch.distributed`` and
 sets global ``RANK``/``WORLD_SIZE`` before calling ``flare.patch(trainer)``.
@@ -296,7 +302,7 @@ override this selection after validating your environment, set
 Unsupported Configurations
 ==========================
 
-The first HuggingFace Client API implementation intentionally does not support:
+The current HuggingFace Client API does not support:
 
 * DeepSpeed;
 * FSDP;


### PR DESCRIPTION
## Summary
- Add a user guide for the Collaboration API (Technical Preview), including its core decorators and facade, `CollabRecipe` usage, authorization and versioning requirements, and runnable example links.
- Add an end-user Agent Conversion Skills guide organized into two workflow groups: deep-learning training-code conversion for plain PyTorch, PyTorch Lightning, and Hugging Face Trainer; and federated-statistics job generation from sample tabular or image data.
- Clarify that deep-learning conversion targets the Client API and Job Recipe API, not the Collaboration API.
- Organize the Agent Skills quickstart by user goal—orientation, federated job creation, AutoFL optimization, and completed-campaign reporting—and surface Agent Skills first in both the User Guide navigation and the documentation landing page.
- Clarify in both the conversion guide and Hugging Face Client API guide that DeepSpeed and FSDP are current product API limitations planned for a future release.
- Document Collaboration API group-call failure semantics accurately: successful results are returned while per-site failures are recorded and must be checked before aggregation.

The API and conversion claims are grounded in the current implementation, skill contracts, and runnable examples in this repository.

## Validation
- [x] `./build_doc.sh --html --skip-api` (build succeeded; no warnings from the changed Agent Skills pages)
- [x] Focused incremental Sphinx builds for the Agent Skills and Hugging Face Client API updates
- [x] `./runtest.sh -s` (Black, isort, Flake8, and Agent Skill lint passed)
- [x] `git diff --check`