### PR TITLE
Stabilize Recipe script packaging and POC lifecycle

### DIFF
--- a/nvflare/job_config/base_app_config.py
+++ b/nvflare/job_config/base_app_config.py
@@ -32,6 +32,7 @@ class BaseAppConfig(ABC):
         self.task_result_filters = []  # list of tuples: (task_set, list of filters)
         self.components: Dict[str, object] = {}
         self.ext_scripts = []
+        self._ext_script_destinations = {}
         self.ext_dirs = []
         self.file_sources = []
         self.handlers: [FLComponent] = []
@@ -60,6 +61,14 @@ class BaseAppConfig(ABC):
             raise RuntimeError(f"Could not locate external script: {ext_script}")
 
         self.ext_scripts.append(ext_script)
+
+    def _set_ext_script_destination(self, ext_script: str, destination: str):
+        """Keep an explicit packaged path for a registered external script."""
+        if ext_script not in self.ext_scripts:
+            raise RuntimeError(f"external script is not registered: {ext_script}")
+        destinations = self._ext_script_destinations.setdefault(ext_script, [])
+        if destination not in destinations:
+            destinations.append(destination)
 
     def add_ext_dir(self, ext_dir: str):
         if not (os.path.isdir(ext_dir) and os.path.exists(ext_dir)):

--- a/nvflare/job_config/fed_job_config.py
+++ b/nvflare/job_config/fed_job_config.py
@@ -318,7 +318,11 @@ class FedJobConfig:
             json_dump = json.dumps(server_app, indent=4)
             outfile.write(json_dump)
 
-        self._copy_ext_scripts(custom_dir, fed_app.server_app.ext_scripts)
+        self._copy_ext_scripts(
+            custom_dir,
+            fed_app.server_app.ext_scripts,
+            fed_app.server_app._ext_script_destinations,
+        )
         self._copy_ext_dirs(custom_dir, fed_app.server_app)
         self._copy_file_sources(config_dir, custom_dir, fed_app.server_app.file_sources)
 
@@ -348,45 +352,57 @@ class FedJobConfig:
                 # this is a dir
                 shutil.copytree(src_path, dest_path, dirs_exist_ok=True)
 
-    def _copy_ext_scripts(self, custom_dir, ext_scripts):
+    def _copy_ext_scripts(self, custom_dir, ext_scripts, ext_script_destinations=None):
+        ext_script_destinations = ext_script_destinations or {}
+        copied_registrations = set()
         for script in ext_scripts:
             if os.path.exists(script):
-                if os.path.isabs(script):
+                relative_scripts = ext_script_destinations.get(script)
+                if relative_scripts:
                     source_file = self._resolved_path(script)
-                    relative_script = self._get_relative_script(source_file)
+                    source_path_for_root = source_file
+                elif os.path.isabs(script):
+                    source_file = self._resolved_path(script)
+                    relative_scripts = [self._get_relative_script(source_file)]
                     source_path_for_root = source_file
                 else:
                     source_file = script
-                    relative_script = script
+                    relative_scripts = [script]
                     source_path_for_root = os.path.abspath(script)
-                relative_script = os.path.normpath(relative_script)
-                if (
-                    relative_script in ("", os.curdir)
-                    or os.path.isabs(relative_script)
-                    or relative_script == os.pardir
-                    or relative_script.startswith(os.pardir + os.sep)
-                ):
-                    raise ValueError(f"Invalid external script path: {script}")
+                for relative_script in relative_scripts:
+                    relative_script = os.path.normpath(relative_script)
+                    if (
+                        relative_script in ("", os.curdir)
+                        or os.path.isabs(relative_script)
+                        or relative_script == os.pardir
+                        or relative_script.startswith(os.pardir + os.sep)
+                    ):
+                        raise ValueError(f"Invalid external script path: {script}")
 
-                dest_file = os.path.join(custom_dir, relative_script)
-                module_path = relative_script[:-3] if relative_script.endswith(".py") else relative_script
-                if os.path.basename(module_path) == "__init__" and os.path.dirname(module_path):
-                    module_path = os.path.dirname(module_path)
-                module = module_path.replace(os.sep, ".")
-                path_depth = len(module_path.split(os.sep))
-                if os.path.basename(source_file) != "__init__.py":
-                    path_depth -= 1
-                source_root = os.path.dirname(source_path_for_root)
-                for _ in range(path_depth):
-                    source_root = os.path.dirname(source_root)
-                self._copy_source_file(
-                    custom_dir,
-                    module,
-                    source_file,
-                    dest_file,
-                    source_root=source_root,
-                    is_external_script=True,
-                )
+                    registration = (source_file, relative_script)
+                    if registration in copied_registrations:
+                        continue
+                    copied_registrations.add(registration)
+
+                    dest_file = os.path.join(custom_dir, relative_script)
+                    module_path = relative_script[:-3] if relative_script.endswith(".py") else relative_script
+                    if os.path.basename(module_path) == "__init__" and os.path.dirname(module_path):
+                        module_path = os.path.dirname(module_path)
+                    module = module_path.replace(os.sep, ".")
+                    path_depth = len(module_path.split(os.sep))
+                    if os.path.basename(source_file) != "__init__.py":
+                        path_depth -= 1
+                    source_root = os.path.dirname(source_path_for_root)
+                    for _ in range(path_depth):
+                        source_root = os.path.dirname(source_root)
+                    self._copy_source_file(
+                        custom_dir,
+                        module,
+                        source_file,
+                        dest_file,
+                        source_root=source_root,
+                        is_external_script=True,
+                    )
 
     def _copy_ext_dirs(self, custom_dir, app_config: BaseAppConfig):
         for dir in app_config.ext_dirs:
@@ -626,7 +642,11 @@ class FedJobConfig:
             json_dump = json.dumps(client_app, indent=4)
             outfile.write(json_dump)
 
-        self._copy_ext_scripts(custom_dir, fed_app.client_app.ext_scripts)
+        self._copy_ext_scripts(
+            custom_dir,
+            fed_app.client_app.ext_scripts,
+            fed_app.client_app._ext_script_destinations,
+        )
         self._copy_ext_dirs(custom_dir, fed_app.client_app)
         self._copy_file_sources(config_dir, custom_dir, fed_app.client_app.file_sources)
 

--- a/nvflare/job_config/script_runner.py
+++ b/nvflare/job_config/script_runner.py
@@ -158,17 +158,37 @@ class ScriptRunner:
         self._execution_mode = execution_mode
         self._params_exchange_format = params_exchange_format
 
-    def _external_process_argv(self) -> list[str]:
+    def _external_process_argv(self, packaged_script_path: Optional[str]) -> list[str]:
         command = _to_external_process_argv(self._command, "command")
-        script = os.path.basename(self._script) if os.path.isabs(self._script) else self._script
+        # Preserve the established external-process command for an absolute script
+        # that is expected to exist only on the target production client.
+        script = packaged_script_path
+        if script is None:
+            script = os.path.basename(self._script) if os.path.isabs(self._script) else self._script
         command.append(f"custom/{script}")
         command.extend(_to_external_process_argv(self._script_args, "script_args"))
         return command
+
+    def _packaged_script_path(self, job: FedJob) -> Optional[str]:
+        """Choose a stable client-relative path only when this process can bundle the script."""
+        # Match FedApp._add_resource(), which intentionally gives directories
+        # precedence when a filesystem abstraction reports both classifications.
+        if os.path.isdir(self._script):
+            return None
+        if not os.path.isfile(self._script):
+            return None
+        if os.path.isabs(self._script):
+            # Freeze the exporter's established sys.path-relative destination now.
+            # The authoring environment may change before export, and separate source
+            # directories must not collapse to the same basename.
+            return job.job._get_relative_script(self._script)
+        return self._script
 
     def add_to_fed_job(self, job: FedJob, ctx, **kwargs):
         """Adds the configured ClientAPIExecutor and script resource to the job."""
         job.check_kwargs(args_to_check=kwargs, args_expected={"tasks": False})
         tasks = kwargs.get("tasks", ["*"])
+        packaged_script_path = self._packaged_script_path(job)
 
         common_args = {
             "execution_mode": self._execution_mode,
@@ -179,7 +199,7 @@ class ScriptRunner:
             "cuda_empty_cache": self._cuda_empty_cache,
         }
         if self._execution_mode == ExecutionMode.EXTERNAL_PROCESS:
-            command = self._external_process_argv()
+            command = self._external_process_argv(packaged_script_path)
             _fill_additional_node_command(job, ctx.target, command, self._launch_once)
             executor = ClientAPIExecutor(
                 command=command,
@@ -189,12 +209,22 @@ class ScriptRunner:
                 **common_args,
             )
         else:
+            # Locally available absolute paths identify authoring-machine source files,
+            # so execute their bundled relative path. An unavailable absolute path is a
+            # supported reference to a script pre-installed on a production client.
+            task_script_path = packaged_script_path or self._script
             executor = ClientAPIExecutor(
-                task_script_path=self._script,
+                task_script_path=task_script_path,
                 task_script_args=self._script_args,
                 **common_args,
             )
 
         job.add_executor(executor, tasks=tasks, ctx=ctx)
         job.add_resources(resources=[self._script], ctx=ctx)
