### PR TITLE
Reject conflicting Hugging Face Client API rank marker

### DIFF
--- a/nvflare/app_opt/hf/api.py
+++ b/nvflare/app_opt/hf/api.py
@@ -246,6 +246,15 @@ def _validate_repatch_settings(
 
 def _resolve_rank(trainer) -> int:
     if environment_declares_single_client_api_process():
+        dist = _torch_dist()
+        if dist is not None:
+            torch_rank = int(dist.get_rank())
+            if torch_rank != 0:
+                raise RuntimeError(
+                    "HuggingFace Client API single-process marker designates this process as Client API rank 0, "
+                    f"but torch.distributed initialized it as Torch rank {torch_rank}. Set the marker only for "
+                    "Torch rank 0 or remove it from the distributed trainer environment."
+                )
         return 0
 
     dist = _torch_dist()

--- a/tests/unit_test/app_opt/hf/api_contract_test.py
+++ b/tests/unit_test/app_opt/hf/api_contract_test.py
@@ -208,6 +208,29 @@ def test_patch_single_process_marker_overrides_inherited_rank_in_multitask_slurm
     assert str(client_api_mock.init_calls[0]["rank"]) == "0"
 
 
+def test_patch_single_process_marker_accepts_initialized_torch_rank_zero(monkeypatch, tmp_path):
+    hf_api, trainer_cls, client_api_mock = _fresh_api(monkeypatch)
+    monkeypatch.setattr(hf_api, "_torch_dist", lambda: _FakeDist(rank=0, world_size=2))
+    monkeypatch.setenv("NVFLARE_CLIENT_API_PROCESS_COUNT", "1")
+    trainer = _make_trainer(trainer_cls, tmp_path, process_index=0)
+
+    hf_api.patch(trainer, restore_state=False)
+
+    assert str(client_api_mock.init_calls[0]["rank"]) == "0"
+
+
+def test_patch_single_process_marker_rejects_nonzero_initialized_torch_rank(monkeypatch, tmp_path):
+    hf_api, trainer_cls, client_api_mock = _fresh_api(monkeypatch)
+    monkeypatch.setattr(hf_api, "_torch_dist", lambda: _FakeDist(rank=1, world_size=2))
+    monkeypatch.setenv("NVFLARE_CLIENT_API_PROCESS_COUNT", "1")
+    trainer = _make_trainer(trainer_cls, tmp_path, process_index=1)
+
+    with pytest.raises(RuntimeError, match="single-process marker.*Torch rank 1|Client API rank 0"):
+        hf_api.patch(trainer, restore_state=False)
+
+    assert not client_api_mock.init_calls
+
+
 def test_patch_rejects_unresolved_slurm_multiprocess_launch(monkeypatch, tmp_path):
     hf_api, trainer_cls, _ = _fresh_api(monkeypatch)
     monkeypatch.setattr(hf_api, "_torch_dist", lambda: None)


### PR DESCRIPTION
## Summary
- reject a single-Client-API-process marker only when the Hugging Face process is initialized as a nonzero Torch distributed rank
- preserve the supported marker path for Torch rank 0 in multi-node training and for rankless single-worker Slurm execution
- add positive rank-0 and negative nonzero-rank regression coverage

## Why
PR #5224 made the launcher-owned process-count marker authoritative for Client API rank resolution. Hugging Face also uses that resolved rank to choose the process that owns Client API operations, while Torch collectives use global rank 0 as their source. Forcing Client API rank 0 on a nonzero Torch rank would split those contracts and could hang distributed execution. The marker remains valid when the process is Torch rank 0, regardless of world size.

## Validation
- python3 -m pytest tests/unit_test/app_opt/hf tests/unit_test/client/rank_test.py -q (137 passed, 8 skipped)
- ./runtest.sh -s (passed)
- pre-push agent-skill lint (passed)