### PR TITLE
Fix Slurm multi-node GPU step allocation

### DIFF
--- a/nvflare/app_opt/job_launcher/slurm/batch.py
+++ b/nvflare/app_opt/job_launcher/slurm/batch.py
@@ -176,7 +176,7 @@ def _apptainer_parts(plan: LaunchPlan, config: SlurmConfig, worker_words: list[s
 
 
 def _multinode_srun_words(plan: LaunchPlan) -> list[str]:
-    return [
+    words = [
         '"${NVFL_SRUN}"',
         shlex.quote(f"--nodes={plan.resources.nodes}"),
         shlex.quote(f"--ntasks={plan.resources.nodes}"),
@@ -188,6 +188,9 @@ def _multinode_srun_words(plan: LaunchPlan) -> list[str]:
         shlex.quote("--wait=0"),
         shlex.quote("--label"),
     ]
+    if plan.resources.gpus_per_node:
+        words.append(shlex.quote(f"--gres=gpu:{plan.resources.gpus_per_node}"))
+    return words
 
 
 def _multinode_parts(plan: LaunchPlan, job_dir: str, config: SlurmConfig) -> tuple[list[str], list[str]]:

--- a/tests/unit_test/app_opt/job_launcher/slurm_batch_test.py
+++ b/tests/unit_test/app_opt/job_launcher/slurm_batch_test.py
@@ -188,8 +188,18 @@ def test_multinode_batch_exports_node_group_contract_and_delegates_to_srun(tmp_p
     assert "--kill-on-bad-exit=1" in command_line
     assert "--wait=0" in command_line
     assert "--label" in command_line
+    assert "--gres=gpu:1" in command_line
     assert f"{job_dir}/node.sh" in command_line
     assert "worker.module" not in command_line
+
+
+def test_multinode_batch_without_gpus_does_not_request_gres(tmp_path):
+    plan = replace(_multinode_plan(tmp_path), resources=JobResources(nodes=2))
+
+    script, _ = _render_batch_script(plan, _job_dir(tmp_path), _config(tmp_path))
+
+    command_line = next(line for line in script.splitlines() if line.startswith("_nvfl_command="))
+    assert "--gres" not in command_line
 
 
 def test_site_port_range_overrides_the_default_rendezvous_ports(tmp_path):


### PR DESCRIPTION
## Summary

- pass the planned per-node GPU GRES request explicitly to launcher-owned multi-node `srun`
- prevent inherited Slurm GPU option variables from changing the client step allocation
- leave zero-GPU multi-node jobs unchanged

Fixes #5268

## Testing

- `python -m pytest tests/unit_test/app_opt/job_launcher/slurm_batch_test.py tests/unit_test/app_opt/job_launcher/slurm_config_test.py tests/unit_test/app_opt/job_launcher/slurm_launcher_test.py tests/unit_test/app_opt/job_launcher/slurm_manager_test.py tests/unit_test/app_opt/job_launcher/slurm_scheduler_client_test.py tests/unit_test/job_config/script_runner_test.py tests/unit_test/recipe/fedavg_recipe_test.py` (`339 passed`)
- `./runtest.sh -s`
- `git diff --check`

## Validation limits

- A live GRES-scheduled Slurm cluster reproduction was not run for this PR.
