### PR TITLE
Remove simple_logging from Collab

### DIFF
--- a/docs/design/collab_api_design.md
+++ b/docs/design/collab_api_design.md
@@ -82,7 +82,6 @@ The top-level `nvflare.collab` package exports:
 - `collab`: decorators, context accessors, proxies, and application properties.
 - `CollabCallError`: structured site/function/cause details for failed calls.
 - `CollabRecipe`: creates the normal NVFlare job.
-- `simple_logging`: convenience logging setup for examples.
 
 Execution environments come from `nvflare.recipe`, not `nvflare.collab`:
 

--- a/examples/advanced/collab/async_aggregation/async_aggregation.py
+++ b/examples/advanced/collab/async_aggregation/async_aggregation.py
@@ -27,7 +27,7 @@ import argparse
 from collab.async_aggregation.avg_intime import NPFedAvgInTime
 from collab.async_aggregation.trainer import NPTrainer
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 
@@ -49,7 +49,6 @@ def main():
     parser.add_argument("--num-clients", type=int, default=2)
     parser.add_argument("--num-rounds", type=int, default=2)
     args = parser.parse_args()
-    simple_logging()
     run = make_recipe(args).execute(SimEnv(num_clients=args.num_clients))
     print("Job Status:", run.get_status())
     print("Results at:", run.get_result())

