### PR TITLE
Link FLARE Day 2026 to the event page

### DIFF
--- a/docs/industry_use_cases.rst
+++ b/docs/industry_use_cases.rst
@@ -179,7 +179,7 @@ FLARE Day is an annual event showcasing real-world federated learning deployment
 healthcare, finance, autonomous driving, and more. These talks feature practitioners sharing
 production experiences and lessons learned.
 
-- **FLARE Day 2026** -- *Coming September 2026*
+- `FLARE Day 2026 <https://events.nvidia.com/flare-day-2026>`_ -- *Coming September 2026*
 - `FLARE Day 2025 <https://developer.nvidia.com/flare-day-2025>`_ -- Real-world FL applications in healthcare, finance, autonomous driving, and more
 - `FLARE Day 2024 <https://nvidia.github.io/NVFlare/flareDay>`_ -- Talks and demos featuring real-world FL deployments at NVIDIA, healthcare institutions, and industry partners
 


### PR DESCRIPTION
## Summary
- Link "FLARE Day 2026" in the Industry Use Cases page to https://events.nvidia.com/flare-day-2026 (was previously unlinked plain text).

## Test plan
- [x] Local Sphinx build clean for docs/industry_use_cases.rst