+        if packaged_script_path is not None:
+            # ScriptRunner and the exporter are part of the same job-config layer. Store
+            # the selected destination privately so packaging cannot derive a different
+            # path later from a changed working directory or sys.path.
+            app_config = job._get_app(ctx).app_config
+            app_config._set_ext_script_destination(self._script, packaged_script_path)
         return {}

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -28,9 +28,11 @@ from nvflare.job_config.api import FedJob
 from nvflare.recipe.spec import ExecEnv
 from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
+    POC_START_READY_TIMEOUT,
     _clean_poc,
     _start_poc,
     _stop_poc,
+    _wait_for_poc_system_ready,
     get_poc_workspace,
     get_prod_dir,
     is_poc_running,
@@ -42,7 +44,6 @@ from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 from .session_mgr import SessionManager
 
 STOP_POC_TIMEOUT = 10
-SERVICE_START_TIMEOUT = 3
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _WORKSPACE_BACKUP_PREFIX = ".nvflare-recipe-backup-"
 
@@ -222,6 +223,16 @@ class PocEnv(ExecEnv):
                 excluded=[self.username],
                 services_list=[],
             )
+            project_config, service_config = setup_service_config(self.poc_workspace)
+            if not _wait_for_poc_system_ready(
+                self.poc_workspace,
+                project_config,
+                service_config,
+                services_list=[],
+                excluded=[self.username],
+                timeout_in_sec=POC_START_READY_TIMEOUT,
+            ):
+                raise RuntimeError("POC services were started but no server or clients were selected for readiness")
         except BaseException:
             if self._check_poc_running():
                 self.stop(clean_up=False)
@@ -255,9 +266,6 @@ class PocEnv(ExecEnv):
             if workspace_backup:
                 shutil.rmtree(workspace_backup, ignore_errors=True)
         self.logger.info("POC services started successfully")
-
-        # Give services time to start up
-        time.sleep(SERVICE_START_TIMEOUT)
 
         # Submit job using SessionManager
         return self._get_session_manager().submit_job(job)

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -31,6 +31,7 @@ from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
     POC_START_READY_TIMEOUT,
     _clean_poc,
+    _docker_cli_env,
     _is_live_pid_file,
     _start_poc,
     _stop_poc,
@@ -186,6 +187,7 @@ class PocEnv(ExecEnv):
                 text=True,
                 timeout=5,
                 check=False,
+                env=_docker_cli_env(),
             )
         except (OSError, subprocess.TimeoutExpired):
             return False

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -14,6 +14,7 @@
 
 import os
 import shutil
+import subprocess
 import threading
 import time
 import uuid