--- a/examples/advanced/collab/pt_async_cifar10/job.py
+++ b/examples/advanced/collab/pt_async_cifar10/job.py
@@ -21,7 +21,6 @@ From the ``examples/advanced/collab/pt_async_cifar10`` directory:
 """
 
 import argparse
-import logging
 from pathlib import Path
 
 from async_aggregator import Cifar10AsyncAggregator
@@ -29,7 +28,7 @@ from data import validate_prepared_data
 from prepare_data import DEFAULT_DATA_ROOT
 from trainer import Cifar10Trainer
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 JOB_NAME = "collab_pt_async_cifar10"
@@ -138,7 +137,6 @@ def main():
     args = define_parser().parse_args()
     args.data_root = str(Path(args.data_root).expanduser().resolve())
     manifest = validate_prepared_data(args.data_root)
-    simple_logging(logging.INFO)
     recipe = make_recipe(args, manifest)
     clients_per_round = args.num_clients if args.clients_per_round is None else args.clients_per_round
 

--- a/examples/advanced/collab/pt_cifar10/fedavg/job.py
+++ b/examples/advanced/collab/pt_cifar10/fedavg/job.py
@@ -14,7 +14,7 @@
 
 """Run the synchronous CIFAR-10 FedAvg Collab example."""
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 from .client import FedAvgClient
@@ -35,7 +35,6 @@ def make_recipe() -> CollabRecipe:
 
 
 def main():
-    simple_logging()
     run = make_recipe().execute(SimEnv(num_clients=NUM_CLIENTS))
     print("Job Status:", run.get_status())
     print("Results at:", run.get_result())

--- a/examples/advanced/collab/pt_cifar10/fedprox/job.py
+++ b/examples/advanced/collab/pt_cifar10/fedprox/job.py
@@ -14,7 +14,7 @@
 
 """Run the synchronous CIFAR-10 FedProx Collab example."""
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 from ..fedavg.server import FedAvgServer
@@ -35,7 +35,6 @@ def make_recipe() -> CollabRecipe:
 
 
 def main():
-    simple_logging()
     run = make_recipe().execute(SimEnv(num_clients=NUM_CLIENTS))
     print("Job Status:", run.get_status())
     print("Results at:", run.get_result())

--- a/examples/advanced/collab/pt_cifar10/scaffold/job.py
+++ b/examples/advanced/collab/pt_cifar10/scaffold/job.py
@@ -14,7 +14,7 @@
 
 """Run the synchronous CIFAR-10 SCAFFOLD Collab example."""
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 from .client import ScaffoldClient
@@ -34,7 +34,6 @@ def make_recipe() -> CollabRecipe:
 
 
 def main():
-    simple_logging()
     run = make_recipe().execute(SimEnv(num_clients=NUM_CLIENTS))
     print("Job Status:", run.get_status())
     print("Results at:", run.get_result())

--- a/examples/advanced/collab/pt_llm_sft/job.py
+++ b/examples/advanced/collab/pt_llm_sft/job.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from client import LLMSFTClient
 from server import SFTFedAvg
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 DEFAULT_DATA_ROOT = "/tmp/nvflare/collab/pt_llm_sft/data"
@@ -109,7 +109,6 @@ def main() -> None:
     args.data_root = Path(args.data_root).expanduser().resolve()
     args.output_root = Path(args.output_root).expanduser().resolve()
 
-    simple_logging()
     print(
         "Starting Collab full-parameter SFT simulation\n"
         f"  model: {args.model_name_or_path}\n"

--- a/examples/advanced/collab/simple_split_learning/simple_split_learning.py
+++ b/examples/advanced/collab/simple_split_learning/simple_split_learning.py
@@ -31,7 +31,7 @@ import torch.optim as optim
 from torch.utils.data import default_collate
 from torchvision import datasets, transforms
 
-from nvflare.collab import CollabRecipe, collab, simple_logging
+from nvflare.collab import CollabRecipe, collab
 from nvflare.recipe import SimEnv
 
 BATCH_SIZE = 64
@@ -118,7 +118,6 @@ def make_recipe():
 
 
 def main():
-    simple_logging()
     run = make_recipe().execute(SimEnv(num_clients=1))
     print("Job Status:", run.get_status())
     print("Results at:", run.get_result())

--- a/examples/advanced/vertical_federated_learning/cifar10-splitnn/job.py
+++ b/examples/advanced/vertical_federated_learning/cifar10-splitnn/job.py
@@ -15,14 +15,13 @@
 """Run two-party CIFAR-10 SplitNN training with a CollabRecipe."""
 
 import argparse
-import logging
 from pathlib import Path
 
 from client import BATCH_SIZE, CALL_TIMEOUT, NUM_STEPS, SplitNNClient
 from data import get_intersection_file
 from server import SplitNNServer
 
-from nvflare.collab import CollabRecipe, simple_logging
+from nvflare.collab import CollabRecipe
 from nvflare.recipe import SimEnv
 
 JOB_NAME = "cifar10_splitnn"
@@ -91,7 +90,6 @@ def make_recipe(dataset_root: str, split_dir: str) -> CollabRecipe:
 def main():
     """Build the recipe from prepared SplitNN data artifacts and simulate it."""
     args = define_parser().parse_args()
-    simple_logging(logging.INFO)
     recipe = make_recipe(args.dataset_root, args.split_dir)
 
     print("=" * 80)

--- a/examples/hello-world/hello-collab/job.py
+++ b/examples/hello-world/hello-collab/job.py
@@ -40,7 +40,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 
-from nvflare.collab import CollabRecipe, collab, simple_logging
+from nvflare.collab import CollabRecipe, collab
 from nvflare.recipe import SimEnv
 
 
@@ -136,7 +136,6 @@ def main():
     parser.add_argument("--num-clients", type=int, default=2)
     parser.add_argument("--num-rounds", type=int, default=3)
     args = parser.parse_args()
-    simple_logging()
     recipe = make_recipe(args)
     run = recipe.execute(make_env(recipe))
     print("Job Status:", run.get_status())

--- a/nvflare/collab/__init__.py
+++ b/nvflare/collab/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 from typing import TYPE_CHECKING
 
 from .api.facade import Facade as collab
@@ -24,13 +23,7 @@ __all__ = [
     "collab",
     "CollabCallError",
     "CollabRecipe",
-    "simple_logging",
 ]
-
-
-def simple_logging(level=logging.INFO):
-    """Configure basic stdout logging for example and user scripts."""
-    logging.basicConfig(level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 
 # The user-facing classes are exported here so users never need implementation

--- a/tests/unit_test/collab/public_imports_test.py
+++ b/tests/unit_test/collab/public_imports_test.py
@@ -23,13 +23,12 @@ import sys
 
 
 def test_top_level_exports():
-    from nvflare.collab import CollabCallError, CollabRecipe, collab, simple_logging
+    from nvflare.collab import CollabCallError, CollabRecipe, collab
 
     for export in (
         collab,
         CollabCallError,
         CollabRecipe,
-        simple_logging,
     ):
         assert export is not None
 
@@ -126,7 +125,7 @@ def test_collab_public_surface_does_not_require_torch():
         "from nvflare.collab.api import Context, GroupCallContext\n"
         "import nvflare.collab.runtime.controller\n"
         "import nvflare.collab.runtime.executor\n"
-        "from nvflare.collab import CollabRecipe, simple_logging\n"
+        "from nvflare.collab import CollabRecipe\n"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
 


### PR DESCRIPTION
## Summary

- remove the `simple_logging` helper from the Collab public API
- remove unnecessary logging setup from Collab examples
- update the public API test and design documentation

Collab examples run inside an NVFlare job, where logging is already configured by the runtime.

## Testing

- `python -m pytest tests/unit_test/collab/public_imports_test.py -q` (6 passed)
- `python -m collab.async_aggregation.async_aggregation --num-clients 2 --num-rounds 1` (completed; server and client INFO logs appeared in the terminal and job logs)
- targeted Black, isort, and Flake8 checks for all changed Python files
- `git diff --check`