### PR TITLE
Honor schema objective during AutoFL initialization

### DIFF
--- a/skills/nvflare-autofl/SKILL.md
+++ b/skills/nvflare-autofl/SKILL.md
@@ -46,14 +46,21 @@ Before editing or running a job, verify that the path is an existing NVFLARE `jo
 Resolve [run_job_campaign.py](scripts/run_job_campaign.py) relative to this `SKILL.md`, store its absolute path as `RUNNER`, and initialize the campaign:
 
 ```bash
-python "$RUNNER" initialize ./job.py [--metric <metric>] --env <sim|poc|prod> [--max-candidates <n>]
+python "$RUNNER" initialize ./job.py --metric <metric> --env <sim|poc|prod> [--max-candidates <n>]
 ```
+
+Pass the user's requested objective through `--metric`; do not rely on the job's key metric when the user named a
+different objective. If `mutation_schema.yaml` declares `objective.requested_metric`, the runner adopts it when the
+flag is omitted, but an explicit user objective still belongs in the command for auditable provenance.
 
 Campaign direction comes from `job.py` `key_metric_mode` or a same-metric `stop_cond`; NVFLARE defaults to `max`.
 Declare raw loss metrics with `key_metric_mode="min"`; explicitly negated metrics remain ordinary `max` metrics. For conditional
 recipes, safe refusals, and unnamed simulator roots, read the [job import contract](references/job-import-contract.md).
 
-Read `autofl.yaml` and the JSON response, then prepare an agent-authored candidate with a short hypothesis and optional candidate-only arguments:
+Read `autofl.yaml`, `.nvflare/autofl/campaign_state.json`, and the JSON response. Before preparing a candidate, verify
+that `requested_metric`, `optimization_metric`, direction, environment, and any user-specified candidate cap match the
+request. Stop before candidate training if any resolved field differs. Then prepare an agent-authored candidate with a
+short hypothesis and optional candidate-only arguments:
 
 ```bash
 python "$RUNNER" prepare ./job.py --name <candidate> --hypothesis "<expected improvement>" [--run-args "<args>"] [--family <slug>] [--literature-event <id>]
@@ -158,4 +165,3 @@ On import or validation failure, fix the reported contract issue without bypassi
 ## Stop Handling
 
 Finalize only when state reports `final_response_allowed=true` for stop, cap, policy, or blocker; then hand off to `nvflare-autofl-report`. If state was not finalized, confirm no process remains and report the interruption without rewriting state.
-

--- a/skills/nvflare-autofl/scripts/run_job_campaign.py
+++ b/skills/nvflare-autofl/scripts/run_job_campaign.py
@@ -2021,6 +2021,22 @@ def load_mutation_schema(cwd: Path) -> Dict[str, Any]:
     return read_yaml(path)
 
 
+def requested_metric_from_schema(schema: Dict[str, Any]) -> Optional[str]:
+    objective = schema.get("objective")
+    if objective is None:
+        return None
+    if not isinstance(objective, dict):
+        raise ValueError("mutation_schema.yaml objective must be a mapping")
+    requested = objective.get("requested_metric")
+    if requested is None:
+        requested = objective.get("metric")
+    if requested is None:
+        return None
+    if not isinstance(requested, str) or not requested.strip():
+        raise ValueError("mutation_schema.yaml objective.requested_metric must be a non-empty string")
+    return requested.strip()
+
+
 def apply_mutation_schema_contract(config: Dict[str, Any], schema: Dict[str, Any], workspace: Path) -> Dict[str, Any]:
     preferred_targets = schema.get("preferred_targets")
     if preferred_targets is None:
@@ -3550,6 +3566,8 @@ def prepare_initial_campaign(args: argparse.Namespace, job: Path) -> None:
         raise ValueError("--confirm-user-approved-cap-change is not valid for an initial campaign cap")
     paths = campaign_paths(args, job)
     schema = load_mutation_schema(job.parent)
