### PR TITLE
Correct Slurm internal connection security in design doc

### DIFF
--- a/docs/design/slurm_job_launcher_design.md
+++ b/docs/design/slurm_job_launcher_design.md
@@ -18,7 +18,8 @@ Supported execution modes are:
 - trusted bare multi-node jobs with application-owned fan-out.
 
 The deployment targets one Slurm cluster, with scheduler routing controlled by trusted site policy. The internal
-worker-to-parent connection is clear TCP and runs on a trusted site network.
+worker-to-parent TCP connection uses mTLS by default. `job_launcher.internal_connection_security: clear` is an
+explicit insecure opt-out for a trusted, isolated site network.
 
 ## Main components
 


### PR DESCRIPTION
### Description

Correct the Slurm job launcher design document to match the current internal connection behavior:

- worker-to-parent TCP connections use mTLS by default
- `job_launcher.internal_connection_security: clear` is an explicit insecure opt-out for trusted, isolated networks

Runtime behavior is unchanged and existing tests already verify the mTLS default.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [x] Documentation updated.

### Validation

- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/private/tmp/uv-cache-flare3160 ./runtest.sh -s --skip-install`
- `git diff --check`