@@ -33,6 +34,7 @@ from nvflare.tool.poc.poc_commands import (
     _is_live_pid_file,
     _start_poc,
     _stop_poc,
+    _wait_for_poc_system_ready,
     get_poc_workspace,
     get_prod_dir,
     is_poc_running,
@@ -175,11 +177,29 @@ class PocEnv(ExecEnv):
         os.replace(backup, self.poc_workspace)
 
     @staticmethod
+    def _is_docker_service_running(service_name: str) -> bool:
+        """Return whether Docker reports the named POC container as running."""
+        try:
+            result = subprocess.run(
+                ["docker", "inspect", "--format", "{{.State.Running}}", service_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+    @staticmethod
     def _running_services(project_config: dict, service_config: dict, poc_workspace: str) -> list[str]:
         """Return managed POC services whose local process is still alive."""
+        service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+        if service_config.get(SC.IS_DOCKER_RUN):
+            return [name for name in service_names if PocEnv._is_docker_service_running(name)]
+
         project_name = project_config.get("name")
         prod_dir = get_prod_dir(poc_workspace, project_name)
-        service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
         running = []
         for service_name in service_names:
             service_dir = os.path.join(prod_dir, service_name)
@@ -268,9 +288,19 @@ class PocEnv(ExecEnv):
             )
             project_config, service_config = setup_service_config(self.poc_workspace)
             self._wait_for_services_ready(project_config, service_config)
+            if not _wait_for_poc_system_ready(
+                self.poc_workspace,
+                project_config,
+                service_config,
+                services_list=[],
+                excluded=[self.username],
+                timeout_in_sec=POC_START_READY_TIMEOUT,
+            ):
+                raise RuntimeError("POC services were started but no server or clients were selected for readiness")
             # Successful submission proves that the admin connection is ready,
-            # in addition to the local process-health check above. Keep the
-            # retained workspace backup until both checks have passed.
+            # in addition to the process/container and client-registration
+            # checks above. Keep the retained workspace backup until all checks
+            # and submission have passed.
             job_id = self._get_session_manager().submit_job(job)
         except BaseException:
             if self._check_poc_running():
@@ -345,7 +375,9 @@ class PocEnv(ExecEnv):
             # the server exited during startup, stop any surviving local client
             # processes directly so the workspace can be restored safely.
             services_list = []
-            if not is_poc_running(self.poc_workspace, service_config, project_config):
+            if service_config.get(SC.IS_DOCKER_RUN) or not is_poc_running(
+                self.poc_workspace, service_config, project_config
+            ):
                 services_list = self._running_services(project_config, service_config, self.poc_workspace)
             _stop_poc(
                 poc_workspace=self.poc_workspace,

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -30,9 +30,9 @@ from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
     POC_START_READY_TIMEOUT,
     _clean_poc,
+    _is_live_pid_file,
     _start_poc,
     _stop_poc,
-    _wait_for_poc_system_ready,
     get_poc_workspace,
     get_prod_dir,
     is_poc_running,
@@ -44,6 +44,8 @@ from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 from .session_mgr import SessionManager
 
 STOP_POC_TIMEOUT = 10
+POC_READY_POLL_INTERVAL = 0.2
+POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _WORKSPACE_BACKUP_PREFIX = ".nvflare-recipe-backup-"
 
@@ -172,6 +174,47 @@ class PocEnv(ExecEnv):
             os.remove(self.poc_workspace)
         os.replace(backup, self.poc_workspace)
 
+    @staticmethod
+    def _running_services(project_config: dict, service_config: dict, poc_workspace: str) -> list[str]:
+        """Return managed POC services whose local process is still alive."""
+        project_name = project_config.get("name")
+        prod_dir = get_prod_dir(poc_workspace, project_name)
+        service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+        running = []
+        for service_name in service_names:
+            service_dir = os.path.join(prod_dir, service_name)
+            if _is_live_pid_file(os.path.join(service_dir, "pid.fl")) or _is_live_pid_file(
+                os.path.join(service_dir, "daemon_pid.fl")
+            ):
+                running.append(service_name)
+        return running
+
+    def _wait_for_services_ready(self, project_config: dict, service_config: dict) -> None:
+        """Wait until every managed service remains alive through a stabilization interval."""
+        expected_services = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+        if not expected_services:
+            raise RuntimeError("POC provisioning did not configure a server or clients")
+
+        deadline = time.monotonic() + POC_START_READY_TIMEOUT
+        all_running_since = None
+        running_services = []
+        while time.monotonic() < deadline:
+            running_services = self._running_services(project_config, service_config, self.poc_workspace)
+            if set(running_services) == set(expected_services):
+                if all_running_since is None:
+                    all_running_since = time.monotonic()
+                elif time.monotonic() - all_running_since >= POC_READY_STABLE_INTERVAL:
+                    return
+            else:
+                all_running_since = None
+            time.sleep(POC_READY_POLL_INTERVAL)
+
+        missing_services = sorted(set(expected_services) - set(running_services))
+        raise RuntimeError(
+            f"POC services did not remain healthy within {POC_START_READY_TIMEOUT} seconds; "
+            f"not running: {', '.join(missing_services)}"
+        )
+
     def deploy(self, job: FedJob) -> str:
         """Deploy a FedJob to the POC environment.
 
@@ -224,15 +267,11 @@ class PocEnv(ExecEnv):
                 services_list=[],
             )
             project_config, service_config = setup_service_config(self.poc_workspace)
-            if not _wait_for_poc_system_ready(
-                self.poc_workspace,
-                project_config,
-                service_config,
-                services_list=[],
-                excluded=[self.username],
-                timeout_in_sec=POC_START_READY_TIMEOUT,
-            ):
-                raise RuntimeError("POC services were started but no server or clients were selected for readiness")
+            self._wait_for_services_ready(project_config, service_config)
+            # Successful submission proves that the admin connection is ready,
+            # in addition to the local process-health check above. Keep the
+            # retained workspace backup until both checks have passed.
+            job_id = self._get_session_manager().submit_job(job)
         except BaseException:
             if self._check_poc_running():
                 self.stop(clean_up=False)
@@ -266,9 +305,7 @@ class PocEnv(ExecEnv):
             if workspace_backup:
                 shutil.rmtree(workspace_backup, ignore_errors=True)
         self.logger.info("POC services started successfully")
-
-        # Submit job using SessionManager
-        return self._get_session_manager().submit_job(job)
+        return job_id
 
     def _check_poc_running(self) -> bool:
         """Check if POC services are currently running.
@@ -282,10 +319,7 @@ class PocEnv(ExecEnv):
             # POC workspace is not initialized yet, so we don't need to stop and clean it
             return False
 
-        if not is_poc_running(self.poc_workspace, service_config, project_config):
-            return False
-
-        return True
+        return bool(self._running_services(project_config, service_config, self.poc_workspace))
 
     def stop(self, clean_up: bool = False) -> None:
         """Try to stop and clean existing POC.
@@ -307,16 +341,22 @@ class PocEnv(ExecEnv):
         try:
             project_config, service_config = setup_service_config(self.poc_workspace)
             self.logger.info("Stopping existing POC services...")
+            # Prefer the coordinated server shutdown while it is reachable. If
+            # the server exited during startup, stop any surviving local client
+            # processes directly so the workspace can be restored safely.
+            services_list = []
+            if not is_poc_running(self.poc_workspace, service_config, project_config):
+                services_list = self._running_services(project_config, service_config, self.poc_workspace)
             _stop_poc(
                 poc_workspace=self.poc_workspace,
                 excluded=[self.username],  # Exclude admin console (consistent with start)
-                services_list=[],
+                services_list=services_list,
             )
             count = 0
             poc_running = True
             while count < STOP_POC_TIMEOUT:
                 try:
-                    if not is_poc_running(self.poc_workspace, service_config, project_config):
+                    if not self._running_services(project_config, service_config, self.poc_workspace):
                         poc_running = False
                         break
                 except Exception:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -139,7 +139,9 @@ class PocEnv(ExecEnv):
 
         self.clients = v.clients
         self.num_clients = len(v.clients) if v.clients is not None else v.num_clients
-        self.poc_workspace = get_poc_workspace()
+        # Keep transactional backups beside the workspace even when the
+        # configured path has a trailing separator.
+        self.poc_workspace = os.path.normpath(get_poc_workspace())
         self.gpu_ids = v.gpu_ids or []
         self.use_he = v.use_he
         self.project_conf_path = v.project_conf_path
@@ -169,6 +171,24 @@ class PocEnv(ExecEnv):
         os.replace(self.poc_workspace, backup)
         return backup
 
+    def _validate_project_conf_location(self) -> None:
+        """Reject a project config that workspace replacement would move away."""
+        if not self.project_conf_path:
+            return
+
+        workspace = os.path.abspath(self.poc_workspace)
+        project_conf = os.path.abspath(os.path.expanduser(self.project_conf_path))
+        resolved_workspace = os.path.realpath(workspace)
+        resolved_project_conf = os.path.realpath(project_conf)
+        if (
+            os.path.commonpath([workspace, project_conf]) == workspace
+            or os.path.commonpath([resolved_workspace, resolved_project_conf]) == resolved_workspace
+        ):
+            raise ValueError(
+                f"project_conf_path must be outside the POC workspace {self.poc_workspace!r}; "
+                "the workspace is replaced during deployment"
+            )
+
     def _restore_existing_workspace(self, backup: str) -> None:
         """Discard a partial replacement and atomically restore the retained workspace."""
         if os.path.isdir(self.poc_workspace) and not os.path.islink(self.poc_workspace):
@@ -189,9 +209,23 @@ class PocEnv(ExecEnv):
                 check=False,
                 env=_docker_cli_env(),
             )
-        except (OSError, subprocess.TimeoutExpired):
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise RuntimeError(f"Could not determine Docker POC service state for {service_name!r}") from error
+
+        state = result.stdout.strip().lower()
+        if result.returncode == 0 and state in ("true", "false"):
+            return state == "true"
+
+        error_message = (getattr(result, "stderr", "") or result.stdout).strip()
+        if result.returncode != 0 and any(
+            marker in error_message.lower() for marker in ("no such object", "no such container")
+        ):
             return False
-        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+        detail = f": {error_message}" if error_message else ""
+        raise RuntimeError(
+            f"Could not determine Docker POC service state for {service_name!r} "
+            f"(docker inspect exited {result.returncode}){detail}"
+        )
 
     @staticmethod
     def _running_services(project_config: dict, service_config: dict, poc_workspace: str) -> list[str]:
@@ -261,6 +295,8 @@ class PocEnv(ExecEnv):
                 f"The following scripts do not exist locally: {non_local_scripts}. "
                 f"For PocEnv, all scripts must be present on the local machine."
             )
+
+        self._validate_project_conf_location()
 
         if self._check_poc_running():
             # Keep the stopped workspace until fresh provisioning succeeds, so

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -197,6 +197,19 @@ class PocEnv(ExecEnv):
             os.remove(self.poc_workspace)
         os.replace(backup, self.poc_workspace)
 
+    def _raise_rollback_error(self, workspace_backup: Optional[str], error: Exception, reason: str) -> None:
+        """Preserve recovery artifacts and report their locations when rollback is unsafe."""
+        self._workspace_owned = True
+        backup_note = (
+            f"the retained workspace backup remains at {workspace_backup}"
+            if workspace_backup
+            else "there was no retained workspace to back up"
+        )
+        raise RuntimeError(
+            f"POC deployment failed and {reason}; "
+            f"the partial replacement remains at {self.poc_workspace}; {backup_note}"
+        ) from error
+
     @staticmethod
     def _is_docker_service_running(service_name: str) -> bool:
         """Return whether Docker reports the named POC container as running."""
@@ -347,20 +360,30 @@ class PocEnv(ExecEnv):
                 # Do not replace or delete either workspace when service state
                 # is unknown. The active path belongs to this invocation, and
                 # the retained backup remains available for manual recovery.
-                self._workspace_owned = True
-                backup_note = (
-                    f"the retained workspace backup remains at {workspace_backup}"
-                    if workspace_backup
-                    else "there was no retained workspace to back up"
+                self._raise_rollback_error(
+                    workspace_backup,
+                    state_error,
+                    "the state of partially started services could not be determined",
                 )
-                raise RuntimeError(
-                    f"POC deployment failed and the state of partially started services could not be determined; "
-                    f"the partial replacement remains at {self.poc_workspace}; {backup_note}"
-                ) from state_error
 
             if poc_running:
-                self.stop(clean_up=False)
-                if self._check_poc_running():
+                try:
+                    self.stop(clean_up=False)
+                except Exception as stop_error:
+                    self._raise_rollback_error(
+                        workspace_backup,
+                        stop_error,
+                        "partially started services could not be safely stopped",
+                    )
+                try:
+                    poc_running = self._check_poc_running()
+                except Exception as state_error:
+                    self._raise_rollback_error(
+                        workspace_backup,
+                        state_error,
+                        "the state of partially started services could not be determined after stopping",
+                    )
+                if poc_running:
                     self._workspace_owned = True
                     backup_note = (
                         f"the retained workspace backup remains at {workspace_backup}"

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -341,7 +341,24 @@ class PocEnv(ExecEnv):
             # and submission have passed.
             job_id = self._get_session_manager().submit_job(job)
         except BaseException:
-            if self._check_poc_running():
+            try:
+                poc_running = self._check_poc_running()
+            except Exception as state_error:
+                # Do not replace or delete either workspace when service state
+                # is unknown. The active path belongs to this invocation, and
+                # the retained backup remains available for manual recovery.
+                self._workspace_owned = True
+                backup_note = (
+                    f"the retained workspace backup remains at {workspace_backup}"
+                    if workspace_backup
+                    else "there was no retained workspace to back up"
+                )
+                raise RuntimeError(
+                    f"POC deployment failed and the state of partially started services could not be determined; "
+                    f"the partial replacement remains at {self.poc_workspace}; {backup_note}"
+                ) from state_error
+
+            if poc_running:
                 self.stop(clean_up=False)
                 if self._check_poc_running():
                     self._workspace_owned = True

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import threading
 import time
+import uuid
 from typing import Optional
 
 from pydantic import BaseModel, conint, model_validator
@@ -43,6 +44,7 @@ from .session_mgr import SessionManager
 STOP_POC_TIMEOUT = 10
 SERVICE_START_TIMEOUT = 3
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
+_WORKSPACE_BACKUP_PREFIX = ".nvflare-recipe-backup-"
 
 
 # Internal — not part of the public API
@@ -140,6 +142,34 @@ class PocEnv(ExecEnv):
         self.study = v.study
         self._session_manager = None  # Lazy initialization
         self._session_manager_lock = threading.Lock()
+        self._deployment_started = False
+        self._workspace_owned = False
+
+    @property
+    def deployment_started(self) -> bool:
+        """Whether the latest deploy call passed preflight and began POC preparation."""
+        return self._deployment_started
+
+    @property
+    def workspace_owned(self) -> bool:
+        """Whether the latest deploy created or replaced the active POC workspace."""
+        return self._workspace_owned
+
+    def _backup_existing_workspace(self) -> Optional[str]:
+        """Move a retained workspace aside before provisioning mutates its path."""
+        if not os.path.exists(self.poc_workspace):
+            return None
+        backup = f"{self.poc_workspace}{_WORKSPACE_BACKUP_PREFIX}{uuid.uuid4().hex}"
+        os.replace(self.poc_workspace, backup)
+        return backup
+
+    def _restore_existing_workspace(self, backup: str) -> None:
+        """Discard a partial replacement and atomically restore the retained workspace."""
+        if os.path.isdir(self.poc_workspace) and not os.path.islink(self.poc_workspace):
+            shutil.rmtree(self.poc_workspace)
+        elif os.path.lexists(self.poc_workspace):
+            os.remove(self.poc_workspace)
+        os.replace(backup, self.poc_workspace)
 
     def deploy(self, job: FedJob) -> str:
         """Deploy a FedJob to the POC environment.
@@ -153,6 +183,11 @@ class PocEnv(ExecEnv):
         Raises:
             ValueError: If scripts do not exist locally.
         """
+        # Reset before non-mutating preflight so callers can distinguish a
+        # rejected job from an invocation that owns a new POC lifecycle.
+        self._deployment_started = False
+        self._workspace_owned = False
+
         # Validate scripts exist locally for POC
         non_local_scripts = collect_non_local_scripts(job)
         if non_local_scripts:
@@ -162,25 +197,63 @@ class PocEnv(ExecEnv):
             )
 
         if self._check_poc_running():
-            self.stop(clean_up=True)
+            # Keep the stopped workspace until fresh provisioning succeeds, so
+            # a failed replacement can restore its prior logs and results.
+            self.stop(clean_up=False)
+            if self._check_poc_running():
+                raise RuntimeError("Existing POC services could not be stopped")
 
+        self._deployment_started = True
+        workspace_backup = self._backup_existing_workspace()
         self.logger.info("Preparing and starting fresh POC services...")
-        prepare_poc_provision(
-            clients=self.clients or [],  # Empty list if None, let prepare_clients generate
-            number_of_clients=self.num_clients,
-            workspace=self.poc_workspace,
-            docker_image=self.docker_image,
-            use_he=self.use_he,
-            project_conf_path=self.project_conf_path,
-            examples_dir=None,
-        )
-
-        _start_poc(
-            poc_workspace=self.poc_workspace,
-            gpu_ids=self.gpu_ids,
-            excluded=[self.username],
-            services_list=[],
-        )
+        try:
+            prepare_poc_provision(
+                clients=self.clients or [],  # Empty list if None, let prepare_clients generate
+                number_of_clients=self.num_clients,
+                workspace=self.poc_workspace,
+                docker_image=self.docker_image,
+                use_he=self.use_he,
+                project_conf_path=self.project_conf_path,
+                examples_dir=None,
+            )
+            _start_poc(
+                poc_workspace=self.poc_workspace,
+                gpu_ids=self.gpu_ids,
+                excluded=[self.username],
+                services_list=[],
+            )
+        except BaseException:
+            if self._check_poc_running():
+                self.stop(clean_up=False)
+                if self._check_poc_running():
+                    self._workspace_owned = True
+                    backup_note = (
+                        f"the retained workspace backup remains at {workspace_backup}"
+                        if workspace_backup
+                        else "there was no retained workspace to restore"
+                    )
+                    raise RuntimeError(
+                        f"POC deployment failed and partially started services could not be stopped; " f"{backup_note}"
+                    )
+            if workspace_backup:
+                try:
+                    self._restore_existing_workspace(workspace_backup)
+                except Exception as restore_error:
+                    # The active path contains only this invocation's partial
+                    # replacement. Let the caller clean it, but retain the
+                    # backup for manual recovery.
+                    self._workspace_owned = True
+                    raise RuntimeError(
+                        f"POC deployment failed and the retained workspace could not be restored from {workspace_backup}"
+                    ) from restore_error
+                self._workspace_owned = False
+            else:
+                self._workspace_owned = True
+            raise
+        else:
+            self._workspace_owned = True
+            if workspace_backup:
+                shutil.rmtree(workspace_backup, ignore_errors=True)
         self.logger.info("POC services started successfully")
 
         # Give services time to start up

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -2128,8 +2128,49 @@ def _env_with_cli_python_path() -> Dict[str, str]:
     return my_env
 
 
+def _docker_cli_env() -> Dict[str, str]:
+    """Build an environment that targets the daemon selected by POC Docker startup scripts."""
+    docker_env = _env_with_cli_python_path()
+    socket_override = docker_env.get("NVFL_DOCKER_SOCK")
+    if not socket_override:
+        return docker_env
+
+    docker_endpoint = docker_env.get("DOCKER_HOST", "")
+    if not docker_endpoint:
+        # Match start_docker.sh: an active remote context keeps controlling
+        # the outer Docker CLI, while a local context uses the explicit POC
+        # socket override as its endpoint.
+        try:
+            context_result = subprocess.run(
+                ["docker", "context", "show"],
+                env=docker_env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            context_name = context_result.stdout.strip() if context_result.returncode == 0 else ""
+            if context_name:
+                endpoint_result = subprocess.run(
+                    ["docker", "context", "inspect", context_name, "--format", "{{.Endpoints.docker.Host}}"],
+                    env=docker_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=False,
+                )
+                if endpoint_result.returncode == 0:
+                    docker_endpoint = endpoint_result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            docker_endpoint = ""
+
+    if not docker_endpoint or docker_endpoint.startswith("unix://"):
+        docker_env["DOCKER_HOST"] = f"unix://{socket_override}"
+    return docker_env
+
+
 def prepare_env(service_name, gpu_ids: Optional[List[int]], service_config: Dict):
-    my_env = _env_with_cli_python_path()
+    my_env = _docker_cli_env() if service_config.get(SC.IS_DOCKER_RUN) else _env_with_cli_python_path()
     if gpu_ids:
         my_env["CUDA_VISIBLE_DEVICES"] = ",".join([str(gid) for gid in gpu_ids])
 
@@ -2192,7 +2233,7 @@ def _run_stop_command(service_name: str, cmd_path: str, timeout: float):
     try:
         completed = subprocess.run(
             cmd_path.split(" "),
-            env=_env_with_cli_python_path(),
+            env=_docker_cli_env(),
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -2166,6 +2166,11 @@ def _docker_cli_env() -> Dict[str, str]:
 
     if not docker_endpoint or docker_endpoint.startswith("unix://"):
         docker_env["DOCKER_HOST"] = f"unix://{socket_override}"
+        # Docker gives DOCKER_CONTEXT precedence over DOCKER_HOST. The POC
+        # startup script uses an explicit --host for this local override, so
+        # remove the context selector to give lifecycle commands the same
+        # endpoint precedence.
+        docker_env.pop("DOCKER_CONTEXT", None)
     return docker_env
 
 

--- a/research/fed-bpt/fedbpt_recipe.py
+++ b/research/fed-bpt/fedbpt_recipe.py
@@ -148,18 +148,21 @@ class FedBPTRecipe(Recipe):
         job.to_server(TBAnalyticsReceiver(events=["fed.analytix_log_stats"]), id="receiver")
         job.to_server(RegisterDecomposer(), id="register_decomposer")
 
-        runner = ScriptRunner(
-            script=TRAIN_SCRIPT,
-            script_args=self.train_args,
-            launch_external_process=True,
-            command="python3 -u",
-            framework=FrameworkType.NUMPY,
-            server_expected_format=ExchangeFormat.NUMPY,
-            params_transfer_type=TransferType.FULL,
-            launch_once=True,
-            shutdown_timeout=10.0,
-        )
-        job.to_clients(runner, tasks=["train"])
+        # Keep the source root active while ScriptRunner freezes the path used by
+        # both client configuration and job packaging.
+        with _temporary_sys_path(SRC_DIR):
+            runner = ScriptRunner(
+                script=TRAIN_SCRIPT,
+                script_args=self.train_args,
+                launch_external_process=True,
+                command="python3 -u",
+                framework=FrameworkType.NUMPY,
+                server_expected_format=ExchangeFormat.NUMPY,
+                params_transfer_type=TransferType.FULL,
+                launch_once=True,
+                shutdown_timeout=10.0,
+            )
+            job.to_clients(runner, tasks=["train"])
         job.to_clients(RegisterDecomposer(), id="register_decomposer")
         super().__init__(job)
 

--- a/tests/unit_test/job_config/base_app_config_test.py
+++ b/tests/unit_test/job_config/base_app_config_test.py
@@ -35,6 +35,23 @@ class TestBaseAppConfig:
         self.app_config.add_ext_script(script)
         assert script in self.app_config.ext_scripts
 
+    def test_set_ext_script_destination(self):
+        script = "/scripts/sample.py"
+        self.app_config.add_ext_script(script)
+
+        self.app_config._set_ext_script_destination(script, "sample.py")
+
+        assert self.app_config._ext_script_destinations == {script: ["sample.py"]}
+
+        self.app_config._set_ext_script_destination(script, "nested/sample.py")
+        self.app_config._set_ext_script_destination(script, "sample.py")
+
+        assert self.app_config._ext_script_destinations == {script: ["sample.py", "nested/sample.py"]}
+
+    def test_set_ext_script_destination_requires_registered_script(self):
+        with pytest.raises(RuntimeError, match="external script is not registered"):
+            self.app_config._set_ext_script_destination("/scripts/missing.py", "missing.py")
+
     def test_add_ext_script_error(self):
         script = "scripts/sample.py"
         with pytest.raises(Exception):

--- a/tests/unit_test/job_config/script_runner_test.py
+++ b/tests/unit_test/job_config/script_runner_test.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import sys
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -544,6 +545,132 @@ class TestExecutionModeSelection:
         config = json.loads(config_path.read_text())
 
         assert config["executors"][0]["executor"]["args"]["command"] == expected
+
+    @pytest.mark.parametrize("execution_mode", ["in_process", "external_process"])
+    def test_absolute_script_destination_survives_sys_path_change(self, tmp_path, monkeypatch, execution_mode):
+        from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+        from nvflare.job_config.api import FedJob
+
+        source_dir = tmp_path / "src"
+        source_dir.mkdir()
+        script = source_dir / "client.py"
+        script.write_text("# test trainer\n")
+        original_sys_path = list(sys.path)
+        monkeypatch.setattr(sys, "path", [str(tmp_path), *original_sys_path])
+
+        job = FedJob(name=f"stable-{execution_mode}")
+        job.to_server(ScatterAndGather(min_clients=1, num_rounds=1, wait_time_after_min_received=0))
+        job.to_clients(ScriptRunner(script=str(script), execution_mode=execution_mode))
+
+        # Export under a different import root. Configuration and packaging must
+        # continue using the single destination selected when the runner was added.
+        monkeypatch.setattr(sys, "path", [str(source_dir), *original_sys_path])
+        export_dir = tmp_path / "export"
+        job.export_job(str(export_dir))
+
+        job_dir = export_dir / job.name
+        config = json.loads((job_dir / "app" / "config" / "config_fed_client.json").read_text())
+        executor_args = config["executors"][0]["executor"]["args"]
+        if execution_mode == "external_process":
+            assert executor_args["command"][2] == "custom/src/client.py"
+        else:
+            assert executor_args["task_script_path"] == "src/client.py"
+        assert (job_dir / "app" / "custom" / "src" / "client.py").is_file()
+        assert not (job_dir / "app" / "custom" / "client.py").exists()
+
+    def test_missing_absolute_in_process_script_remains_a_production_client_path(self, tmp_path):
+        from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor
+        from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+        from nvflare.job_config.api import FedJob
+
+        remote_script = "/preinstalled/scripts/remote_train.py"
+        job = FedJob(name="remote-script")
+        job.to_server(ScatterAndGather(min_clients=1, num_rounds=1, wait_time_after_min_received=0))
+        job.to_clients(ScriptRunner(script=remote_script, execution_mode="in_process"))
+
+        app_config = job._deploy_map["@ALL"].app_config
+        executor = app_config.executors[0].executor
+        assert isinstance(executor, ClientAPIExecutor)
+        assert executor._task_script_path == remote_script
+        assert app_config._ext_script_destinations == {}
+
+        export_dir = tmp_path / "export"
+        job.export_job(str(export_dir))
+        config = json.loads((export_dir / job.name / "app" / "config" / "config_fed_client.json").read_text())
+        assert config["executors"][0]["executor"]["args"]["task_script_path"] == remote_script
+        assert not list((export_dir / job.name / "app" / "custom").rglob("remote_train.py"))
+
+    def test_distinct_absolute_scripts_keep_unique_relative_destinations(self, tmp_path, monkeypatch):
+        from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+        from nvflare.job_config.api import FedJob
+
+        project_dir = tmp_path / "project"
+        site_1_dir = project_dir / "site-1"
+        site_2_dir = project_dir / "site-2"
+        site_1_dir.mkdir(parents=True)
+        site_2_dir.mkdir(parents=True)
+        site_1_script = site_1_dir / "client.py"
+        site_2_script = site_2_dir / "client.py"
+        site_1_script.write_text("SITE = 1\n")
+        site_2_script.write_text("SITE = 2\n")
+        monkeypatch.setattr(sys, "path", [str(project_dir)])
+
+        job = FedJob(name="unique-scripts")
+        job.to_server(ScatterAndGather(min_clients=1, num_rounds=1, wait_time_after_min_received=0))
+        job.to_clients(ScriptRunner(script=str(site_1_script), execution_mode="in_process"), tasks=["site-1-train"])
+        job.to_clients(ScriptRunner(script=str(site_2_script), execution_mode="in_process"), tasks=["site-2-train"])
+        export_dir = tmp_path / "export"
+        job.export_job(str(export_dir))
+
+        job_dir = export_dir / job.name
+        config = json.loads((job_dir / "app" / "config" / "config_fed_client.json").read_text())
+        task_paths = [entry["executor"]["args"]["task_script_path"] for entry in config["executors"]]
+        assert task_paths == ["site-1/client.py", "site-2/client.py"]
+        assert (job_dir / "app" / "custom" / "site-1" / "client.py").read_text() == "SITE = 1\n"
+        assert (job_dir / "app" / "custom" / "site-2" / "client.py").read_text() == "SITE = 2\n"
+
+    def test_same_absolute_script_is_copied_to_each_frozen_destination(self, tmp_path, monkeypatch):
+        from nvflare.app_common.workflows.scatter_and_gather import ScatterAndGather
+        from nvflare.job_config.api import FedJob
+
+        project_dir = tmp_path / "project"
+        source_dir = project_dir / "src"
+        source_dir.mkdir(parents=True)
+        script = source_dir / "client.py"
+        script.write_text("VALUE = 1\n")
+
+        job = FedJob(name="reused-script")
+        job.to_server(ScatterAndGather(min_clients=1, num_rounds=1, wait_time_after_min_received=0))
+        monkeypatch.setattr(sys, "path", [str(project_dir)])
+        job.to_clients(ScriptRunner(script=str(script), execution_mode="in_process"), tasks=["nested-train"])
+        monkeypatch.setattr(sys, "path", [str(source_dir)])
+        job.to_clients(ScriptRunner(script=str(script), execution_mode="in_process"), tasks=["flat-train"])
+
+        export_dir = tmp_path / "export"
+        job.export_job(str(export_dir))
+
+        job_dir = export_dir / job.name
+        config = json.loads((job_dir / "app" / "config" / "config_fed_client.json").read_text())
+        task_paths = [entry["executor"]["args"]["task_script_path"] for entry in config["executors"]]
+        assert task_paths == ["src/client.py", "client.py"]
+        assert (job_dir / "app" / "custom" / "src" / "client.py").read_text() == "VALUE = 1\n"
+        assert (job_dir / "app" / "custom" / "client.py").read_text() == "VALUE = 1\n"
+
+    def test_resource_classification_matches_directory_precedence(self):
+        from nvflare.job_config.api import FedJob
+
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.exists", return_value=True),
+        ):
+            job = FedJob(name="filesystem-abstraction")
+            job.to_clients(ScriptRunner(script="client.py", execution_mode="in_process"))
+
+        app_config = job._deploy_map["@ALL"].app_config
+        assert app_config.ext_scripts == []
+        assert app_config.ext_dirs == ["client.py"]
+        assert app_config._ext_script_destinations == {}
 
     def test_launch_flag_conflicts_with_explicit_in_process_mode(self):
         with pytest.raises(ValueError, match="launch_external_process=True requires"):

--- a/tests/unit_test/recipe/fedavg_recipe_test.py
+++ b/tests/unit_test/recipe/fedavg_recipe_test.py
@@ -1492,7 +1492,9 @@ class TestFedAvgRecipeExternalProcessStartup:
             assert train_executor_args["command"][:2] == ["python3", "-u"]
             assert train_executor_args["command"][-2:] == ["--epochs", "1"]
         else:
-            assert train_executor_args["task_script_path"] == str(train_script)
+            # The merged argv contract keeps token boundaries while this PR's
+            # packaging contract points the executor at the bundled script.
+            assert train_executor_args["task_script_path"] == train_script.name
             assert train_executor_args["task_script_args"] == ["--epochs", "1"]
 
 

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -226,13 +226,17 @@ def test_failed_readiness_restores_retained_workspace(tmp_path, monkeypatch):
 
     monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
     monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
-    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: ({"name": "poc"}, {"admin": "a"}))
     monkeypatch.setattr(
         poc_env_module,
-        "_wait_for_poc_system_ready",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("POC did not become ready")),
+        "setup_service_config",
+        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
     )
     env = PocEnv()
+    monkeypatch.setattr(
+        env,
+        "_wait_for_services_ready",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("POC did not become ready")),
+    )
 
     with pytest.raises(RuntimeError, match="did not become ready"):
         env.deploy(object())
@@ -244,7 +248,7 @@ def test_failed_readiness_restores_retained_workspace(tmp_path, monkeypatch):
     assert not list(tmp_path.glob("readiness-failure-workspace.nvflare-recipe-backup-*"))
 
 
-def test_successful_readiness_discards_backup_only_after_health_check(tmp_path, monkeypatch):
+def test_successful_submission_discards_backup_only_after_health_check(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
     workspace = tmp_path / "healthy-workspace"
@@ -258,18 +262,28 @@ def test_successful_readiness_discards_backup_only_after_health_check(tmp_path, 
         workspace.mkdir()
         (workspace / "new-workspace.txt").write_text("new")
 
-    def verify_ready(*args, **kwargs):
+    def assert_backup_retained():
         backups = list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
         assert len(backups) == 1
         assert (backups[0] / "prior-result.txt").read_text() == "old"
-        return True
+
+    def verify_ready(*args, **kwargs):
+        assert_backup_retained()
+
+    def submit_job(job):
+        assert_backup_retained()
+        return "job-id"
 
     monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
     monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
-    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: ({"name": "poc"}, {"admin": "a"}))
-    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", verify_ready)
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
+    )
     env = PocEnv()
-    monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=lambda job: "job-id"))
+    monkeypatch.setattr(env, "_wait_for_services_ready", verify_ready)
+    monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=submit_job))
 
     assert env.deploy(object()) == "job-id"
 
@@ -277,6 +291,56 @@ def test_successful_readiness_discards_backup_only_after_health_check(tmp_path, 
     assert (workspace / "new-workspace.txt").read_text() == "new"
     assert not (workspace / "prior-result.txt").exists()
     assert not list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
+
+
+def test_failed_submission_restores_retained_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "submission-failure-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
+
+    def prepare_replacement(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
+    )
+    env = PocEnv()
+    monkeypatch.setattr(env, "_wait_for_services_ready", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        env,
+        "_get_session_manager",
+        lambda: SimpleNamespace(submit_job=lambda job: (_ for _ in ()).throw(RuntimeError("job submission failed"))),
+    )
+
+    with pytest.raises(RuntimeError, match="job submission failed"):
+        env.deploy(object())
+
+    assert env.workspace_owned is False
+    assert (workspace / "prior-result.txt").read_text() == "old"
+    assert not (workspace / "partial-result.txt").exists()
+    assert not list(tmp_path.glob("submission-failure-workspace.nvflare-recipe-backup-*"))
+
+
+def test_wait_for_services_ready_rejects_an_exited_client(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    env = PocEnv()
+    monkeypatch.setattr(poc_env_module, "POC_START_READY_TIMEOUT", 0.01)
+    monkeypatch.setattr(poc_env_module, "POC_READY_POLL_INTERVAL", 0.001)
+    monkeypatch.setattr(env, "_running_services", lambda *args: ["server"])
+
+    with pytest.raises(RuntimeError, match="not running: site-1"):
+        env._wait_for_services_ready({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]})
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
@@ -324,12 +388,11 @@ def test_get_admin_startup_kit_path_not_found(mock_setup, mock_get_prod_dir, moc
 def test_stop_poc(mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup):
     """Test stop and clean POC functionality."""
     mock_setup.return_value = ({"name": "test"}, {"server": "server"})
-    # Mock is_poc_running to return True initially (POC is running),
-    # then False (POC stops successfully after _stop_poc is called)
-    mock_is_running.side_effect = [True, False]
+    mock_is_running.return_value = True
 
     env = PocEnv()
-    env.stop(clean_up=True)
+    with patch.object(PocEnv, "_running_services", side_effect=[["server"], []]):
+        env.stop(clean_up=True)
 
     mock_stop_poc.assert_called_once_with(
         poc_workspace=env.poc_workspace, excluded=["admin@nvidia.com"], services_list=[]

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -207,6 +208,75 @@ def test_failed_start_restores_retained_workspace(tmp_path, monkeypatch):
     assert env.workspace_owned is False
     assert (workspace / "prior-result.txt").read_text() == "old"
     assert not list(tmp_path.glob("start-failure-workspace.nvflare-recipe-backup-*"))
+
+
+def test_failed_readiness_restores_retained_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "readiness-failure-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
+
+    def prepare_replacement(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: ({"name": "poc"}, {"admin": "a"}))
+    monkeypatch.setattr(
+        poc_env_module,
+        "_wait_for_poc_system_ready",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("POC did not become ready")),
+    )
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        env.deploy(object())
+
+    assert env.deployment_started is True
+    assert env.workspace_owned is False
+    assert (workspace / "prior-result.txt").read_text() == "old"
+    assert not (workspace / "partial-result.txt").exists()
+    assert not list(tmp_path.glob("readiness-failure-workspace.nvflare-recipe-backup-*"))
+
+
+def test_successful_readiness_discards_backup_only_after_health_check(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "healthy-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
+
+    def prepare_replacement(**kwargs):
+        workspace.mkdir()
+        (workspace / "new-workspace.txt").write_text("new")
+
+    def verify_ready(*args, **kwargs):
+        backups = list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
+        assert len(backups) == 1
+        assert (backups[0] / "prior-result.txt").read_text() == "old"
+        return True
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: ({"name": "poc"}, {"admin": "a"}))
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", verify_ready)
+    env = PocEnv()
+    monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=lambda job: "job-id"))
+
+    assert env.deploy(object()) == "job-id"
+
+    assert env.workspace_owned is True
+    assert (workspace / "new-workspace.txt").read_text() == "new"
+    assert not (workspace / "prior-result.txt").exists()
+    assert not list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -272,6 +272,81 @@ def test_rollback_state_error_preserves_partial_workspace_and_backup(tmp_path, m
     assert (backups[0] / "prior-result.txt").read_text() == "old"
 
 
+def test_post_stop_state_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "unknown-post-stop-state-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+
+    def write_then_fail(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+        raise RuntimeError("provisioning failed after partial writes")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
+    env = PocEnv()
+    state_checks = iter([False, True, RuntimeError("Docker inspection unavailable after stop")])
+
+    def check_state():
+        result = next(state_checks)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    stop_calls = []
+    monkeypatch.setattr(env, "_check_poc_running", check_state)
+    monkeypatch.setattr(env, "stop", lambda clean_up: stop_calls.append(clean_up))
+
+    with pytest.raises(RuntimeError, match="could not be determined after stopping") as exc_info:
+        env.deploy(object())
+
+    backups = list(tmp_path.glob("unknown-post-stop-state-workspace.nvflare-recipe-backup-*"))
+    assert stop_calls == [False]
+    assert len(backups) == 1
+    assert str(backups[0]) in str(exc_info.value)
+    assert env.workspace_owned is True
+    assert (workspace / "partial-result.txt").read_text() == "partial"
+    assert (backups[0] / "prior-result.txt").read_text() == "old"
+
+
+def test_rollback_stop_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "failed-rollback-stop-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+
+    def write_then_fail(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+        raise RuntimeError("provisioning failed after partial writes")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
+    env = PocEnv()
+    state_checks = iter([False, True])
+    monkeypatch.setattr(env, "_check_poc_running", lambda: next(state_checks))
+    monkeypatch.setattr(
+        env,
+        "stop",
+        lambda clean_up: (_ for _ in ()).throw(RuntimeError("Docker stop failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="could not be safely stopped") as exc_info:
+        env.deploy(object())
+
+    backups = list(tmp_path.glob("failed-rollback-stop-workspace.nvflare-recipe-backup-*"))
+    assert len(backups) == 1
+    assert str(backups[0]) in str(exc_info.value)
+    assert env.workspace_owned is True
+    assert (workspace / "partial-result.txt").read_text() == "partial"
+    assert (backups[0] / "prior-result.txt").read_text() == "old"
+
+
 def test_failed_start_restores_retained_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -382,6 +382,7 @@ def test_docker_liveness_honors_poc_socket_override(monkeypatch):
         return SimpleNamespace(returncode=0, stdout="true\n")
 
     monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    monkeypatch.setenv("DOCKER_CONTEXT", "remote-context")
     monkeypatch.setenv("NVFL_DOCKER_SOCK", "/run/user/1000/docker.sock")
     monkeypatch.setattr(poc_env_module.subprocess, "run", inspect_container)
 
@@ -389,6 +390,7 @@ def test_docker_liveness_honors_poc_socket_override(monkeypatch):
     command, kwargs = calls[0]
     assert command[-1] == "site-1"
     assert kwargs["env"]["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
+    assert "DOCKER_CONTEXT" not in kwargs["env"]
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -28,6 +28,8 @@ def test_poc_env_initialization():
     assert env.num_clients == 2
     assert env.gpu_ids == []
     assert env.study == "default"
+    assert env.deployment_started is False
+    assert env.workspace_owned is False
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
@@ -100,6 +102,111 @@ def test_poc_env_initialization_with_study(mock_get_workspace):
 def test_poc_env_rejects_invalid_study_name():
     with pytest.raises(ValueError):
         PocEnv(study="Bad Study")
+
+
+@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=["missing.py"])
+def test_deploy_preflight_failure_does_not_start_lifecycle(mock_collect_non_local_scripts):
+    env = PocEnv()
+
+    with pytest.raises(ValueError, match="scripts do not exist locally"):
+        env.deploy(object())
+
+    assert env.deployment_started is False
+    assert env.workspace_owned is False
+
+
+@patch("nvflare.recipe.poc_env.get_poc_workspace")
+@patch("nvflare.recipe.poc_env.prepare_poc_provision", side_effect=RuntimeError("provisioning failed"))
+@patch.object(PocEnv, "_check_poc_running", return_value=False)
+@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=[])
+def test_deploy_marks_lifecycle_started_before_provisioning(
+    mock_collect_non_local_scripts, mock_check_poc_running, mock_prepare_poc_provision, mock_get_workspace, tmp_path
+):
+    mock_get_workspace.return_value = str(tmp_path / "new-poc-workspace")
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="provisioning failed"):
+        env.deploy(object())
+
+    assert env.deployment_started is True
+    assert env.workspace_owned is True
+
+
+@patch("nvflare.recipe.poc_env.prepare_poc_provision", side_effect=RuntimeError("provisioning failed"))
+@patch.object(PocEnv, "_check_poc_running", return_value=False)
+@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=[])
+@patch("nvflare.recipe.poc_env.get_poc_workspace")
+def test_failed_provisioning_does_not_claim_existing_workspace(
+    mock_get_workspace, mock_collect_non_local_scripts, mock_check_poc_running, mock_prepare_poc_provision, tmp_path
+):
+    workspace = tmp_path / "retained-poc-workspace"
+    workspace.mkdir()
+    retained_result = workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    mock_get_workspace.return_value = str(workspace)
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="provisioning failed"):
+        env.deploy(object())
+
+    assert env.deployment_started is True
+    assert env.workspace_owned is False
+    assert retained_result.read_text() == "keep me"
+    assert not list(tmp_path.glob("retained-poc-workspace.nvflare-recipe-backup-*"))
+
+
+def test_failed_provisioning_restores_workspace_after_partial_writes(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "replaced-poc-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
+
+    def write_then_fail(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+        raise RuntimeError("provisioning failed after partial writes")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="failed after partial writes"):
+        env.deploy(object())
+
+    assert env.deployment_started is True
+    assert env.workspace_owned is False
+    assert (workspace / "prior-result.txt").read_text() == "old"
+    assert not (workspace / "partial-result.txt").exists()
+    assert not list(tmp_path.glob("replaced-poc-workspace.nvflare-recipe-backup-*"))
+
+
+def test_failed_start_restores_retained_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "start-failure-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", lambda **kwargs: workspace.mkdir())
+
+    def fail_start(**kwargs):
+        raise RuntimeError("start failed")
+
+    monkeypatch.setattr(poc_env_module, "_start_poc", fail_start)
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        env.deploy(object())
+
+    assert env.deployment_started is True
+    assert env.workspace_owned is False
+    assert (workspace / "prior-result.txt").read_text() == "old"
+    assert not list(tmp_path.glob("start-failure-workspace.nvflare-recipe-backup-*"))
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -232,6 +232,46 @@ def test_failed_provisioning_restores_workspace_after_partial_writes(tmp_path, m
     assert not list(tmp_path.glob("replaced-poc-workspace.nvflare-recipe-backup-*"))
 
 
+def test_rollback_state_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "unknown-rollback-state-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+
+    def write_then_fail(**kwargs):
+        workspace.mkdir()
+        (workspace / "partial-result.txt").write_text("partial")
+        raise RuntimeError("provisioning failed after partial writes")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
+    env = PocEnv()
+    state_checks = iter([False, RuntimeError("Docker inspection unavailable")])
+
+    def check_state():
+        result = next(state_checks)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(env, "_check_poc_running", check_state)
+
+    with pytest.raises(RuntimeError, match="state of partially started services could not be determined") as exc_info:
+        env.deploy(object())
+
+    backups = list(tmp_path.glob("unknown-rollback-state-workspace.nvflare-recipe-backup-*"))
+    assert len(backups) == 1
+    assert str(backups[0]) in str(exc_info.value)
+    assert str(workspace) in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "Docker inspection unavailable" in str(exc_info.value.__cause__)
+    assert env.workspace_owned is True
+    assert (workspace / "partial-result.txt").read_text() == "partial"
+    assert (backups[0] / "prior-result.txt").read_text() == "old"
+
+
 def test_failed_start_restores_retained_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -360,6 +360,7 @@ def test_running_services_uses_docker_container_state(monkeypatch):
         running = command[-1] != "site-1"
         return SimpleNamespace(returncode=0, stdout=f"{str(running).lower()}\n")
 
+    monkeypatch.setenv("DOCKER_HOST", "tcp://docker.example:2375")
     monkeypatch.setattr(poc_env_module.subprocess, "run", inspect_container)
     service_config = {
         SC.FLARE_SERVER: "server",
@@ -369,6 +370,25 @@ def test_running_services_uses_docker_container_state(monkeypatch):
 
     assert PocEnv._running_services({"name": "poc"}, service_config, "/unused") == ["server", "site-2"]
     assert [command[-1] for command in inspected] == ["server", "site-1", "site-2"]
+
+
+def test_docker_liveness_honors_poc_socket_override(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    calls = []
+
+    def inspect_container(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(returncode=0, stdout="true\n")
+
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    monkeypatch.setenv("NVFL_DOCKER_SOCK", "/run/user/1000/docker.sock")
+    monkeypatch.setattr(poc_env_module.subprocess, "run", inspect_container)
+
+    assert PocEnv._is_docker_service_running("site-1") is True
+    command, kwargs = calls[0]
+    assert command[-1] == "site-1"
+    assert kwargs["env"]["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import subprocess
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -45,6 +46,33 @@ def test_poc_env_initialization_with_custom_values(mock_get_workspace):
         assert env.poc_workspace == temp_dir
         assert env.num_clients == 3
         assert env.gpu_ids == [0, 1]
+
+
+@patch("nvflare.recipe.poc_env.get_poc_workspace")
+def test_poc_env_normalizes_workspace_trailing_separator(mock_get_workspace, tmp_path):
+    workspace = tmp_path / "poc-workspace"
+    mock_get_workspace.return_value = f"{workspace}{os.sep}"
+
+    env = PocEnv()
+
+    assert env.poc_workspace == str(workspace)
+
+
+def test_backup_with_normalized_workspace_is_created_as_sibling(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "poc-workspace"
+    workspace.mkdir()
+    (workspace / "prior-result.txt").write_text("old")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: f"{workspace}{os.sep}")
+    env = PocEnv()
+
+    backup = env._backup_existing_workspace()
+
+    assert backup is not None
+    assert os.path.dirname(backup) == str(tmp_path)
+    assert os.path.basename(backup).startswith("poc-workspace.nvflare-recipe-backup-")
+    assert os.path.exists(os.path.join(backup, "prior-result.txt"))
 
 
 def test_poc_env_validation():
@@ -114,6 +142,26 @@ def test_deploy_preflight_failure_does_not_start_lifecycle(mock_collect_non_loca
 
     assert env.deployment_started is False
     assert env.workspace_owned is False
+
+
+def test_deploy_rejects_project_config_inside_workspace_before_replacement(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "poc-workspace"
+    workspace.mkdir()
+    project_conf = workspace / "project.yml"
+    project_conf.write_text("name: retained")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    env = PocEnv(project_conf_path=str(project_conf))
+
+    with pytest.raises(ValueError, match="project_conf_path must be outside"):
+        env.deploy(object())
+
+    assert env.deployment_started is False
+    assert env.workspace_owned is False
+    assert project_conf.read_text() == "name: retained"
+    assert not list(tmp_path.glob("poc-workspace.nvflare-recipe-backup-*"))
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
@@ -391,6 +439,68 @@ def test_docker_liveness_honors_poc_socket_override(monkeypatch):
     assert command[-1] == "site-1"
     assert kwargs["env"]["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
     assert "DOCKER_CONTEXT" not in kwargs["env"]
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        subprocess.TimeoutExpired(cmd="docker inspect", timeout=5),
+        OSError("docker is unavailable"),
+    ],
+)
+def test_docker_liveness_fails_closed_when_inspection_cannot_run(monkeypatch, failure):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module.subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(failure))
+
+    with pytest.raises(RuntimeError, match="Could not determine Docker POC service state"):
+        PocEnv._is_docker_service_running("server")
+
+
+def test_docker_liveness_distinguishes_missing_container_from_inspection_error(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    missing = SimpleNamespace(returncode=1, stdout="", stderr="Error: No such object: server")
+    monkeypatch.setattr(poc_env_module.subprocess, "run", lambda *args, **kwargs: missing)
+    assert PocEnv._is_docker_service_running("server") is False
+
+    unavailable = SimpleNamespace(returncode=1, stdout="", stderr="Cannot connect to the Docker daemon")
+    monkeypatch.setattr(poc_env_module.subprocess, "run", lambda *args, **kwargs: unavailable)
+    with pytest.raises(RuntimeError, match="Cannot connect to the Docker daemon"):
+        PocEnv._is_docker_service_running("server")
+
+
+def test_deploy_does_not_move_workspace_when_docker_state_is_unknown(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    workspace = tmp_path / "retained-docker-workspace"
+    workspace.mkdir()
+    retained_result = workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (
+            {"name": "poc"},
+            {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"], SC.IS_DOCKER_RUN: True},
+        ),
+    )
+    monkeypatch.setattr(
+        PocEnv,
+        "_is_docker_service_running",
+        lambda service_name: (_ for _ in ()).throw(RuntimeError("Docker state is unknown")),
+    )
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="Docker state is unknown"):
+        env.deploy(object())
+
+    assert env.deployment_started is False
+    assert env.workspace_owned is False
+    assert retained_result.read_text() == "keep me"
+    assert not list(tmp_path.glob("retained-docker-workspace.nvflare-recipe-backup-*"))
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -231,6 +231,7 @@ def test_failed_readiness_restores_retained_workspace(tmp_path, monkeypatch):
         "setup_service_config",
         lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
     )
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
     env = PocEnv()
     monkeypatch.setattr(
         env,
@@ -270,6 +271,10 @@ def test_successful_submission_discards_backup_only_after_health_check(tmp_path,
     def verify_ready(*args, **kwargs):
         assert_backup_retained()
 
+    def verify_registered(*args, **kwargs):
+        assert_backup_retained()
+        return True
+
     def submit_job(job):
         assert_backup_retained()
         return "job-id"
@@ -281,6 +286,7 @@ def test_successful_submission_discards_backup_only_after_health_check(tmp_path,
         "setup_service_config",
         lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
     )
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", verify_registered)
     env = PocEnv()
     monkeypatch.setattr(env, "_wait_for_services_ready", verify_ready)
     monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=submit_job))
@@ -314,6 +320,7 @@ def test_failed_submission_restores_retained_workspace(tmp_path, monkeypatch):
         "setup_service_config",
         lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
     )
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
     env = PocEnv()
     monkeypatch.setattr(env, "_wait_for_services_ready", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -341,6 +348,27 @@ def test_wait_for_services_ready_rejects_an_exited_client(monkeypatch):
 
     with pytest.raises(RuntimeError, match="not running: site-1"):
         env._wait_for_services_ready({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]})
+
+
+def test_running_services_uses_docker_container_state(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    inspected = []
+
+    def inspect_container(command, **kwargs):
+        inspected.append(command)
+        running = command[-1] != "site-1"
+        return SimpleNamespace(returncode=0, stdout=f"{str(running).lower()}\n")
+
+    monkeypatch.setattr(poc_env_module.subprocess, "run", inspect_container)
+    service_config = {
+        SC.FLARE_SERVER: "server",
+        SC.FLARE_CLIENTS: ["site-1", "site-2"],
+        SC.IS_DOCKER_RUN: True,
+    }
+
+    assert PocEnv._running_services({"name": "poc"}, service_config, "/unused") == ["server", "site-2"]
+    assert [command[-1] for command in inspected] == ["server", "site-1", "site-2"]
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/tool/poc/poc_output_test.py
+++ b/tests/unit_test/tool/poc/poc_output_test.py
@@ -15,6 +15,7 @@
 import json
 import subprocess
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1406,6 +1407,30 @@ class TestPocOutput:
 
         assert [call.args[:2] for call in run_stop_command.call_args_list] == service_commands
         assert [call.kwargs["timeout"] for call in run_stop_command.call_args_list] == [POC_STOP_TIMEOUT] * 2
+
+    def test_docker_stop_honors_poc_socket_override(self, monkeypatch):
+        from nvflare.tool.poc.poc_commands import _run_stop_command
+
+        monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+        monkeypatch.setenv("NVFL_DOCKER_SOCK", "/run/user/1000/docker.sock")
+        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("nvflare.tool.poc.poc_commands.subprocess.run", return_value=completed) as run_command:
+            _run_stop_command("site-1", "docker stop site-1", timeout=30)
+
+        assert run_command.call_args.args[0] == ["docker", "stop", "site-1"]
+        assert run_command.call_args.kwargs["env"]["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
+
+    def test_docker_process_env_honors_poc_socket_override(self, monkeypatch):
+        from nvflare.tool.poc.poc_commands import prepare_env
+        from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
+
+        monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+        monkeypatch.setenv("NVFL_DOCKER_SOCK", "/run/user/1000/docker.sock")
+
+        process_env = prepare_env("site-1", None, {SC.IS_DOCKER_RUN: True})
+
+        assert process_env["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
 
     def test_wait_for_poc_services_stopped_reports_lingering_services(self):
         from nvflare.tool.poc.poc_commands import _wait_for_poc_services_stopped

--- a/tests/unit_test/tool/poc/poc_output_test.py
+++ b/tests/unit_test/tool/poc/poc_output_test.py
@@ -1412,6 +1412,7 @@ class TestPocOutput:
         from nvflare.tool.poc.poc_commands import _run_stop_command
 
         monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+        monkeypatch.setenv("DOCKER_CONTEXT", "remote-context")
         monkeypatch.setenv("NVFL_DOCKER_SOCK", "/run/user/1000/docker.sock")
         completed = SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -1420,6 +1421,7 @@ class TestPocOutput:
 
         assert run_command.call_args.args[0] == ["docker", "stop", "site-1"]
         assert run_command.call_args.kwargs["env"]["DOCKER_HOST"] == "unix:///run/user/1000/docker.sock"
+        assert "DOCKER_CONTEXT" not in run_command.call_args.kwargs["env"]
 
     def test_docker_process_env_honors_poc_socket_override(self, monkeypatch):
         from nvflare.tool.poc.poc_commands import prepare_env


### PR DESCRIPTION
## Summary

This extracts the framework-level prerequisites from the advanced Hello PyTorch environment work so PR #5255 can remain scoped to examples, documentation, tests, and CI.

- freeze a locally available script's packaged relative destination when its `ScriptRunner` is registered
- use that same destination in executor configuration and export, even if `sys.path` later changes
- preserve every destination when one source is registered by multiple runners
- keep distinct relative directories for different same-named scripts
- preserve unavailable absolute in-process paths for scripts pre-installed on production clients
- make script/directory resource classification consistent
- provision a fresh POC workspace transactionally while retaining and restoring an existing stopped workspace on preparation, startup, or readiness failure
- require every selected server/client process or Docker container to remain alive and then pass the existing client-registration readiness check before discarding the retained backup
- route Docker start, inspect, and stop operations through the same endpoint selection, including `NVFL_DOCKER_SOCK` overriding a local `DOCKER_HOST` or `DOCKER_CONTEXT`
- fail closed before workspace replacement when Docker service state cannot be determined, while treating an explicit missing container as stopped
- normalize the POC workspace path before deriving its sibling backup and reject project configurations located inside that replaceable workspace
- expose whether the current `PocEnv` invocation began deployment and owns the replacement workspace, so callers can clean up only their own artifacts

## Why

Recipe construction and export can run under different import paths. Deriving the deployed script path twice can therefore configure the executor for one path while copying the file to another. Freezing the mapping once makes the executor and package agree without changing the public Job API.

`PocEnv` reuses the standard local POC path. A failed in-place reprovision could otherwise corrupt or delete logs and results retained from an earlier invocation. The updated lifecycle moves an existing stopped workspace aside, prepares and starts the replacement, waits for every selected service to remain alive, verifies exact client registration through the existing system-status check, and removes the backup only after job submission succeeds. If preparation, launch, readiness, or submission fails, every surviving managed service is stopped before the partial replacement is discarded and the original workspace is restored atomically. If partially started services cannot be stopped, the backup is retained for recovery rather than overwritten.

Docker-backed POC uses container state rather than host PID files. The same Docker CLI environment is applied to start, readiness inspection, and stop operations. For a local `NVFL_DOCKER_SOCK` override, `DOCKER_CONTEXT` is removed because Docker gives it precedence over `DOCKER_HOST`; remote endpoints retain their existing selection behavior.

This PR intentionally contains no Hello PyTorch example changes. PR #5255 consumes these behaviors as an example-only follow-up.

## Compatibility

- Relative script paths keep their existing packaged layout.
- Locally available absolute scripts use a stable `sys.path`-relative destination.
- Absolute in-process scripts unavailable on the authoring machine remain absolute for production clients that pre-install them.
- Multiple identical source/destination registrations are deduplicated; distinct destinations are all preserved.
- The existing FedBPT recipe is updated to register its source under the same import root used by export.
- POC preflight failures do not claim workspace ownership, and failed replacements restore retained workspaces and results even when asynchronous launch returns before the services become healthy.
- Readiness requires both stable service/container liveness and expected client registration; Docker cleanup inspects all managed containers before workspace restoration.
- Docker inspection timeouts, CLI/daemon errors, and unknown responses stop deployment before a retained workspace is moved.
- If inspection or stopping fails at any rollback stage—including the post-stop verification—rollback preserves both the partial active workspace and retained backup, marks the active workspace owned by the invocation, and reports both recovery paths instead of guessing that services are stopped.
- `project_conf_path` must remain outside `poc_workspace`; trailing workspace separators are normalized so backups cannot be nested inside the directory they replace.

## Validation

- broad job-config, Recipe, POC lifecycle, POC CLI, and FedBPT unit set — 817 passed, 20 skipped
- focused POC lifecycle and CLI tests after the final rollback hardening — 98 passed
- combined prerequisite/example stack unit tests — 138 passed
- stacked real-environment acceptance test — simulation followed by local POC passed in 75.61 seconds with identical final per-site accuracies
- `./runtest.sh -s` — passed
- `git diff --check` — passed