+    if args.metric is None:
+        args.metric = requested_metric_from_schema(schema)
     timeout, _ = campaign_timeout(args, schema)
     config = import_job_config(
         args,

--- a/tests/unit_test/tool/autofl_skill_runner_test.py
+++ b/tests/unit_test/tool/autofl_skill_runner_test.py
@@ -3500,7 +3500,7 @@ def test_prepare_and_status_never_request_simulation_runner_approval(tmp_path, m
             assert runner.main(["status", str(job)]) == 0
 
 
-def test_omitted_metric_uses_imported_job_metric(tmp_path, monkeypatch):
+def test_omitted_metric_without_schema_uses_imported_job_metric(tmp_path, monkeypatch):
     runner = _load_runner()
     job = tmp_path / "job.py"
     job.write_text("print('job')\n", encoding="utf-8")
@@ -3530,6 +3530,65 @@ def test_omitted_metric_uses_imported_job_metric(tmp_path, monkeypatch):
     assert runner.main(["initialize", str(job)]) == 0
     metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
     assert metadata["settings"]["metric"] == "auc"
+
+
+def test_omitted_metric_adopts_mutation_schema_requested_metric(tmp_path, monkeypatch):
+    runner = _load_runner()
+    job = tmp_path / "job.py"
+    job.write_text("print('job')\n", encoding="utf-8")
+    tmp_path.joinpath("client.py").write_text("ALGORITHM = 'baseline'\n", encoding="utf-8")
+    tmp_path.joinpath("mutation_schema.yaml").write_text(
+        """
+objective:
+  requested_metric: val_auc
+  optimization_metric: val_auc
+  metric_extraction_order: [val_auc]
+""".lstrip(),
+        encoding="utf-8",
+    )
+    config = _campaign_config()
+    config["objective"] = {
+        "metric": "val_auc",
+        "requested_metric": "val_auc",
+        "optimization_metric": "val_auc",
+        "metric_extraction_order": ["val_auc"],
+        "mode": "max",
+        "mode_contract_source": "core_default",
+        "job_key_metric": "train_proxy_auc",
+        "job_key_metric_source": "literal",
+        "metric_contract_source": "user_request",
+    }
+
+    def fake_import(args, *unused, **kwargs):
+        assert args.metric == "val_auc"
+        return deepcopy(config)
+
+    monkeypatch.setattr(runner, "import_job_config", fake_import)
+    monkeypatch.setattr(runner, "job_help", lambda *args, **kwargs: "")
+    monkeypatch.setattr(runner, "write_progress", lambda path, *args: path.write_bytes(b"progress"))
+    monkeypatch.setattr(
+        runner,
+        "run_job",
+        lambda run_def, **kwargs: runner.RunRecord(
+            "baseline", run_def.name, 0.6, 1.0, "none", "baseline", "python job.py", "/tmp/baseline"
+        ),
+    )
+
+    assert runner.main(["initialize", str(job), "--max-candidates", "1"]) == 0
+
+    metadata = json.loads(tmp_path.joinpath(".nvflare/autofl/campaign.json").read_text(encoding="utf-8"))
+    resolved = runner.read_yaml(tmp_path / "autofl.yaml")["objective"]
+    assert metadata["settings"]["metric"] == "val_auc"
+    assert metadata["settings"]["max_candidates"] == 1
+    assert resolved["requested_metric"] == "val_auc"
+    assert resolved["optimization_metric"] == "val_auc"
+
+
+def test_requested_metric_from_schema_rejects_invalid_value():
+    runner = _load_runner()
+
+    with pytest.raises(ValueError, match="requested_metric must be a non-empty string"):
+        runner.requested_metric_from_schema({"objective": {"requested_metric": []}})
 
 
 def test_explicit_mutable_campaign_settings_persist_and_uncapped_removes_cap(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- require the user-requested metric in the AutoFL initialization workflow
- adopt `mutation_schema.yaml` requested metric when `--metric` is omitted
- verify resolved campaign fields before candidate training
- add regression coverage for schema fallback and invalid values

## Regression evidence
MF07 repeatedly optimized the imported job proxy metric when an agent omitted `--metric val_auc`, despite the authoritative mutation schema carrying the user objective.

## Tests
- targeted AutoFL metric tests: 3 passed
- full runner file: 231 passed; 2 unrelated end-to-end tests could not import optional `torch` in the local environment
- `./runtest.sh -s` (passed; one advisory SKILL.md size info)