### PR TITLE
Isolate Recipe POC workspaces per deployment

### DIFF
--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -442,14 +442,6 @@ recipe framework:
   ``fedprox-tf`` manual pattern as a concrete recipe. TensorFlow clients
   can still combine a FedAvg recipe with ``TFFedProxLoss`` explicitly.
 
-- **``PocEnv`` instances are now one-shot.** After ``deploy()`` begins
-  provisioning, the same instance rejects later deployments even after
-  ``stop()``. This replaces the 2.8 auto-stop-and-redeploy behavior.
-  ``Run.abort()`` aborts the job without stopping its environment, so an
-  abort followed by another execution with the same ``PocEnv`` raises. Call
-  ``Run.get_result()`` or ``PocEnv.stop()``, then create a new ``PocEnv``
-  before executing another Recipe.
-
 **Streaming and Collaboration API** — narrower audience: sites moving
 large models, and early adopters of the Technical Preview Collaboration
 API:

--- a/docs/release_notes/flare_290.rst
+++ b/docs/release_notes/flare_290.rst
@@ -442,6 +442,14 @@ recipe framework:
   ``fedprox-tf`` manual pattern as a concrete recipe. TensorFlow clients
   can still combine a FedAvg recipe with ``TFFedProxLoss`` explicitly.
 
+- **``PocEnv`` instances are now one-shot.** After ``deploy()`` begins
+  provisioning, the same instance rejects later deployments even after
+  ``stop()``. This replaces the 2.8 auto-stop-and-redeploy behavior.
+  ``Run.abort()`` aborts the job without stopping its environment, so an
+  abort followed by another execution with the same ``PocEnv`` raises. Call
+  ``Run.get_result()`` or ``PocEnv.stop()``, then create a new ``PocEnv``
+  before executing another Recipe.
+
 **Streaming and Collaboration API** — narrower audience: sites moving
 large models, and early adopters of the Technical Preview Collaboration
 API:

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -327,7 +327,12 @@ Let's first set the path to the POC environment:
    run.get_status()
    run.get_result()
 
-The result is stored under the directory ``/tmp/nvflare/poc``.
+``PocEnv`` creates a unique Recipe-owned workspace beside the configured path,
+such as ``/tmp/nvflare/poc.recipe-<unique-id>``. The reusable ``nvflare poc``
+CLI workspace at ``/tmp/nvflare/poc`` is not replaced by Recipe provisioning.
+The active path is available as ``env.poc_workspace``. Pass ``clean_up=False``
+to ``run.get_result()`` when you want to retain that workspace and its logs
+after the run.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -337,7 +337,8 @@ names, so only one Recipe-managed POC deployment can be active on a host for a
 user. Also run ``nvflare poc stop`` before starting ``PocEnv`` when the
 configured CLI deployment is active. If the Recipe process exits unexpectedly,
 the next deployment checks the recorded per-run workspace and refuses to start
-while any of its services remain active.
+while any of its services remain active. It also fails closed with manual
+recovery guidance if that recorded workspace is missing or unreadable.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -335,7 +335,9 @@ to ``run.get_result()`` when you want to retain that workspace and its logs
 after the run. POC deployments still share default ports and Docker participant
 names, so only one Recipe-managed POC deployment can be active on a host for a
 user. Also run ``nvflare poc stop`` before starting ``PocEnv`` when the
-configured CLI deployment is active.
+configured CLI deployment is active. If the Recipe process exits unexpectedly,
+the next deployment checks the recorded per-run workspace and refuses to start
+while any of its services remain active.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -332,7 +332,9 @@ such as ``/tmp/nvflare/poc.recipe-<unique-id>``. The reusable ``nvflare poc``
 CLI workspace at ``/tmp/nvflare/poc`` is not replaced by Recipe provisioning.
 The active path is available as ``env.poc_workspace``. Pass ``clean_up=False``
 to ``run.get_result()`` when you want to retain that workspace and its logs
-after the run.
+after the run. The Recipe and CLI deployments still share default ports and
+Docker participant names, so run ``nvflare poc stop`` before starting
+``PocEnv`` when the configured CLI deployment is active.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -332,9 +332,10 @@ such as ``/tmp/nvflare/poc.recipe-<unique-id>``. The reusable ``nvflare poc``
 CLI workspace at ``/tmp/nvflare/poc`` is not replaced by Recipe provisioning.
 The active path is available as ``env.poc_workspace``. Pass ``clean_up=False``
 to ``run.get_result()`` when you want to retain that workspace and its logs
-after the run. The Recipe and CLI deployments still share default ports and
-Docker participant names, so run ``nvflare poc stop`` before starting
-``PocEnv`` when the configured CLI deployment is active.
+after the run. POC deployments still share default ports and Docker participant
+names, so only one Recipe-managed POC deployment can be active on a host for a
+user. Also run ``nvflare poc stop`` before starting ``PocEnv`` when the
+configured CLI deployment is active.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -333,14 +333,13 @@ CLI workspace at ``/tmp/nvflare/poc`` is not replaced by Recipe provisioning.
 The active path is available as ``env.poc_workspace``. Pass ``clean_up=False``
 to ``run.get_result()`` when you want to retain that workspace and its logs
 after the run. Each ``PocEnv`` instance owns one provisioning lifecycle; create
-a new instance for another deployment after provisioning has begun. POC
-deployments still share default ports and Docker participant names, so only one
-Recipe-managed POC deployment can be active on a host for a user. Also run
-``nvflare poc stop`` before starting ``PocEnv`` when the configured CLI
-deployment is active. If the Recipe process exits unexpectedly, the next
-deployment checks the recorded per-run workspace and refuses to start while any
-of its services remain active. It also fails closed with manual recovery
-guidance if that recorded workspace is missing or unreadable.
+a new instance for another deployment after provisioning has begun. Recipe POC
+deployments still compete for their configured server ports, although custom
+projects with distinct ports can run concurrently. Docker Recipe deployments
+use unique per-workspace container and network names. Also run ``nvflare poc
+stop`` before starting ``PocEnv`` when the configured CLI deployment is active.
+See :ref:`recipe_execution_environments` for lifecycle, conflict-checking, and
+failure-cleanup details.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/job_recipe.rst
+++ b/docs/user_guide/data_scientist_guide/job_recipe.rst
@@ -332,13 +332,15 @@ such as ``/tmp/nvflare/poc.recipe-<unique-id>``. The reusable ``nvflare poc``
 CLI workspace at ``/tmp/nvflare/poc`` is not replaced by Recipe provisioning.
 The active path is available as ``env.poc_workspace``. Pass ``clean_up=False``
 to ``run.get_result()`` when you want to retain that workspace and its logs
-after the run. POC deployments still share default ports and Docker participant
-names, so only one Recipe-managed POC deployment can be active on a host for a
-user. Also run ``nvflare poc stop`` before starting ``PocEnv`` when the
-configured CLI deployment is active. If the Recipe process exits unexpectedly,
-the next deployment checks the recorded per-run workspace and refuses to start
-while any of its services remain active. It also fails closed with manual
-recovery guidance if that recorded workspace is missing or unreadable.
+after the run. Each ``PocEnv`` instance owns one provisioning lifecycle; create
+a new instance for another deployment after provisioning has begun. POC
+deployments still share default ports and Docker participant names, so only one
+Recipe-managed POC deployment can be active on a host for a user. Also run
+``nvflare poc stop`` before starting ``PocEnv`` when the configured CLI
+deployment is active. If the Recipe process exits unexpectedly, the next
+deployment checks the recorded per-run workspace and refuses to start while any
+of its services remain active. It also fails closed with manual recovery
+guidance if that recorded workspace is missing or unreadable.
 
 To use a named study, point ``PocEnv`` to a custom project file that defines ``studies:``:
 

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -479,6 +479,9 @@ workspace is never replaced by Recipe provisioning. Reusing a stopped
 ``PocEnv`` creates another new workspace, so a retained result or log directory
 from an earlier run is not overwritten. Pass ``clean_up=False`` to
 ``Run.get_result()`` to retain the current Recipe workspace for inspection.
+If failure cleanup cannot be verified, the raised error identifies the unique
+workspace for manual cleanup. Other deployments do not scan or delete retained
+Recipe workspaces.
 
 ``ProdEnv`` submits through an admin startup kit. ``login_timeout`` must be
 positive, and ``username`` selects the admin identity. ``PocEnv`` and

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -484,7 +484,9 @@ File isolation does not isolate default ports or Docker participant names.
 for a user and refuses to start while the configured CLI POC deployment is
 running; stop that deployment with ``nvflare poc stop`` first. The runtime lock
 records the current per-run workspace, allowing a later process to detect and
-reject services left behind by an unexpected process exit.
+reject services left behind by an unexpected process exit. If the recorded
+workspace or its service configuration cannot be read, deployment fails closed
+and reports how to remove the stale record after manually stopping services.
 If failure cleanup cannot be verified, the raised error identifies the unique
 workspace for manual cleanup. Other deployments do not scan or delete retained
 Recipe workspaces.

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -482,7 +482,9 @@ from an earlier run is not overwritten. Pass ``clean_up=False`` to
 File isolation does not isolate default ports or Docker participant names.
 ``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
 for a user and refuses to start while the configured CLI POC deployment is
-running; stop that deployment with ``nvflare poc stop`` first.
+running; stop that deployment with ``nvflare poc stop`` first. The runtime lock
+records the current per-run workspace, allowing a later process to detect and
+reject services left behind by an unexpected process exit.
 If failure cleanup cannot be verified, the raised error identifies the unique
 workspace for manual cleanup. Other deployments do not scan or delete retained
 Recipe workspaces.

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -479,6 +479,9 @@ workspace is never replaced by Recipe provisioning. Reusing a stopped
 ``PocEnv`` creates another new workspace, so a retained result or log directory
 from an earlier run is not overwritten. Pass ``clean_up=False`` to
 ``Run.get_result()`` to retain the current Recipe workspace for inspection.
+File isolation does not isolate default ports or Docker participant names, so
+``PocEnv`` refuses to start while the configured CLI POC deployment is running;
+stop that deployment with ``nvflare poc stop`` first.
 If failure cleanup cannot be verified, the raised error identifies the unique
 workspace for manual cleanup. Other deployments do not scan or delete retained
 Recipe workspaces.

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -479,9 +479,10 @@ workspace is never replaced by Recipe provisioning. Reusing a stopped
 ``PocEnv`` creates another new workspace, so a retained result or log directory
 from an earlier run is not overwritten. Pass ``clean_up=False`` to
 ``Run.get_result()`` to retain the current Recipe workspace for inspection.
-File isolation does not isolate default ports or Docker participant names, so
-``PocEnv`` refuses to start while the configured CLI POC deployment is running;
-stop that deployment with ``nvflare poc stop`` first.
+File isolation does not isolate default ports or Docker participant names.
+``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
+for a user and refuses to start while the configured CLI POC deployment is
+running; stop that deployment with ``nvflare poc stop`` first.
 If failure cleanup cannot be verified, the raised error identifies the unique
 workspace for manual cleanup. Other deployments do not scan or delete retained
 Recipe workspaces.

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -473,6 +473,13 @@ POC mode. Jobs in Docker POC mode specify their SJ/CJ image in recipe launcher
 metadata. When ``project_conf_path`` is supplied, its project definition takes
 precedence over client-count and Docker preparation options.
 
+Each ``PocEnv`` deployment creates a unique Recipe-owned workspace beside the
+workspace configured for the reusable ``nvflare poc`` CLI workflow. The CLI
+workspace is never replaced by Recipe provisioning. Reusing a stopped
+``PocEnv`` creates another new workspace, so a retained result or log directory
+from an earlier run is not overwritten. Pass ``clean_up=False`` to
+``Run.get_result()`` to retain the current Recipe workspace for inspection.
+
 ``ProdEnv`` submits through an admin startup kit. ``login_timeout`` must be
 positive, and ``username`` selects the admin identity. ``PocEnv`` and
 ``ProdEnv`` use ``study`` to select the submission context; see

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -486,13 +486,18 @@ File isolation does not isolate default ports or Docker participant names.
 ``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
 for a user and refuses to start while the configured CLI POC deployment is
 running; stop that deployment with ``nvflare poc stop`` first. The runtime lock
-records the current per-run workspace, allowing a later process to detect and
-reject services left behind by an unexpected process exit. If the recorded
-workspace or its service configuration cannot be read, deployment fails closed
-and reports how to remove the stale record after manually stopping services.
-If failure cleanup cannot be verified, the raised error identifies the unique
-workspace for manual cleanup. Other deployments do not scan or delete retained
-Recipe workspaces.
+uses one canonical host-local per-user directory rather than the home or
+process-configured temporary directory. It securely bootstraps a stable,
+randomly named, owner-only directory below the canonical host ``/tmp``, including
+for arbitrary UIDs without an NSS entry. The lock records the current per-run
+workspace immediately before service startup, allowing a later process to
+detect and reject services left behind by an unexpected process exit. Once all
+services are confirmed stopped, the record is cleared before workspace
+deletion. If the recorded workspace or its service configuration cannot be
+read, deployment fails closed and reports how to remove the stale record after
+manually stopping services. If failure cleanup cannot be verified, the raised
+error identifies the unique workspace for manual cleanup. Other deployments do
+not scan or delete retained Recipe workspaces.
 
 ``ProdEnv`` submits through an admin startup kit. ``login_timeout`` must be
 positive, and ``username`` selects the admin identity. ``PocEnv`` and

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -483,21 +483,15 @@ new instance for another deployment. Pass ``clean_up=False`` to
 again with that same ``PocEnv`` raises. Call ``Run.get_result()`` or
 ``PocEnv.stop()``, then create a new environment for the next execution.
 File isolation does not isolate default ports or Docker participant names.
-``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
-for a user and refuses to start while the configured CLI POC deployment is
-running; stop that deployment with ``nvflare poc stop`` first. The runtime lock
-uses one canonical host-local per-user directory rather than the home or
-process-configured temporary directory. It securely bootstraps a stable,
-randomly named, owner-only directory below the canonical host ``/tmp``, including
-for arbitrary UIDs without an NSS entry. The lock records the current per-run
-workspace immediately before service startup, allowing a later process to
-detect and reject services left behind by an unexpected process exit. Once all
-services are confirmed stopped, the record is cleared before workspace
-deletion. If the recorded workspace or its service configuration cannot be
-read, deployment fails closed and reports how to remove the stale record after
-manually stopping services. If failure cleanup cannot be verified, the raised
-error identifies the unique workspace for manual cleanup. Other deployments do
-not scan or delete retained Recipe workspaces.
+Before starting services, ``PocEnv`` checks the configured server ports and, in
+Docker mode, participant container names, and rejects resources already used by
+another deployment. It also refuses to start while the configured CLI POC
+deployment is running; stop that deployment with ``nvflare poc stop`` first. If
+two deployments race between preflight and startup, the losing deployment fails
+during startup or readiness checks and cleans only its own unique workspace. If
+failure cleanup cannot be verified, the raised error identifies that workspace
+for manual cleanup. Other deployments do not scan or delete retained Recipe
+workspaces.
 
 ``ProdEnv`` submits through an admin startup kit. ``login_timeout`` must be
 positive, and ``username`` selects the admin identity. ``PocEnv`` and

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -473,12 +473,12 @@ POC mode. Jobs in Docker POC mode specify their SJ/CJ image in recipe launcher
 metadata. When ``project_conf_path`` is supplied, its project definition takes
 precedence over client-count and Docker preparation options.
 
-Each ``PocEnv`` deployment creates a unique Recipe-owned workspace beside the
+Each ``PocEnv`` instance creates a unique Recipe-owned workspace beside the
 workspace configured for the reusable ``nvflare poc`` CLI workflow. The CLI
-workspace is never replaced by Recipe provisioning. Reusing a stopped
-``PocEnv`` creates another new workspace, so a retained result or log directory
-from an earlier run is not overwritten. Pass ``clean_up=False`` to
-``Run.get_result()`` to retain the current Recipe workspace for inspection.
+workspace is never replaced by Recipe provisioning. A ``PocEnv`` owns one
+provisioning lifecycle and cannot be reused after provisioning begins; create a
+new instance for another deployment. Pass ``clean_up=False`` to
+``Run.get_result()`` to retain the Recipe workspace for inspection.
 File isolation does not isolate default ports or Docker participant names.
 ``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
 for a user and refuses to start while the configured CLI POC deployment is

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -479,6 +479,9 @@ workspace is never replaced by Recipe provisioning. A ``PocEnv`` owns one
 provisioning lifecycle and cannot be reused after provisioning begins; create a
 new instance for another deployment. Pass ``clean_up=False`` to
 ``Run.get_result()`` to retain the Recipe workspace for inspection.
+``Run.abort()`` aborts the job without stopping the environment, so executing
+again with that same ``PocEnv`` raises. Call ``Run.get_result()`` or
+``PocEnv.stop()``, then create a new environment for the next execution.
 File isolation does not isolate default ports or Docker participant names.
 ``PocEnv`` therefore permits only one Recipe-managed POC deployment per host
 for a user and refuses to start while the configured CLI POC deployment is

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -482,16 +482,18 @@ new instance for another deployment. Pass ``clean_up=False`` to
 ``Run.abort()`` aborts the job without stopping the environment, so executing
 again with that same ``PocEnv`` raises. Call ``Run.get_result()`` or
 ``PocEnv.stop()``, then create a new environment for the next execution.
-File isolation does not isolate default ports or Docker participant names.
-Before starting services, ``PocEnv`` checks the configured server ports and, in
-Docker mode, participant container names, and rejects resources already used by
-another deployment. It also refuses to start while the configured CLI POC
+File isolation does not isolate configured server ports. Before starting local
+processes, ``PocEnv`` checks those ports and rejects resources already in use.
+Docker Recipe deployments use unique per-workspace container and network names,
+so a deployment that loses a concurrent port race cannot observe or stop the
+other deployment's containers. The local port probe is also used for a verified
+local Docker daemon; for a remote ``DOCKER_HOST`` or Docker context, daemon-side
+startup and readiness checks are authoritative because local loopback is a
+different host. ``PocEnv`` also refuses to start while the configured CLI POC
 deployment is running; stop that deployment with ``nvflare poc stop`` first. If
-two deployments race between preflight and startup, the losing deployment fails
-during startup or readiness checks and cleans only its own unique workspace. If
-failure cleanup cannot be verified, the raised error identifies that workspace
-for manual cleanup. Other deployments do not scan or delete retained Recipe
-workspaces.
+failure cleanup cannot be verified, the raised error identifies the unique
+Recipe workspace for manual cleanup. Other deployments do not scan or delete
+retained Recipe workspaces.
 
 ``ProdEnv`` submits through an admin startup kit. ``login_timeout`` must be
 positive, and ``username`` selects the admin identity. ``PocEnv`` and

--- a/docs/user_guide/data_scientist_guide/recipe_api.rst
+++ b/docs/user_guide/data_scientist_guide/recipe_api.rst
@@ -486,8 +486,8 @@ File isolation does not isolate configured server ports. Before starting local
 processes, ``PocEnv`` checks those ports and rejects resources already in use.
 Docker Recipe deployments use unique per-workspace container and network names,
 so a deployment that loses a concurrent port race cannot observe or stop the
-other deployment's containers. The local port probe is also used for a verified
-local Docker daemon; for a remote ``DOCKER_HOST`` or Docker context, daemon-side
+other deployment's containers. The local port probe is also used for a local
+Docker daemon; for a remote ``DOCKER_HOST`` or Docker context, daemon-side
 startup and readiness checks are authoritative because local loopback is a
 different host. ``PocEnv`` also refuses to start while the configured CLI POC
 deployment is running; stop that deployment with ``nvflare poc stop`` first. If

--- a/examples/tutorials/flare_api.ipynb
+++ b/examples/tutorials/flare_api.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "The hello-numpy example uses Recipe API. To submit it to POC, we need to export it to traditional job format first.\n",
     "\n",
-    "> **Note**: Recipe API directories cannot be submitted directly. They must be exported first OR you can use `recipe.execute(PocEnv)` (see alternative method below)."
+    "> **Note**: Recipe API directories cannot be submitted directly to the running FL system. Export them first as shown below. In a separate workflow where no CLI POC is running, you can instead use `recipe.execute(PocEnv)` (see the alternative method below)."
    ]
   },
   {
@@ -148,11 +148,12 @@
     "job_id = sess.submit_job(path_to_example_job)\n",
     "print(job_id + \" was submitted\")\n",
     "\n",
-    "# Alternative method using Recipe API directly:\n",
+    "# Alternative Recipe-managed POC workflow (do not run while this notebook's CLI POC is active):\n",
     "# from nvflare.recipe import PocEnv\n",
     "# env = PocEnv(num_clients=2)\n",
     "# run = recipe.execute(env)\n",
-    "# job_id = run.job_id"
+    "# job_id = run.job_id\n",
+    "# result = run.get_result()  # Stops POC and removes its unique workspace by default"
    ]
   },
   {

--- a/examples/tutorials/job_recipe.ipynb
+++ b/examples/tutorials/job_recipe.ipynb
@@ -281,9 +281,9 @@
    "id": "e8336793-fee0-46ff-84de-0456fa7fdab9",
    "metadata": {},
    "source": [
-    "The result are stored under the directory `/tmp/nvflare/poc`.\n",
+    "The active Recipe POC workspace is available as `env.poc_workspace` and uses a unique path such as `/tmp/nvflare/poc.recipe-<unique-id>`. The reusable CLI POC workspace at `/tmp/nvflare/poc` is not replaced.\n",
     "\n",
-    "**Note:** The POC environment is always started fresh at the beginning of each `recipe.execute(env)` call, and is automatically stopped when `run.get_result()` returns. This means every job run gets a clean environment.\n",
+    "**Note:** Each `PocEnv` instance owns one provisioning lifecycle. `run.get_result()` stops the POC environment and removes its unique workspace by default; pass `clean_up=False` to retain the results and logs. Create a new `PocEnv` instance for another execution.\n",
     "\n",
     "If you prefer to keep the POC environment running persistently and avoid the start/stop overhead on each job run, you can start a POC manually (`nvflare poc start`) and then use `ProdEnv` to connect to it, effectively treating the POC as a production environment."
    ]

--- a/nvflare/app_opt/job_launcher/docker_launcher.py
+++ b/nvflare/app_opt/job_launcher/docker_launcher.py
@@ -420,6 +420,7 @@ class DockerJobLauncher(JobLauncherSpec):
 
     WORKSPACE_MOUNT = "/var/tmp/nvflare/workspace"
     STUDY_DATA_PATH_FILE = "local/study_data.yaml"
+    NETWORK_ENV = "NVFL_DOCKER_NETWORK"
 
     DEFAULT_PYTHON_PATH = "/usr/local/bin/python"
 
@@ -440,7 +441,8 @@ class DockerJobLauncher(JobLauncherSpec):
                        is mounted read-write at /var/tmp/nvflare/workspace/<job_id>. If not provided,
                        reads from NVFL_DOCKER_WORKSPACE environment variable. Must be the HOST path
                        because it is passed directly to the Docker daemon as a volume bind source.
-            network: Docker network name. Must already exist.
+            network: Docker network name. Must already exist. The parent runtime can override it with
+                     ``NVFL_DOCKER_NETWORK`` so parent and job containers use the same runtime-selected network.
             python_path: Deprecated alias for default_python_path.
             timeout: max seconds to wait for container to reach RUNNING state (default 30).
             default_job_container_kwargs: site-level default docker run kwargs applied to every job
@@ -467,7 +469,7 @@ class DockerJobLauncher(JobLauncherSpec):
             workspace = os.environ.get("NVFL_DOCKER_WORKSPACE")
 
         self.workspace = workspace
-        self.network = network
+        self.network = os.environ.get(self.NETWORK_ENV, network)
         self.default_python_path = default_python_path if default_python_path is not None else python_path
         if self.default_python_path is None:
             self.default_python_path = self.DEFAULT_PYTHON_PATH

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -50,6 +50,7 @@ STOP_POC_TIMEOUT = 10
 POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
+_RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
 # Internal — not part of the public API
@@ -156,10 +157,25 @@ class PocEnv(ExecEnv):
 
     def _new_poc_workspace(self) -> str:
         """Return a unique Recipe-owned workspace beside the configured POC path."""
-        return f"{self._poc_workspace_root}.recipe-{uuid.uuid4().hex}"
+        return f"{self._poc_workspace_root}{_RECIPE_WORKSPACE_SUFFIX}{uuid.uuid4().hex}"
+
+    def _is_recipe_workspace(self, workspace: str) -> bool:
+        """Return whether the path has this environment's exact sibling-and-UUID form."""
+        root = os.path.abspath(self._poc_workspace_root)
+        candidate = os.path.abspath(workspace)
+        if os.path.dirname(candidate) != os.path.dirname(root):
+            return False
+        prefix = f"{os.path.basename(root)}{_RECIPE_WORKSPACE_SUFFIX}"
+        candidate_name = os.path.basename(candidate)
+        if not candidate_name.startswith(prefix):
+            return False
+        identifier = candidate_name[len(prefix) :]
+        return len(identifier) == 32 and all(c in "0123456789abcdef" for c in identifier.lower())
 
     def _clean_up_failed_deployment(self) -> None:
         """Stop a failed deployment and verify its per-run workspace was cleaned."""
+        if not self._is_recipe_workspace(self.poc_workspace):
+            raise RuntimeError(f"refusing to clean unmanaged POC workspace {self.poc_workspace}")
         self.stop(clean_up=True)
         if self._check_poc_running():
             raise RuntimeError("POC services remain running")
@@ -306,7 +322,8 @@ class PocEnv(ExecEnv):
             except BaseException as cleanup_error:
                 raise RuntimeError(
                     f"POC deployment failed ({deployment_error}); cleanup could not be completed safely "
-                    f"for the per-run workspace {self.poc_workspace}: {cleanup_error}"
+                    f"for the per-run workspace {self.poc_workspace}: {cleanup_error}. Stop any remaining POC "
+                    "services and remove this workspace manually."
                 ) from cleanup_error
             raise
         self.logger.info("POC services started successfully")

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -383,8 +383,11 @@ class PocEnv(ExecEnv):
                     if not self._running_services(project_config, service_config, self.poc_workspace):
                         poc_running = False
                         break
-                except Exception:
-                    poc_running = False
+                except Exception as state_error:
+                    self.logger.warning(f"Could not verify whether POC services stopped: {state_error}")
+                    # Preserve the workspace when service state is unknown. It
+                    # contains the configuration needed for manual cleanup.
+                    poc_running = True
                     break
                 time.sleep(1)
                 count += 1

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
+import fcntl
 import os
 import shutil
+import stat
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -51,6 +55,11 @@ POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
+
+
+def _recipe_runtime_lock_path() -> str:
+    """Return the per-user host lock that serializes Recipe POC runtimes."""
+    return os.path.join(tempfile.gettempdir(), f".nvflare-recipe-poc-{os.geteuid()}.lock")
 
 
 # Internal — not part of the public API
@@ -154,6 +163,7 @@ class PocEnv(ExecEnv):
         self._session_manager = None  # Lazy initialization
         self._session_manager_lock = threading.Lock()
         self._workspace_used = False
+        self._runtime_lock_file = None
 
     def _new_poc_workspace(self) -> str:
         """Return a unique Recipe-owned workspace beside the configured POC path."""
@@ -189,6 +199,48 @@ class PocEnv(ExecEnv):
         except Exception:
             return False
         return bool(self._running_services(project_config, service_config, workspace))
+
+    def _acquire_runtime_lock(self) -> None:
+        """Claim the host's single Recipe-managed POC runtime slot."""
+        if self._runtime_lock_file is not None:
+            return
+
+        lock_path = _recipe_runtime_lock_path()
+        flags = os.O_CREAT | os.O_RDWR
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(lock_path, flags, 0o600)
+        try:
+            lock_stat = os.fstat(fd)
+            if not stat.S_ISREG(lock_stat.st_mode) or lock_stat.st_uid != os.geteuid():
+                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock {lock_path}")
+            os.fchmod(fd, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as e:
+                if e.errno in (errno.EACCES, errno.EAGAIN):
+                    raise RuntimeError(
+                        "Another Recipe PocEnv deployment is active on this host. "
+                        "Stop it before starting this deployment."
+                    ) from e
+                raise
+            self._runtime_lock_file = os.fdopen(fd, "a+")
+        except BaseException:
+            os.close(fd)
+            raise
+
+    def _release_runtime_lock(self) -> None:
+        """Release this environment's Recipe POC runtime slot, if held."""
+        lock_file = self._runtime_lock_file
+        if lock_file is None:
+            return
+        self._runtime_lock_file = None
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            lock_file.close()
 
     @staticmethod
     def _is_docker_service_running(service_name: str) -> bool:
@@ -284,18 +336,25 @@ class PocEnv(ExecEnv):
                 f"For PocEnv, all scripts must be present on the local machine."
             )
 
-        # Unique workspaces isolate files, but POC deployments still share
-        # default ports and Docker participant names. Never compete with the
-        # reusable CLI-managed deployment selected by the user's configuration.
-        if self._is_poc_workspace_running(self._poc_workspace_root):
-            raise RuntimeError(
-                f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
-                "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
-            )
+        if self._workspace_used and self._check_poc_running():
+            raise RuntimeError("This PocEnv already has a running deployment; stop it before deploying another job")
+
+        # Recipe POC workspaces have isolated files but share host ports and
+        # Docker participant names. The process-held lock closes the race
+        # between checking those resources and starting services. It is
+        # released only after this deployment's services have stopped.
+        self._acquire_runtime_lock()
+        try:
+            if self._is_poc_workspace_running(self._poc_workspace_root):
+                raise RuntimeError(
+                    f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
+                    "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
+                )
+        except BaseException:
+            self._release_runtime_lock()
+            raise
 
         if self._workspace_used:
-            if self._check_poc_running():
-                raise RuntimeError("This PocEnv already has a running deployment; stop it before deploying another job")
             self.poc_workspace = self._new_poc_workspace()
             self._session_manager = None
         self._workspace_used = True
@@ -369,6 +428,7 @@ class PocEnv(ExecEnv):
                 self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
                 shutil.rmtree(self.poc_workspace, ignore_errors=True)
             self._session_manager = None  # Clear stale session manager
+            self._release_runtime_lock()
             return
 
         try:
@@ -423,6 +483,8 @@ class PocEnv(ExecEnv):
                         self.logger.warning(
                             f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
                         )
+            if not poc_running:
+                self._release_runtime_lock()
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")
         finally:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -195,11 +195,17 @@ class PocEnv(ExecEnv):
         if os.path.exists(self.poc_workspace):
             raise RuntimeError("the per-run POC workspace could not be removed")
 
-    def _is_poc_workspace_running(self, workspace: str) -> bool:
+    def _is_poc_workspace_running(self, workspace: str, fail_if_unknown: bool = False) -> bool:
         """Return whether any managed service is running in a POC workspace."""
         try:
             project_config, service_config = setup_service_config(workspace)
-        except Exception:
+        except Exception as e:
+            if fail_if_unknown:
+                raise RuntimeError(
+                    f"Could not determine service state for the previously active Recipe PocEnv workspace {workspace}: "
+                    f"{e}. Stop any remaining services, then remove the stale runtime record "
+                    f"{_recipe_runtime_lock_path()} manually."
+                ) from e
             return False
         return bool(self._running_services(project_config, service_config, workspace))
 
@@ -232,7 +238,7 @@ class PocEnv(ExecEnv):
             lock_file = os.fdopen(fd, "r+")
             fd = None
             previous_workspace = lock_file.read().strip()
-            if previous_workspace and self._is_poc_workspace_running(previous_workspace):
+            if previous_workspace and self._is_poc_workspace_running(previous_workspace, fail_if_unknown=True):
                 raise RuntimeError(
                     f"A prior Recipe PocEnv deployment is still active at {previous_workspace}. "
                     "Stop its services and remove the workspace manually before starting another deployment."

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -187,7 +187,9 @@ class PocEnv(ExecEnv):
         """Stop a failed deployment and verify its per-run workspace was cleaned."""
         if not self._is_recipe_workspace(self.poc_workspace):
             raise RuntimeError(f"refusing to clean unmanaged POC workspace {self.poc_workspace}")
-        self.stop(clean_up=True)
+        # deploy() already holds the instance lifecycle guard. Use the private
+        # implementation so failure cleanup cannot deadlock on that guard.
+        self._stop(clean_up=True)
         if self._check_poc_running():
             raise RuntimeError("POC services remain running")
         if os.path.exists(self.poc_workspace):
@@ -463,6 +465,13 @@ class PocEnv(ExecEnv):
         Args:
             clean_up (bool, optional): Whether to clean the POC workspace. Defaults to False.
         """
+        # Wait for an in-progress deployment to finish before inspecting
+        # services or clearing its durable runtime record.
+        with self._deployment_lock:
+            self._stop(clean_up)
+
+    def _stop(self, clean_up: bool = False) -> None:
+        """Stop POC while the caller holds the instance lifecycle guard."""
         # Check if already stopped (idempotent)
         if not self._check_poc_running():
             # POC already stopped or workspace doesn't exist

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -207,7 +207,16 @@ class PocEnv(ExecEnv):
                     f"{_recipe_runtime_lock_path()} manually."
                 ) from e
             return False
-        return bool(self._running_services(project_config, service_config, workspace))
+        try:
+            return bool(self._running_services(project_config, service_config, workspace))
+        except Exception as e:
+            if fail_if_unknown:
+                raise RuntimeError(
+                    f"Could not determine service state for the previously active Recipe PocEnv workspace {workspace}: "
+                    f"{e}. Stop any remaining services, then remove the stale runtime record "
+                    f"{_recipe_runtime_lock_path()} manually."
+                ) from e
+            raise
 
     def _acquire_runtime_lock(self) -> None:
         """Claim the host's single Recipe-managed POC runtime slot."""

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -164,6 +164,7 @@ class PocEnv(ExecEnv):
         self._session_manager_lock = threading.Lock()
         self._workspace_used = False
         self._runtime_lock_file = None
+        self._deployment_lock = threading.Lock()
 
     def _new_poc_workspace(self) -> str:
         """Return a unique Recipe-owned workspace beside the configured POC path."""
@@ -226,18 +227,45 @@ class PocEnv(ExecEnv):
                         "Stop it before starting this deployment."
                     ) from e
                 raise
-            self._runtime_lock_file = os.fdopen(fd, "a+")
+            lock_file = os.fdopen(fd, "r+")
+            fd = None
+            previous_workspace = lock_file.read().strip()
+            if previous_workspace and self._is_poc_workspace_running(previous_workspace):
+                raise RuntimeError(
+                    f"A prior Recipe PocEnv deployment is still active at {previous_workspace}. "
+                    "Stop its services and remove the workspace manually before starting another deployment."
+                )
+            self._runtime_lock_file = lock_file
         except BaseException:
-            os.close(fd)
+            if fd is not None:
+                os.close(fd)
+            else:
+                lock_file.close()
             raise
 
-    def _release_runtime_lock(self) -> None:
+    def _record_runtime_workspace(self) -> None:
+        """Durably record the workspace whose services own the runtime slot."""
+        lock_file = self._runtime_lock_file
+        if lock_file is None:
+            raise RuntimeError("Recipe POC runtime lock is not held")
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(os.path.abspath(self.poc_workspace))
+        lock_file.flush()
+        os.fsync(lock_file.fileno())
+
+    def _release_runtime_lock(self, clear_workspace: bool = False) -> None:
         """Release this environment's Recipe POC runtime slot, if held."""
         lock_file = self._runtime_lock_file
         if lock_file is None:
             return
         self._runtime_lock_file = None
         try:
+            if clear_workspace:
+                lock_file.seek(0)
+                lock_file.truncate()
+                lock_file.flush()
+                os.fsync(lock_file.fileno())
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
         finally:
             lock_file.close()
@@ -328,6 +356,15 @@ class PocEnv(ExecEnv):
         Raises:
             ValueError: If scripts do not exist locally.
         """
+        if not self._deployment_lock.acquire(blocking=False):
+            raise RuntimeError("This PocEnv already has a deployment in progress")
+        try:
+            return self._deploy(job)
+        finally:
+            self._deployment_lock.release()
+
+    def _deploy(self, job: FedJob) -> str:
+        """Perform one deployment while the instance deployment guard is held."""
         # Validate scripts exist locally for POC
         non_local_scripts = collect_non_local_scripts(job)
         if non_local_scripts:
@@ -357,6 +394,11 @@ class PocEnv(ExecEnv):
         if self._workspace_used:
             self.poc_workspace = self._new_poc_workspace()
             self._session_manager = None
+        try:
+            self._record_runtime_workspace()
+        except BaseException:
+            self._release_runtime_lock()
+            raise
         self._workspace_used = True
 
         self.logger.info(f"Preparing and starting POC services in new workspace: {self.poc_workspace}")
@@ -428,7 +470,7 @@ class PocEnv(ExecEnv):
                 self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
                 shutil.rmtree(self.poc_workspace, ignore_errors=True)
             self._session_manager = None  # Clear stale session manager
-            self._release_runtime_lock()
+            self._release_runtime_lock(clear_workspace=True)
             return
 
         try:
@@ -484,7 +526,7 @@ class PocEnv(ExecEnv):
                             f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
                         )
             if not poc_running:
-                self._release_runtime_lock()
+                self._release_runtime_lock(clear_workspace=True)
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")
         finally:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ STOP_POC_TIMEOUT = 10
 POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
-_WORKSPACE_BACKUP_PREFIX = ".nvflare-recipe-backup-"
 
 
 # Internal — not part of the public API
@@ -92,7 +91,8 @@ class PocEnv(ExecEnv):
     """Proof of Concept execution environment for local testing and development.
 
     This environment sets up a POC deployment on a single machine with multiple
-    processes representing the server, clients, and admin console.
+    processes representing the server, clients, and admin console. Each deployment
+    uses a new Recipe-owned workspace beside the configured CLI POC workspace.
     """
 
     def __init__(
@@ -139,9 +139,11 @@ class PocEnv(ExecEnv):
 
         self.clients = v.clients
         self.num_clients = len(v.clients) if v.clients is not None else v.num_clients
-        # Keep transactional backups beside the workspace even when the
-        # configured path has a trailing separator.
-        self.poc_workspace = os.path.normpath(get_poc_workspace())
+        # The configured POC path belongs to the reusable CLI workflow. Recipe
+        # executions use unique sibling workspaces so they never replace or
+        # restore user-retained POC state.
+        self._poc_workspace_root = os.path.normpath(get_poc_workspace())
+        self.poc_workspace = self._new_poc_workspace()
         self.gpu_ids = v.gpu_ids or []
         self.use_he = v.use_he
         self.project_conf_path = v.project_conf_path
@@ -150,65 +152,11 @@ class PocEnv(ExecEnv):
         self.study = v.study
         self._session_manager = None  # Lazy initialization
         self._session_manager_lock = threading.Lock()
-        self._deployment_started = False
-        self._workspace_owned = False
+        self._workspace_used = False
 
-    @property
-    def deployment_started(self) -> bool:
-        """Whether the latest deploy call passed preflight and began POC preparation."""
-        return self._deployment_started
-
-    @property
-    def workspace_owned(self) -> bool:
-        """Whether the latest deploy created or replaced the active POC workspace."""
-        return self._workspace_owned
-
-    def _backup_existing_workspace(self) -> Optional[str]:
-        """Move a retained workspace aside before provisioning mutates its path."""
-        if not os.path.exists(self.poc_workspace):
-            return None
-        backup = f"{self.poc_workspace}{_WORKSPACE_BACKUP_PREFIX}{uuid.uuid4().hex}"
-        os.replace(self.poc_workspace, backup)
-        return backup
-
-    def _validate_project_conf_location(self) -> None:
-        """Reject a project config that workspace replacement would move away."""
-        if not self.project_conf_path:
-            return
-
-        workspace = os.path.abspath(self.poc_workspace)
-        project_conf = os.path.abspath(os.path.expanduser(self.project_conf_path))
-        resolved_workspace = os.path.realpath(workspace)
-        resolved_project_conf = os.path.realpath(project_conf)
-        if (
-            os.path.commonpath([workspace, project_conf]) == workspace
-            or os.path.commonpath([resolved_workspace, resolved_project_conf]) == resolved_workspace
-        ):
-            raise ValueError(
-                f"project_conf_path must be outside the POC workspace {self.poc_workspace!r}; "
-                "the workspace is replaced during deployment"
-            )
-
-    def _restore_existing_workspace(self, backup: str) -> None:
-        """Discard a partial replacement and atomically restore the retained workspace."""
-        if os.path.isdir(self.poc_workspace) and not os.path.islink(self.poc_workspace):
-            shutil.rmtree(self.poc_workspace)
-        elif os.path.lexists(self.poc_workspace):
-            os.remove(self.poc_workspace)
-        os.replace(backup, self.poc_workspace)
-
-    def _raise_rollback_error(self, workspace_backup: Optional[str], error: Exception, reason: str) -> None:
-        """Preserve recovery artifacts and report their locations when rollback is unsafe."""
-        self._workspace_owned = True
-        backup_note = (
-            f"the retained workspace backup remains at {workspace_backup}"
-            if workspace_backup
-            else "there was no retained workspace to back up"
-        )
-        raise RuntimeError(
-            f"POC deployment failed and {reason}; "
-            f"the partial replacement remains at {self.poc_workspace}; {backup_note}"
-        ) from error
+    def _new_poc_workspace(self) -> str:
+        """Return a unique Recipe-owned workspace beside the configured POC path."""
+        return f"{self._poc_workspace_root}.recipe-{uuid.uuid4().hex}"
 
     @staticmethod
     def _is_docker_service_running(service_name: str) -> bool:
@@ -296,11 +244,6 @@ class PocEnv(ExecEnv):
         Raises:
             ValueError: If scripts do not exist locally.
         """
-        # Reset before non-mutating preflight so callers can distinguish a
-        # rejected job from an invocation that owns a new POC lifecycle.
-        self._deployment_started = False
-        self._workspace_owned = False
-
         # Validate scripts exist locally for POC
         non_local_scripts = collect_non_local_scripts(job)
         if non_local_scripts:
@@ -309,18 +252,14 @@ class PocEnv(ExecEnv):
                 f"For PocEnv, all scripts must be present on the local machine."
             )
 
-        self._validate_project_conf_location()
-
-        if self._check_poc_running():
-            # Keep the stopped workspace until fresh provisioning succeeds, so
-            # a failed replacement can restore its prior logs and results.
-            self.stop(clean_up=False)
+        if self._workspace_used:
             if self._check_poc_running():
-                raise RuntimeError("Existing POC services could not be stopped")
+                raise RuntimeError("This PocEnv already has a running deployment; stop it before deploying another job")
+            self.poc_workspace = self._new_poc_workspace()
+            self._session_manager = None
+        self._workspace_used = True
 
-        self._deployment_started = True
-        workspace_backup = self._backup_existing_workspace()
-        self.logger.info("Preparing and starting fresh POC services...")
+        self.logger.info(f"Preparing and starting POC services in new workspace: {self.poc_workspace}")
         try:
             prepare_poc_provision(
                 clients=self.clients or [],  # Empty list if None, let prepare_clients generate
@@ -348,70 +287,14 @@ class PocEnv(ExecEnv):
                 timeout_in_sec=POC_START_READY_TIMEOUT,
             ):
                 raise RuntimeError("POC services were started but no server or clients were selected for readiness")
-            # Successful submission proves that the admin connection is ready,
-            # in addition to the process/container and client-registration
-            # checks above. Keep the retained workspace backup until all checks
-            # and submission have passed.
+            # Successful submission also proves that the admin connection is
+            # ready after the process/container and client-registration checks.
             job_id = self._get_session_manager().submit_job(job)
         except BaseException:
-            try:
-                poc_running = self._check_poc_running()
-            except Exception as state_error:
-                # Do not replace or delete either workspace when service state
-                # is unknown. The active path belongs to this invocation, and
-                # the retained backup remains available for manual recovery.
-                self._raise_rollback_error(
-                    workspace_backup,
-                    state_error,
-                    "the state of partially started services could not be determined",
-                )
-
-            if poc_running:
-                try:
-                    self.stop(clean_up=False)
-                except Exception as stop_error:
-                    self._raise_rollback_error(
-                        workspace_backup,
-                        stop_error,
-                        "partially started services could not be safely stopped",
-                    )
-                try:
-                    poc_running = self._check_poc_running()
-                except Exception as state_error:
-                    self._raise_rollback_error(
-                        workspace_backup,
-                        state_error,
-                        "the state of partially started services could not be determined after stopping",
-                    )
-                if poc_running:
-                    self._workspace_owned = True
-                    backup_note = (
-                        f"the retained workspace backup remains at {workspace_backup}"
-                        if workspace_backup
-                        else "there was no retained workspace to restore"
-                    )
-                    raise RuntimeError(
-                        f"POC deployment failed and partially started services could not be stopped; " f"{backup_note}"
-                    )
-            if workspace_backup:
-                try:
-                    self._restore_existing_workspace(workspace_backup)
-                except Exception as restore_error:
-                    # The active path contains only this invocation's partial
-                    # replacement. Let the caller clean it, but retain the
-                    # backup for manual recovery.
-                    self._workspace_owned = True
-                    raise RuntimeError(
-                        f"POC deployment failed and the retained workspace could not be restored from {workspace_backup}"
-                    ) from restore_error
-                self._workspace_owned = False
-            else:
-                self._workspace_owned = True
+            # This path is unique to the current Recipe execution, so failure
+            # cleanup cannot delete a retained CLI workspace or a prior run.
+            self.stop(clean_up=True)
             raise
-        else:
-            self._workspace_owned = True
-            if workspace_backup:
-                shutil.rmtree(workspace_backup, ignore_errors=True)
         self.logger.info("POC services started successfully")
         return job_id
 
@@ -451,7 +334,7 @@ class PocEnv(ExecEnv):
             self.logger.info("Stopping existing POC services...")
             # Prefer the coordinated server shutdown while it is reachable. If
             # the server exited during startup, stop any surviving local client
-            # processes directly so the workspace can be restored safely.
+            # processes directly so the per-run workspace can be cleaned safely.
             services_list = []
             if service_config.get(SC.IS_DOCKER_RUN) or not is_poc_running(
                 self.poc_workspace, service_config, project_config

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -182,6 +182,14 @@ class PocEnv(ExecEnv):
         if os.path.exists(self.poc_workspace):
             raise RuntimeError("the per-run POC workspace could not be removed")
 
+    def _is_poc_workspace_running(self, workspace: str) -> bool:
+        """Return whether any managed service is running in a POC workspace."""
+        try:
+            project_config, service_config = setup_service_config(workspace)
+        except Exception:
+            return False
+        return bool(self._running_services(project_config, service_config, workspace))
+
     @staticmethod
     def _is_docker_service_running(service_name: str) -> bool:
         """Return whether Docker reports the named POC container as running."""
@@ -276,6 +284,15 @@ class PocEnv(ExecEnv):
                 f"For PocEnv, all scripts must be present on the local machine."
             )
 
+        # Unique workspaces isolate files, but POC deployments still share
+        # default ports and Docker participant names. Never compete with the
+        # reusable CLI-managed deployment selected by the user's configuration.
+        if self._is_poc_workspace_running(self._poc_workspace_root):
+            raise RuntimeError(
+                f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
+                "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
+            )
+
         if self._workspace_used:
             if self._check_poc_running():
                 raise RuntimeError("This PocEnv already has a running deployment; stop it before deploying another job")
@@ -319,7 +336,7 @@ class PocEnv(ExecEnv):
             # cleanup cannot delete a retained CLI workspace or a prior run.
             try:
                 self._clean_up_failed_deployment()
-            except BaseException as cleanup_error:
+            except Exception as cleanup_error:
                 raise RuntimeError(
                     f"POC deployment failed ({deployment_error}); cleanup could not be completed safely "
                     f"for the per-run workspace {self.poc_workspace}: {cleanup_error}. Stop any remaining POC "
@@ -335,13 +352,7 @@ class PocEnv(ExecEnv):
         Returns:
             bool: True if POC is running, False otherwise.
         """
-        try:
-            project_config, service_config = setup_service_config(self.poc_workspace)
-        except Exception:
-            # POC workspace is not initialized yet, so we don't need to stop and clean it
-            return False
-
-        return bool(self._running_services(project_config, service_config, self.poc_workspace))
+        return self._is_poc_workspace_running(self.poc_workspace)
 
     def stop(self, clean_up: bool = False) -> None:
         """Try to stop and clean existing POC.

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -158,6 +158,14 @@ class PocEnv(ExecEnv):
         """Return a unique Recipe-owned workspace beside the configured POC path."""
         return f"{self._poc_workspace_root}.recipe-{uuid.uuid4().hex}"
 
+    def _clean_up_failed_deployment(self) -> None:
+        """Stop a failed deployment and verify its per-run workspace was cleaned."""
+        self.stop(clean_up=True)
+        if self._check_poc_running():
+            raise RuntimeError("POC services remain running")
+        if os.path.exists(self.poc_workspace):
+            raise RuntimeError("the per-run POC workspace could not be removed")
+
     @staticmethod
     def _is_docker_service_running(service_name: str) -> bool:
         """Return whether Docker reports the named POC container as running."""
@@ -290,10 +298,16 @@ class PocEnv(ExecEnv):
             # Successful submission also proves that the admin connection is
             # ready after the process/container and client-registration checks.
             job_id = self._get_session_manager().submit_job(job)
-        except BaseException:
+        except BaseException as deployment_error:
             # This path is unique to the current Recipe execution, so failure
             # cleanup cannot delete a retained CLI workspace or a prior run.
-            self.stop(clean_up=True)
+            try:
+                self._clean_up_failed_deployment()
+            except BaseException as cleanup_error:
+                raise RuntimeError(
+                    f"POC deployment failed ({deployment_error}); cleanup could not be completed safely "
+                    f"for the per-run workspace {self.poc_workspace}: {cleanup_error}"
+                ) from cleanup_error
             raise
         self.logger.info("POC services started successfully")
         return job_id

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -378,12 +378,14 @@ class PocEnv(ExecEnv):
             )
             count = 0
             poc_running = True
+            poc_state_error = None
             while count < STOP_POC_TIMEOUT:
                 try:
                     if not self._running_services(project_config, service_config, self.poc_workspace):
                         poc_running = False
                         break
                 except Exception as state_error:
+                    poc_state_error = state_error
                     self.logger.warning(f"Could not verify whether POC services stopped: {state_error}")
                     # Preserve the workspace when service state is unknown. It
                     # contains the configuration needed for manual cleanup.
@@ -394,14 +396,22 @@ class PocEnv(ExecEnv):
 
             if clean_up:
                 if poc_running:
+                    reason = (
+                        f"service state could not be verified ({poc_state_error})"
+                        if poc_state_error
+                        else f"services are still running after {STOP_POC_TIMEOUT} seconds"
+                    )
                     self.logger.warning(
-                        f"POC still running after {STOP_POC_TIMEOUT} seconds, cannot clean workspace. Skipping cleanup."
+                        f"POC {reason}; preserving workspace {self.poc_workspace}. "
+                        "Stop any remaining services and remove it manually."
                     )
                 else:
                     try:
                         _clean_poc(self.poc_workspace)
                     except Exception as e:
-                        self.logger.debug(f"Failed to clean POC: {e}")
+                        self.logger.warning(
+                            f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
+                        )
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")
         finally:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -654,6 +654,11 @@ class PocEnv(ExecEnv):
                         )
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")
+            if clean_up:
+                self.logger.warning(
+                    f"POC cleanup could not be completed; preserving workspace {self.poc_workspace}. "
+                    "Stop any remaining services or job containers, then retry PocEnv.stop(clean_up=True)."
+                )
         finally:
             self._session_manager = None  # Clear stale session manager
 

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -15,6 +15,7 @@
 import errno
 import fcntl
 import os
+import pwd
 import shutil
 import stat
 import subprocess
@@ -56,8 +57,9 @@ _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
 def _recipe_runtime_lock_path() -> str:
-    """Return the environment-independent, per-user host runtime lock."""
-    return os.path.join(os.path.realpath("/tmp"), f".nvflare-recipe-poc-{os.geteuid()}.lock")
+    """Return the environment-independent runtime lock for the OS user."""
+    user_home = pwd.getpwuid(os.geteuid()).pw_dir
+    return os.path.join(user_home, ".nvflare", "recipe-poc-runtime.lock")
 
 
 # Internal — not part of the public API
@@ -229,6 +231,15 @@ class PocEnv(ExecEnv):
             return
 
         lock_path = _recipe_runtime_lock_path()
+        lock_dir = os.path.dirname(lock_path)
+        os.makedirs(lock_dir, mode=0o700, exist_ok=True)
+        lock_dir_stat = os.stat(lock_dir)
+        if (
+            not stat.S_ISDIR(lock_dir_stat.st_mode)
+            or lock_dir_stat.st_uid != os.geteuid()
+            or lock_dir_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
         flags = os.O_CREAT | os.O_RDWR
         if hasattr(os, "O_CLOEXEC"):
             flags |= os.O_CLOEXEC

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -55,9 +55,9 @@ DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
-def _recipe_runtime_lock_path(poc_workspace_root: str) -> str:
-    """Return the per-user runtime lock beside the configured POC workspace."""
-    return f"{os.path.abspath(poc_workspace_root)}.recipe-{os.geteuid()}.lock"
+def _recipe_runtime_lock_path() -> str:
+    """Return the environment-independent, per-user host runtime lock."""
+    return os.path.join(os.path.realpath("/tmp"), f".nvflare-recipe-poc-{os.geteuid()}.lock")
 
 
 # Internal — not part of the public API
@@ -193,7 +193,7 @@ class PocEnv(ExecEnv):
         raise RuntimeError(
             f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
             f"{error}. Stop any remaining services, then remove the stale runtime record "
-            f"{_recipe_runtime_lock_path(self._poc_workspace_root)} manually."
+            f"{_recipe_runtime_lock_path()} manually."
         ) from error
 
     def _clean_up_failed_deployment(self) -> None:
@@ -228,8 +228,7 @@ class PocEnv(ExecEnv):
         if self._runtime_lock_file is not None:
             return
 
-        lock_path = _recipe_runtime_lock_path(self._poc_workspace_root)
-        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        lock_path = _recipe_runtime_lock_path()
         flags = os.O_CREAT | os.O_RDWR
         if hasattr(os, "O_CLOEXEC"):
             flags |= os.O_CLOEXEC

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -34,7 +34,6 @@ from nvflare.recipe.spec import ExecEnv
 from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
     POC_START_READY_TIMEOUT,
-    _clean_poc,
     _docker_cli_env,
     _is_live_pid_file,
     _start_poc,
@@ -162,7 +161,8 @@ class PocEnv(ExecEnv):
         self.study = v.study
         self._session_manager = None  # Lazy initialization
         self._session_manager_lock = threading.Lock()
-        self._workspace_used = False
+        self._deployment_started = False
+        self._services_may_have_started = False
         self._runtime_lock_file = None
         self._deployment_lock = threading.Lock()
 
@@ -183,6 +183,12 @@ class PocEnv(ExecEnv):
         identifier = candidate_name[len(prefix) :]
         return len(identifier) == 32 and all(c in "0123456789abcdef" for c in identifier.lower())
 
+    def _remove_recipe_workspace(self) -> None:
+        """Remove only this environment's Recipe-owned workspace."""
+        if not self._is_recipe_workspace(self.poc_workspace):
+            raise RuntimeError(f"refusing to remove unmanaged POC workspace {self.poc_workspace}")
+        shutil.rmtree(self.poc_workspace)
+
     def _clean_up_failed_deployment(self) -> None:
         """Stop a failed deployment and verify its per-run workspace was cleaned."""
         if not self._is_recipe_workspace(self.poc_workspace):
@@ -202,7 +208,7 @@ class PocEnv(ExecEnv):
         except Exception as e:
             if fail_if_unknown:
                 raise RuntimeError(
-                    f"Could not determine service state for the previously active Recipe PocEnv workspace {workspace}: "
+                    f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
                     f"{e}. Stop any remaining services, then remove the stale runtime record "
                     f"{_recipe_runtime_lock_path()} manually."
                 ) from e
@@ -212,7 +218,7 @@ class PocEnv(ExecEnv):
         except Exception as e:
             if fail_if_unknown:
                 raise RuntimeError(
-                    f"Could not determine service state for the previously active Recipe PocEnv workspace {workspace}: "
+                    f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
                     f"{e}. Stop any remaining services, then remove the stale runtime record "
                     f"{_recipe_runtime_lock_path()} manually."
                 ) from e
@@ -382,6 +388,9 @@ class PocEnv(ExecEnv):
 
     def _deploy(self, job: FedJob) -> str:
         """Perform one deployment while the instance deployment guard is held."""
+        if self._deployment_started:
+            raise RuntimeError("This PocEnv has already been used; create a new PocEnv for another deployment")
+
         # Validate scripts exist locally for POC
         non_local_scripts = collect_non_local_scripts(job)
         if non_local_scripts:
@@ -389,9 +398,6 @@ class PocEnv(ExecEnv):
                 f"The following scripts do not exist locally: {non_local_scripts}. "
                 f"For PocEnv, all scripts must be present on the local machine."
             )
-
-        if self._workspace_used and self._check_poc_running():
-            raise RuntimeError("This PocEnv already has a running deployment; stop it before deploying another job")
 
         # Recipe POC workspaces have isolated files but share host ports and
         # Docker participant names. The process-held lock closes the race
@@ -408,18 +414,16 @@ class PocEnv(ExecEnv):
             self._release_runtime_lock()
             raise
 
-        if self._workspace_used:
-            self.poc_workspace = self._new_poc_workspace()
-            self._session_manager = None
         try:
             self._record_runtime_workspace()
         except BaseException:
             self._release_runtime_lock()
             raise
-        self._workspace_used = True
-
         self.logger.info(f"Preparing and starting POC services in new workspace: {self.poc_workspace}")
         try:
+            # A PocEnv owns one provisioning lifecycle. Mark it consumed at
+            # the point provisioning begins, even if this attempt later fails.
+            self._deployment_started = True
             prepare_poc_provision(
                 clients=self.clients or [],  # Empty list if None, let prepare_clients generate
                 number_of_clients=self.num_clients,
@@ -429,6 +433,10 @@ class PocEnv(ExecEnv):
                 project_conf_path=self.project_conf_path,
                 examples_dir=None,
             )
+            # Startup can leave some services running even if it raises. From
+            # this point onward, missing service metadata is an unknown state
+            # and cleanup must preserve both the workspace and runtime lock.
+            self._services_may_have_started = True
             _start_poc(
                 poc_workspace=self.poc_workspace,
                 gpu_ids=self.gpu_ids,
@@ -470,7 +478,7 @@ class PocEnv(ExecEnv):
         Returns:
             bool: True if POC is running, False otherwise.
         """
-        return self._is_poc_workspace_running(self.poc_workspace)
+        return self._is_poc_workspace_running(self.poc_workspace, fail_if_unknown=self._services_may_have_started)
 
     def stop(self, clean_up: bool = False) -> None:
         """Try to stop and clean existing POC.
@@ -492,8 +500,12 @@ class PocEnv(ExecEnv):
             # POC already stopped or workspace doesn't exist
             if clean_up and os.path.exists(self.poc_workspace):
                 self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
-                shutil.rmtree(self.poc_workspace, ignore_errors=True)
+                try:
+                    self._remove_recipe_workspace()
+                except Exception as e:
+                    self.logger.warning(f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually.")
             self._session_manager = None  # Clear stale session manager
+            self._services_may_have_started = False
             self._release_runtime_lock(clear_workspace=True)
             return
 
@@ -544,12 +556,13 @@ class PocEnv(ExecEnv):
                     )
                 else:
                     try:
-                        _clean_poc(self.poc_workspace)
+                        self._remove_recipe_workspace()
                     except Exception as e:
                         self.logger.warning(
                             f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
                         )
             if not poc_running:
+                self._services_may_have_started = False
                 self._release_runtime_lock(clear_workspace=True)
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -15,10 +15,10 @@
 import errno
 import fcntl
 import os
-import pwd
 import shutil
 import stat
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -54,52 +54,81 @@ POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
+_RECIPE_RUNTIME_LOCK_DIR = "nvflare-recipe-poc"
+_RECIPE_RUNTIME_LOCK_FILE = "runtime.lock"
+_SHARED_RUNTIME_ROOT = "/tmp"
+
+
+def _private_temp_runtime_dir(effective_uid: int) -> str:
+    """Bootstrap a stable private UID directory below the host-local /tmp."""
+    shared_root = os.path.realpath(_SHARED_RUNTIME_ROOT)
+    root_flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        root_flags |= os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        root_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        root_flags |= os.O_NOFOLLOW
+
+    try:
+        root_fd = os.open(shared_root, root_flags)
+    except OSError as e:
+        raise RuntimeError(f"Could not open shared host runtime directory {shared_root}: {e}") from e
+    root_locked = False
+    try:
+        root_stat = os.fstat(root_fd)
+        writable_by_others = root_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        if (
+            not stat.S_ISDIR(root_stat.st_mode)
+            or root_stat.st_uid not in (0, effective_uid)
+            or (writable_by_others and not root_stat.st_mode & stat.S_ISVTX)
+        ):
+            raise RuntimeError(f"Refusing to bootstrap a Recipe POC runtime directory below {shared_root}")
+
+        # Serialize discovery and creation by locking the shared directory
+        # inode. Unlike a predictable file in /tmp, another user cannot
+        # pre-create or replace this inode to cause a persistent denial of
+        # service. The lock is held only for this short bootstrap operation.
+        fcntl.flock(root_fd, fcntl.LOCK_EX)
+        root_locked = True
+        prefix = f".nvflare-recipe-poc-{effective_uid}-"
+        private_dirs = []
+        with os.scandir(shared_root) as entries:
+            for entry in entries:
+                if not entry.name.startswith(prefix):
+                    continue
+                try:
+                    entry_stat = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if (
+                    stat.S_ISDIR(entry_stat.st_mode)
+                    and entry_stat.st_uid == effective_uid
+                    and not entry_stat.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
+                ):
+                    private_dirs.append(entry.path)
+        if private_dirs:
+            return os.path.realpath(min(private_dirs))
+
+        private_dir = tempfile.mkdtemp(prefix=prefix, dir=shared_root)
+        os.chmod(private_dir, 0o700)
+        return os.path.realpath(private_dir)
+    finally:
+        try:
+            if root_locked:
+                fcntl.flock(root_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(root_fd)
+
+
+def _host_user_runtime_dir() -> str:
+    """Return one canonical host-local runtime directory for the effective UID."""
+    return _private_temp_runtime_dir(os.geteuid())
 
 
 def _recipe_runtime_lock_path() -> str:
-    """Return the preferred environment-independent runtime lock."""
-    return _recipe_runtime_lock_paths()[0]
-
-
-def _recipe_runtime_lock_paths() -> list[str]:
-    """Return trusted runtime lock paths derived from the effective OS user."""
-    lock_dirs = []
-    try:
-        user_home = pwd.getpwuid(os.geteuid()).pw_dir
-    except KeyError:
-        pass
-    else:
-        if user_home:
-            lock_dirs.append(os.path.join(user_home, ".nvflare"))
-
-    effective_uid = os.geteuid()
-    for user_runtime_root in (f"/run/user/{effective_uid}", f"/var/run/user/{effective_uid}"):
-        if os.path.isdir(user_runtime_root):
-            lock_dirs.append(os.path.join(user_runtime_root, "nvflare"))
-
-    getconf = "/usr/bin/getconf"
-    if os.path.isfile(getconf):
-        try:
-            result = subprocess.run(
-                [getconf, "DARWIN_USER_TEMP_DIR"], capture_output=True, text=True, timeout=5, check=False
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            pass
-        else:
-            if result.returncode == 0 and result.stdout.strip():
-                lock_dirs.append(os.path.join(result.stdout.strip(), "nvflare"))
-
-    paths = []
-    for lock_dir in lock_dirs:
-        lock_path = os.path.join(os.path.realpath(lock_dir), "recipe-poc-runtime.lock")
-        if lock_path not in paths:
-            paths.append(lock_path)
-    if not paths:
-        raise RuntimeError(
-            "Could not determine a stable per-user Recipe POC runtime lock location; "
-            "configure an OS account home or user runtime directory"
-        )
-    return paths
+    """Return the canonical host-local lock for the effective OS user."""
+    return os.path.join(_host_user_runtime_dir(), _RECIPE_RUNTIME_LOCK_DIR, _RECIPE_RUNTIME_LOCK_FILE)
 
 
 # Internal — not part of the public API
@@ -278,25 +307,27 @@ class PocEnv(ExecEnv):
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
 
-        fd = None
-        location_errors = []
-        for lock_path in _recipe_runtime_lock_paths():
-            try:
-                lock_dir = os.path.dirname(lock_path)
-                os.makedirs(lock_dir, mode=0o700, exist_ok=True)
-                lock_dir_stat = os.stat(lock_dir)
-                if (
-                    not stat.S_ISDIR(lock_dir_stat.st_mode)
-                    or lock_dir_stat.st_uid != os.geteuid()
-                    or lock_dir_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-                ):
-                    raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
-                fd = os.open(lock_path, flags, 0o600)
-                break
-            except (OSError, RuntimeError) as e:
-                location_errors.append(f"{lock_path}: {e}")
-        if fd is None:
-            raise RuntimeError("Could not use a secure Recipe POC runtime lock location: " + "; ".join(location_errors))
+        lock_path = _recipe_runtime_lock_path()
+        lock_dir = os.path.dirname(lock_path)
+        try:
+            os.makedirs(lock_dir, mode=0o700, exist_ok=True)
+            lock_dir_stat = os.lstat(lock_dir)
+            if not stat.S_ISDIR(lock_dir_stat.st_mode) or lock_dir_stat.st_uid != os.geteuid():
+                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
+            # A pre-existing owner-controlled directory may have been created
+            # under a permissive umask. Normalize this dedicated directory,
+            # then verify it again before opening the lock file.
+            os.chmod(lock_dir, 0o700)
+            lock_dir_stat = os.lstat(lock_dir)
+            if (
+                not stat.S_ISDIR(lock_dir_stat.st_mode)
+                or lock_dir_stat.st_uid != os.geteuid()
+                or lock_dir_stat.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
+            ):
+                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
+            fd = os.open(lock_path, flags, 0o600)
+        except (OSError, RuntimeError) as e:
+            raise RuntimeError(f"Could not use secure Recipe POC runtime lock {lock_path}: {e}") from e
 
         try:
             lock_stat = os.fstat(fd)
@@ -321,6 +352,8 @@ class PocEnv(ExecEnv):
                     f"A prior Recipe PocEnv deployment is still active at {previous_workspace}. "
                     "Stop its services and remove the workspace manually before starting another deployment."
                 )
+            if previous_workspace:
+                self._write_runtime_workspace(lock_file, "")
             self._runtime_lock_file = lock_file
         except BaseException:
             self._runtime_lock_path = None
@@ -330,16 +363,21 @@ class PocEnv(ExecEnv):
                 lock_file.close()
             raise
 
+    @staticmethod
+    def _write_runtime_workspace(lock_file, workspace: str) -> None:
+        """Durably replace the workspace stored in an acquired runtime lock."""
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(workspace)
+        lock_file.flush()
+        os.fsync(lock_file.fileno())
+
     def _record_runtime_workspace(self) -> None:
-        """Durably record the workspace whose services own the runtime slot."""
+        """Durably record the workspace whose services may own the runtime slot."""
         lock_file = self._runtime_lock_file
         if lock_file is None:
             raise RuntimeError("Recipe POC runtime lock is not held")
-        lock_file.seek(0)
-        lock_file.truncate()
-        lock_file.write(os.path.abspath(self.poc_workspace))
-        lock_file.flush()
-        os.fsync(lock_file.fileno())
+        self._write_runtime_workspace(lock_file, os.path.abspath(self.poc_workspace))
 
     def _release_runtime_lock(self, clear_workspace: bool = False) -> None:
         """Release this environment's Recipe POC runtime slot, if held."""
@@ -350,10 +388,7 @@ class PocEnv(ExecEnv):
         self._runtime_lock_path = None
         try:
             if clear_workspace:
-                lock_file.seek(0)
-                lock_file.truncate()
-                lock_file.flush()
-                os.fsync(lock_file.fileno())
+                self._write_runtime_workspace(lock_file, "")
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
         finally:
             lock_file.close()
@@ -475,7 +510,6 @@ class PocEnv(ExecEnv):
                     f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
                     "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
                 )
-            self._record_runtime_workspace()
         except BaseException:
             self._release_runtime_lock()
             raise
@@ -493,6 +527,11 @@ class PocEnv(ExecEnv):
                 project_conf_path=self.project_conf_path,
                 examples_dir=None,
             )
+            # Provisioning only creates files. Record the workspace after it
+            # succeeds but before startup can leave services behind, avoiding
+            # a stale missing-workspace record if the process exits during
+            # provisioning.
+            self._record_runtime_workspace()
             # Startup can leave some services running even if it raises. From
             # this point onward, missing service metadata is an unknown state
             # and cleanup must preserve both the workspace and runtime lock.
@@ -558,15 +597,19 @@ class PocEnv(ExecEnv):
         # Check if already stopped (idempotent)
         if not self._check_poc_running():
             # POC already stopped or workspace doesn't exist
+            self._session_manager = None  # Clear stale session manager
+            self._services_may_have_started = False
+            # Once no service can still use this workspace, clear its durable
+            # record and release the runtime slot before removing files. A
+            # process exit during deletion can then leave only an inert,
+            # uniquely named directory rather than a blocking stale record.
+            self._release_runtime_lock(clear_workspace=True)
             if clean_up and os.path.exists(self.poc_workspace):
                 self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
                 try:
                     self._remove_recipe_workspace()
                 except Exception as e:
                     self.logger.warning(f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually.")
-            self._session_manager = None  # Clear stale session manager
-            self._services_may_have_started = False
-            self._release_runtime_lock(clear_workspace=True)
             return
 
         try:
@@ -603,8 +646,8 @@ class PocEnv(ExecEnv):
                 time.sleep(1)
                 count += 1
 
-            if clean_up:
-                if poc_running:
+            if poc_running:
+                if clean_up:
                     reason = (
                         f"service state could not be verified ({poc_state_error})"
                         if poc_state_error
@@ -614,16 +657,16 @@ class PocEnv(ExecEnv):
                         f"POC {reason}; preserving workspace {self.poc_workspace}. "
                         "Stop any remaining services and remove it manually."
                     )
-                else:
+            else:
+                self._services_may_have_started = False
+                self._release_runtime_lock(clear_workspace=True)
+                if clean_up:
                     try:
                         self._remove_recipe_workspace()
                     except Exception as e:
                         self.logger.warning(
                             f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
                         )
-            if not poc_running:
-                self._services_may_have_started = False
-                self._release_runtime_lock(clear_workspace=True)
         except Exception as e:
             self.logger.warning(f"Failed to stop and clean existing POC: {e}")
         finally:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -18,7 +18,6 @@ import os
 import shutil
 import stat
 import subprocess
-import tempfile
 import threading
 import time
 import uuid
@@ -56,9 +55,9 @@ DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
-def _recipe_runtime_lock_path() -> str:
-    """Return the per-user host lock that serializes Recipe POC runtimes."""
-    return os.path.join(tempfile.gettempdir(), f".nvflare-recipe-poc-{os.geteuid()}.lock")
+def _recipe_runtime_lock_path(poc_workspace_root: str) -> str:
+    """Return the per-user runtime lock beside the configured POC workspace."""
+    return f"{os.path.abspath(poc_workspace_root)}.recipe-{os.geteuid()}.lock"
 
 
 # Internal — not part of the public API
@@ -189,6 +188,14 @@ class PocEnv(ExecEnv):
             raise RuntimeError(f"refusing to remove unmanaged POC workspace {self.poc_workspace}")
         shutil.rmtree(self.poc_workspace)
 
+    def _raise_unknown_service_state(self, workspace: str, error: Exception) -> None:
+        """Raise recovery guidance when a Recipe workspace cannot be inspected."""
+        raise RuntimeError(
+            f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
+            f"{error}. Stop any remaining services, then remove the stale runtime record "
+            f"{_recipe_runtime_lock_path(self._poc_workspace_root)} manually."
+        ) from error
+
     def _clean_up_failed_deployment(self) -> None:
         """Stop a failed deployment and verify its per-run workspace was cleaned."""
         if not self._is_recipe_workspace(self.poc_workspace):
@@ -207,21 +214,13 @@ class PocEnv(ExecEnv):
             project_config, service_config = setup_service_config(workspace)
         except Exception as e:
             if fail_if_unknown:
-                raise RuntimeError(
-                    f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
-                    f"{e}. Stop any remaining services, then remove the stale runtime record "
-                    f"{_recipe_runtime_lock_path()} manually."
-                ) from e
+                self._raise_unknown_service_state(workspace, e)
             return False
         try:
             return bool(self._running_services(project_config, service_config, workspace))
         except Exception as e:
             if fail_if_unknown:
-                raise RuntimeError(
-                    f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
-                    f"{e}. Stop any remaining services, then remove the stale runtime record "
-                    f"{_recipe_runtime_lock_path()} manually."
-                ) from e
+                self._raise_unknown_service_state(workspace, e)
             raise
 
     def _acquire_runtime_lock(self) -> None:
@@ -229,7 +228,8 @@ class PocEnv(ExecEnv):
         if self._runtime_lock_file is not None:
             return
 
-        lock_path = _recipe_runtime_lock_path()
+        lock_path = _recipe_runtime_lock_path(self._poc_workspace_root)
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
         flags = os.O_CREAT | os.O_RDWR
         if hasattr(os, "O_CLOEXEC"):
             flags |= os.O_CLOEXEC
@@ -410,11 +410,6 @@ class PocEnv(ExecEnv):
                     f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
                     "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
                 )
-        except BaseException:
-            self._release_runtime_lock()
-            raise
-
-        try:
             self._record_runtime_workspace()
         except BaseException:
             self._release_runtime_lock()

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -206,32 +206,47 @@ class PocEnv(ExecEnv):
         self._docker_network_name = f"nvflare-recipe-{deployment_id}"
 
     def _remove_docker_network(self) -> None:
-        """Remove this deployment's Docker network after its containers stop."""
+        """Remove the network, allowing time for auto-removed job containers to detach."""
         if not self._docker_network_name:
             return
-        try:
-            result = subprocess.run(
-                ["docker", "network", "rm", self._docker_network_name],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-                env=_docker_cli_env(),
-            )
-        except (OSError, subprocess.TimeoutExpired) as error:
-            raise RuntimeError(f"could not remove Docker network {self._docker_network_name!r}") from error
+        docker_env = _docker_cli_env()
+        deadline = time.monotonic() + STOP_POC_TIMEOUT
+        error_message = "cleanup deadline reached"
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"could not remove Docker network {self._docker_network_name!r} "
+                    f"within {STOP_POC_TIMEOUT} seconds: {error_message}"
+                )
+            try:
+                result = subprocess.run(
+                    ["docker", "network", "rm", self._docker_network_name],
+                    capture_output=True,
+                    text=True,
+                    timeout=min(5, remaining),
+                    check=False,
+                    env=docker_env,
+                )
+            except (OSError, subprocess.TimeoutExpired) as error:
+                raise RuntimeError(f"could not remove Docker network {self._docker_network_name!r}") from error
 
-        error_message = (getattr(result, "stderr", "") or result.stdout).strip()
-        if result.returncode == 0 or any(
-            marker in error_message.lower() for marker in ("no such network", "not found")
-        ):
-            self._docker_network_name = None
-            return
-        detail = f": {error_message}" if error_message else ""
-        raise RuntimeError(
-            f"could not remove Docker network {self._docker_network_name!r} "
-            f"(docker network rm exited {result.returncode}){detail}"
-        )
+            error_message = (getattr(result, "stderr", "") or result.stdout).strip()
+            if result.returncode == 0 or any(
+                marker in error_message.lower() for marker in ("no such network", "not found")
+            ):
+                self._docker_network_name = None
+                return
+            if "active endpoints" not in error_message.lower():
+                detail = f": {error_message}" if error_message else ""
+                raise RuntimeError(
+                    f"could not remove Docker network {self._docker_network_name!r} "
+                    f"(docker network rm exited {result.returncode}){detail}"
+                )
+            # Parent shutdown can finish before --rm job containers release their
+            # network endpoints. Let Docker finish without disconnecting containers
+            # or removing their workspace while they may still be using it.
+            time.sleep(min(POC_READY_POLL_INTERVAL, max(0, deadline - time.monotonic())))
 
     def _with_docker_container_names(self, workspace: str, service_config: dict) -> dict:
         """Attach this deployment's Docker-name mapping to current-workspace service state."""

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -57,24 +57,48 @@ _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
 def _recipe_runtime_lock_path() -> str:
-    """Return the preferred runtime lock for the OS user."""
-    try:
-        user_home = pwd.getpwuid(os.geteuid()).pw_dir
-    except KeyError:
-        user_home = os.environ.get("HOME")
-    if not user_home:
-        raise RuntimeError("Could not determine a home directory for the Recipe POC runtime lock")
-    return os.path.join(user_home, ".nvflare", "recipe-poc-runtime.lock")
+    """Return the preferred environment-independent runtime lock."""
+    return _recipe_runtime_lock_paths()[0]
 
 
 def _recipe_runtime_lock_paths() -> list[str]:
-    """Return preferred and environment-home fallback lock paths."""
-    paths = [_recipe_runtime_lock_path()]
-    env_home = os.environ.get("HOME")
-    if env_home:
-        fallback = os.path.join(env_home, ".nvflare", "recipe-poc-runtime.lock")
-        if fallback not in paths:
-            paths.append(fallback)
+    """Return trusted runtime lock paths derived from the effective OS user."""
+    lock_dirs = []
+    try:
+        user_home = pwd.getpwuid(os.geteuid()).pw_dir
+    except KeyError:
+        pass
+    else:
+        if user_home:
+            lock_dirs.append(os.path.join(user_home, ".nvflare"))
+
+    effective_uid = os.geteuid()
+    for user_runtime_root in (f"/run/user/{effective_uid}", f"/var/run/user/{effective_uid}"):
+        if os.path.isdir(user_runtime_root):
+            lock_dirs.append(os.path.join(user_runtime_root, "nvflare"))
+
+    getconf = "/usr/bin/getconf"
+    if os.path.isfile(getconf):
+        try:
+            result = subprocess.run(
+                [getconf, "DARWIN_USER_TEMP_DIR"], capture_output=True, text=True, timeout=5, check=False
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        else:
+            if result.returncode == 0 and result.stdout.strip():
+                lock_dirs.append(os.path.join(result.stdout.strip(), "nvflare"))
+
+    paths = []
+    for lock_dir in lock_dirs:
+        lock_path = os.path.join(os.path.realpath(lock_dir), "recipe-poc-runtime.lock")
+        if lock_path not in paths:
+            paths.append(lock_path)
+    if not paths:
+        raise RuntimeError(
+            "Could not determine a stable per-user Recipe POC runtime lock location; "
+            "configure an OS account home or user runtime directory"
+        )
     return paths
 
 

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -26,18 +26,23 @@ from nvflare.apis.job_def import DEFAULT_STUDY
 from nvflare.apis.utils.format_check import name_check
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.job_config.api import FedJob
+from nvflare.lighter.utils import load_yaml
 from nvflare.recipe.spec import ExecEnv
 from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
+    POC_DEFAULT_ADMIN_PORT,
+    POC_DEFAULT_FED_LEARN_PORT,
     POC_START_READY_TIMEOUT,
     _build_poc_port_preflight,
     _docker_cli_env,
+    _get_docker_endpoint,
     _is_live_pid_file,
     _start_poc,
     _stop_poc,
     _wait_for_poc_system_ready,
     get_poc_workspace,
     get_prod_dir,
+    is_docker_run,
     is_poc_running,
     prepare_poc_provision,
     setup_service_config,
@@ -51,6 +56,7 @@ POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
+_RECIPE_DOCKER_CONTAINER_NAMES = "_recipe_docker_container_names"
 
 
 # Internal — not part of the public API
@@ -155,6 +161,8 @@ class PocEnv(ExecEnv):
         self._session_manager_lock = threading.Lock()
         self._deployment_started = False
         self._services_may_have_started = False
+        self._docker_container_names = {}
+        self._docker_network_name = None
         self._deployment_lock = threading.Lock()
 
     def _new_poc_workspace(self) -> str:
@@ -179,6 +187,61 @@ class PocEnv(ExecEnv):
         if not self._is_recipe_workspace(self.poc_workspace):
             raise RuntimeError(f"refusing to remove unmanaged POC workspace {self.poc_workspace}")
         shutil.rmtree(self.poc_workspace)
+
+    def _configure_docker_identities(self, service_config: dict) -> None:
+        """Assign unique per-workspace Docker identities without changing FL identities."""
+        self._docker_container_names = {}
+        self._docker_network_name = None
+        if not service_config.get(SC.IS_DOCKER_RUN):
+            return
+        if not self._is_recipe_workspace(self.poc_workspace):
+            raise RuntimeError(f"cannot create Recipe Docker names for unmanaged workspace {self.poc_workspace}")
+
+        deployment_id = os.path.basename(self.poc_workspace).rsplit(_RECIPE_WORKSPACE_SUFFIX, 1)[1]
+        service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+        self._docker_container_names = {
+            service_name: f"nvflare-recipe-{deployment_id}-{uuid.uuid5(uuid.NAMESPACE_OID, service_name).hex}"
+            for service_name in service_names
+        }
+        self._docker_network_name = f"nvflare-recipe-{deployment_id}"
+
+    def _remove_docker_network(self) -> None:
+        """Remove this deployment's Docker network after its containers stop."""
+        if not self._docker_network_name:
+            return
+        try:
+            result = subprocess.run(
+                ["docker", "network", "rm", self._docker_network_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+                env=_docker_cli_env(),
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise RuntimeError(f"could not remove Docker network {self._docker_network_name!r}") from error
+
+        error_message = (getattr(result, "stderr", "") or result.stdout).strip()
+        if result.returncode == 0 or any(
+            marker in error_message.lower() for marker in ("no such network", "not found")
+        ):
+            self._docker_network_name = None
+            return
+        detail = f": {error_message}" if error_message else ""
+        raise RuntimeError(
+            f"could not remove Docker network {self._docker_network_name!r} "
+            f"(docker network rm exited {result.returncode}){detail}"
+        )
+
+    def _with_docker_container_names(self, workspace: str, service_config: dict) -> dict:
+        """Attach this deployment's Docker-name mapping to current-workspace service state."""
+        if (
+            self._docker_container_names
+            and os.path.abspath(workspace) == os.path.abspath(self.poc_workspace)
+            and service_config.get(SC.IS_DOCKER_RUN)
+        ):
+            return {**service_config, _RECIPE_DOCKER_CONTAINER_NAMES: self._docker_container_names}
+        return service_config
 
     def _raise_unknown_service_state(self, workspace: str, error: Exception) -> None:
         """Raise recovery guidance when a Recipe workspace cannot be inspected."""
@@ -212,6 +275,7 @@ class PocEnv(ExecEnv):
             if fail_if_unknown:
                 self._raise_unknown_service_state(workspace, e)
             return False
+        service_config = self._with_docker_container_names(workspace, service_config)
         try:
             return bool(self._running_services(project_config, service_config, workspace))
         except Exception as e:
@@ -255,22 +319,38 @@ class PocEnv(ExecEnv):
         return PocEnv._get_docker_service_state(service_name) is True
 
     @staticmethod
+    def _docker_daemon_is_local() -> bool:
+        """Return whether Docker targets a verified local Unix-socket daemon."""
+        return _get_docker_endpoint(_docker_cli_env()).startswith("unix://")
+
+    @staticmethod
+    def _ensure_ports_available(project_config: dict, is_docker: bool) -> None:
+        """Reject configured ports already owned by another local deployment."""
+        # A loopback bind is authoritative only when Docker uses the local
+        # Unix-socket daemon. Remote-daemon conflicts fail at Docker startup.
+        if not is_docker or PocEnv._docker_daemon_is_local():
+            port_conflicts = _build_poc_port_preflight(project_config).get("conflicts", [])
+            if port_conflicts:
+                details = "; ".join(conflict.get("message", str(conflict)) for conflict in port_conflicts)
+                raise RuntimeError(
+                    f"POC service port preflight failed: {details}. Stop the process or other Recipe PocEnv using "
+                    "the configured port(s) before starting this PocEnv; 'nvflare poc stop' only stops the "
+                    "configured CLI deployment."
+                )
+
+    @staticmethod
     def _ensure_shared_resources_available(project_config: dict, service_config: dict) -> None:
         """Reject ports or Docker names already owned by another POC deployment."""
-        port_conflicts = _build_poc_port_preflight(project_config).get("conflicts", [])
-        if port_conflicts:
-            details = "; ".join(conflict.get("message", str(conflict)) for conflict in port_conflicts)
-            raise RuntimeError(
-                f"POC service port preflight failed: {details}. Stop the process using the configured port(s) "
-                "before starting this PocEnv."
-            )
+        is_docker = service_config.get(SC.IS_DOCKER_RUN)
+        PocEnv._ensure_ports_available(project_config, is_docker)
 
-        if service_config.get(SC.IS_DOCKER_RUN):
+        if is_docker:
             service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+            container_names = service_config.get(_RECIPE_DOCKER_CONTAINER_NAMES, {})
             existing_services = [
-                service_name
+                container_names.get(service_name, service_name)
                 for service_name in service_names
-                if PocEnv._get_docker_service_state(service_name) is not None
+                if PocEnv._get_docker_service_state(container_names.get(service_name, service_name)) is not None
             ]
             if existing_services:
                 raise RuntimeError(
@@ -278,12 +358,34 @@ class PocEnv(ExecEnv):
                     f"{', '.join(existing_services)}. Stop and remove them before starting this PocEnv."
                 )
 
+    def _preflight_ports_before_provision(self) -> None:
+        """Check intended ports before provisioning consumes this one-shot environment."""
+        if self.project_conf_path:
+            project_config = load_yaml(self.project_conf_path)
+            is_docker = is_docker_run(project_config)
+        else:
+            project_config = {
+                "participants": [
+                    {
+                        "name": "server",
+                        "type": "server",
+                        "fed_learn_port": POC_DEFAULT_FED_LEARN_PORT,
+                        "admin_port": POC_DEFAULT_ADMIN_PORT,
+                    }
+                ]
+            }
+            is_docker = bool(self.docker_image)
+        self._ensure_ports_available(project_config, is_docker)
+
     @staticmethod
     def _running_services(project_config: dict, service_config: dict, poc_workspace: str) -> list[str]:
         """Return managed POC services whose local process is still alive."""
         service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
         if service_config.get(SC.IS_DOCKER_RUN):
-            return [name for name in service_names if PocEnv._is_docker_service_running(name)]
+            container_names = service_config.get(_RECIPE_DOCKER_CONTAINER_NAMES, {})
+            return [
+                name for name in service_names if PocEnv._is_docker_service_running(container_names.get(name, name))
+            ]
 
         project_name = project_config.get("name")
         prod_dir = get_prod_dir(poc_workspace, project_name)
@@ -359,6 +461,7 @@ class PocEnv(ExecEnv):
                 f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
                 "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
             )
+        self._preflight_ports_before_provision()
         self.logger.info(f"Preparing and starting POC services in new workspace: {self.poc_workspace}")
         try:
             # A PocEnv owns one provisioning lifecycle. Mark it consumed at
@@ -374,19 +477,27 @@ class PocEnv(ExecEnv):
                 examples_dir=None,
             )
             project_config, service_config = setup_service_config(self.poc_workspace)
-            # Recipe workspaces isolate files, but POC servers still bind host
-            # ports and Docker mode still uses participant names as container
-            # names. Check those shared resources immediately before startup.
+            self._configure_docker_identities(service_config)
+            service_config = self._with_docker_container_names(self.poc_workspace, service_config)
+            # Recipe workspaces isolate files, while POC servers still bind
+            # configured ports. Docker deployments additionally get unique
+            # container and network identities so cleanup cannot cross runs.
             self._ensure_shared_resources_available(project_config, service_config)
             # Startup can leave some services running even if it raises. From
             # this point onward, missing service metadata is an unknown state
             # and cleanup must preserve the workspace.
             self._services_may_have_started = True
+            start_args = {
+                "poc_workspace": self.poc_workspace,
+                "gpu_ids": self.gpu_ids,
+                "excluded": [self.username],
+                "services_list": [],
+            }
+            if self._docker_container_names:
+                start_args["docker_container_names"] = self._docker_container_names
+                start_args["docker_network_name"] = self._docker_network_name
             _start_poc(
-                poc_workspace=self.poc_workspace,
-                gpu_ids=self.gpu_ids,
-                excluded=[self.username],
-                services_list=[],
+                **start_args,
             )
             self._wait_for_services_ready(project_config, service_config)
             if not _wait_for_poc_system_ready(
@@ -439,21 +550,49 @@ class PocEnv(ExecEnv):
 
     def _stop(self, clean_up: bool = False) -> None:
         """Stop POC while the caller holds the instance lifecycle guard."""
-        # Check if already stopped (idempotent)
-        if not self._check_poc_running():
-            # POC already stopped or workspace doesn't exist
-            self._session_manager = None  # Clear stale session manager
-            self._services_may_have_started = False
-            if clean_up and os.path.exists(self.poc_workspace):
-                self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
-                try:
-                    self._remove_recipe_workspace()
-                except Exception as e:
-                    self.logger.warning(f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually.")
-            return
-
         try:
+            try:
+                poc_running = self._check_poc_running()
+            except Exception as state_error:
+                # State can be unknown when provisioned metadata is damaged.
+                # Still make the normal stop attempt, but do not remove the
+                # workspace or reset the uncertainty flag without verification.
+                self.logger.warning(f"Could not determine whether POC services are running: {state_error}")
+                stop_args = {
+                    "poc_workspace": self.poc_workspace,
+                    "excluded": [self.username],
+                    "services_list": [],
+                }
+                if self._docker_container_names:
+                    stop_args["docker_container_names"] = self._docker_container_names
+                try:
+                    _stop_poc(**stop_args)
+                except Exception as stop_error:
+                    self.logger.warning(f"Could not stop POC services with unknown state: {stop_error}")
+                if clean_up:
+                    self.logger.warning(
+                        f"POC service state could not be verified; preserving workspace {self.poc_workspace}. "
+                        "Stop any remaining services and remove it manually."
+                    )
+                return
+
+            # Check if already stopped (idempotent)
+            if not poc_running:
+                # POC already stopped or workspace doesn't exist
+                self._remove_docker_network()
+                self._services_may_have_started = False
+                if clean_up and os.path.exists(self.poc_workspace):
+                    self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
+                    try:
+                        self._remove_recipe_workspace()
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Failed to clean POC workspace {self.poc_workspace}: {e}. Remove it manually."
+                        )
+                return
+
             project_config, service_config = setup_service_config(self.poc_workspace)
+            service_config = self._with_docker_container_names(self.poc_workspace, service_config)
             self.logger.info("Stopping existing POC services...")
             # Prefer the coordinated server shutdown while it is reachable. If
             # the server exited during startup, stop any surviving local client
@@ -463,10 +602,15 @@ class PocEnv(ExecEnv):
                 self.poc_workspace, service_config, project_config
             ):
                 services_list = self._running_services(project_config, service_config, self.poc_workspace)
+            stop_args = {
+                "poc_workspace": self.poc_workspace,
+                "excluded": [self.username],  # Exclude admin console (consistent with start)
+                "services_list": services_list,
+            }
+            if self._docker_container_names:
+                stop_args["docker_container_names"] = self._docker_container_names
             _stop_poc(
-                poc_workspace=self.poc_workspace,
-                excluded=[self.username],  # Exclude admin console (consistent with start)
-                services_list=services_list,
+                **stop_args,
             )
             count = 0
             poc_running = True
@@ -498,6 +642,7 @@ class PocEnv(ExecEnv):
                         "Stop any remaining services and remove it manually."
                     )
             else:
+                self._remove_docker_network()
                 self._services_may_have_started = False
                 if clean_up:
                     try:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import errno
-import fcntl
 import os
 import shutil
-import stat
 import subprocess
-import tempfile
 import threading
 import time
 import uuid
@@ -34,6 +30,7 @@ from nvflare.recipe.spec import ExecEnv
 from nvflare.recipe.utils import collect_non_local_scripts
 from nvflare.tool.poc.poc_commands import (
     POC_START_READY_TIMEOUT,
+    _build_poc_port_preflight,
     _docker_cli_env,
     _is_live_pid_file,
     _start_poc,
@@ -54,81 +51,6 @@ POC_READY_POLL_INTERVAL = 0.2
 POC_READY_STABLE_INTERVAL = 2.0
 DEFAULT_ADMIN_USER = "admin@nvidia.com"
 _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
-_RECIPE_RUNTIME_LOCK_DIR = "nvflare-recipe-poc"
-_RECIPE_RUNTIME_LOCK_FILE = "runtime.lock"
-_SHARED_RUNTIME_ROOT = "/tmp"
-
-
-def _private_temp_runtime_dir(effective_uid: int) -> str:
-    """Bootstrap a stable private UID directory below the host-local /tmp."""
-    shared_root = os.path.realpath(_SHARED_RUNTIME_ROOT)
-    root_flags = os.O_RDONLY
-    if hasattr(os, "O_CLOEXEC"):
-        root_flags |= os.O_CLOEXEC
-    if hasattr(os, "O_DIRECTORY"):
-        root_flags |= os.O_DIRECTORY
-    if hasattr(os, "O_NOFOLLOW"):
-        root_flags |= os.O_NOFOLLOW
-
-    try:
-        root_fd = os.open(shared_root, root_flags)
-    except OSError as e:
-        raise RuntimeError(f"Could not open shared host runtime directory {shared_root}: {e}") from e
-    root_locked = False
-    try:
-        root_stat = os.fstat(root_fd)
-        writable_by_others = root_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-        if (
-            not stat.S_ISDIR(root_stat.st_mode)
-            or root_stat.st_uid not in (0, effective_uid)
-            or (writable_by_others and not root_stat.st_mode & stat.S_ISVTX)
-        ):
-            raise RuntimeError(f"Refusing to bootstrap a Recipe POC runtime directory below {shared_root}")
-
-        # Serialize discovery and creation by locking the shared directory
-        # inode. Unlike a predictable file in /tmp, another user cannot
-        # pre-create or replace this inode to cause a persistent denial of
-        # service. The lock is held only for this short bootstrap operation.
-        fcntl.flock(root_fd, fcntl.LOCK_EX)
-        root_locked = True
-        prefix = f".nvflare-recipe-poc-{effective_uid}-"
-        private_dirs = []
-        with os.scandir(shared_root) as entries:
-            for entry in entries:
-                if not entry.name.startswith(prefix):
-                    continue
-                try:
-                    entry_stat = entry.stat(follow_symlinks=False)
-                except OSError:
-                    continue
-                if (
-                    stat.S_ISDIR(entry_stat.st_mode)
-                    and entry_stat.st_uid == effective_uid
-                    and not entry_stat.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
-                ):
-                    private_dirs.append(entry.path)
-        if private_dirs:
-            return os.path.realpath(min(private_dirs))
-
-        private_dir = tempfile.mkdtemp(prefix=prefix, dir=shared_root)
-        os.chmod(private_dir, 0o700)
-        return os.path.realpath(private_dir)
-    finally:
-        try:
-            if root_locked:
-                fcntl.flock(root_fd, fcntl.LOCK_UN)
-        finally:
-            os.close(root_fd)
-
-
-def _host_user_runtime_dir() -> str:
-    """Return one canonical host-local runtime directory for the effective UID."""
-    return _private_temp_runtime_dir(os.geteuid())
-
-
-def _recipe_runtime_lock_path() -> str:
-    """Return the canonical host-local lock for the effective OS user."""
-    return os.path.join(_host_user_runtime_dir(), _RECIPE_RUNTIME_LOCK_DIR, _RECIPE_RUNTIME_LOCK_FILE)
 
 
 # Internal — not part of the public API
@@ -233,8 +155,6 @@ class PocEnv(ExecEnv):
         self._session_manager_lock = threading.Lock()
         self._deployment_started = False
         self._services_may_have_started = False
-        self._runtime_lock_file = None
-        self._runtime_lock_path = None
         self._deployment_lock = threading.Lock()
 
     def _new_poc_workspace(self) -> str:
@@ -262,17 +182,20 @@ class PocEnv(ExecEnv):
 
     def _raise_unknown_service_state(self, workspace: str, error: Exception) -> None:
         """Raise recovery guidance when a Recipe workspace cannot be inspected."""
-        lock_path = self._runtime_lock_path or _recipe_runtime_lock_path()
         raise RuntimeError(
             f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
-            f"{error}. Stop any remaining services, then remove the stale runtime record "
-            f"{lock_path} manually."
+            f"{error}. Stop any remaining services, then remove the workspace manually."
         ) from error
 
     def _clean_up_failed_deployment(self) -> None:
         """Stop a failed deployment and verify its per-run workspace was cleaned."""
         if not self._is_recipe_workspace(self.poc_workspace):
             raise RuntimeError(f"refusing to clean unmanaged POC workspace {self.poc_workspace}")
+        if not self._services_may_have_started:
+            if os.path.exists(self.poc_workspace):
+                self._remove_recipe_workspace()
+            self._session_manager = None
+            return
         # deploy() already holds the instance lifecycle guard. Use the private
         # implementation so failure cleanup cannot deadlock on that guard.
         self._stop(clean_up=True)
@@ -296,106 +219,9 @@ class PocEnv(ExecEnv):
                 self._raise_unknown_service_state(workspace, e)
             raise
 
-    def _acquire_runtime_lock(self) -> None:
-        """Claim the host's single Recipe-managed POC runtime slot."""
-        if self._runtime_lock_file is not None:
-            return
-
-        flags = os.O_CREAT | os.O_RDWR
-        if hasattr(os, "O_CLOEXEC"):
-            flags |= os.O_CLOEXEC
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
-
-        lock_path = _recipe_runtime_lock_path()
-        lock_dir = os.path.dirname(lock_path)
-        try:
-            os.makedirs(lock_dir, mode=0o700, exist_ok=True)
-            lock_dir_stat = os.lstat(lock_dir)
-            if not stat.S_ISDIR(lock_dir_stat.st_mode) or lock_dir_stat.st_uid != os.geteuid():
-                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
-            # A pre-existing owner-controlled directory may have been created
-            # under a permissive umask. Normalize this dedicated directory,
-            # then verify it again before opening the lock file.
-            os.chmod(lock_dir, 0o700)
-            lock_dir_stat = os.lstat(lock_dir)
-            if (
-                not stat.S_ISDIR(lock_dir_stat.st_mode)
-                or lock_dir_stat.st_uid != os.geteuid()
-                or lock_dir_stat.st_mode & (stat.S_IRWXG | stat.S_IRWXO)
-            ):
-                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
-            fd = os.open(lock_path, flags, 0o600)
-        except (OSError, RuntimeError) as e:
-            raise RuntimeError(f"Could not use secure Recipe POC runtime lock {lock_path}: {e}") from e
-
-        try:
-            lock_stat = os.fstat(fd)
-            if not stat.S_ISREG(lock_stat.st_mode) or lock_stat.st_uid != os.geteuid():
-                raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock {lock_path}")
-            os.fchmod(fd, 0o600)
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError as e:
-                if e.errno in (errno.EACCES, errno.EAGAIN):
-                    raise RuntimeError(
-                        "Another Recipe PocEnv deployment is active on this host. "
-                        "Stop it before starting this deployment."
-                    ) from e
-                raise
-            self._runtime_lock_path = lock_path
-            lock_file = os.fdopen(fd, "r+")
-            fd = None
-            previous_workspace = lock_file.read().strip()
-            if previous_workspace and self._is_poc_workspace_running(previous_workspace, fail_if_unknown=True):
-                raise RuntimeError(
-                    f"A prior Recipe PocEnv deployment is still active at {previous_workspace}. "
-                    "Stop its services and remove the workspace manually before starting another deployment."
-                )
-            if previous_workspace:
-                self._write_runtime_workspace(lock_file, "")
-            self._runtime_lock_file = lock_file
-        except BaseException:
-            self._runtime_lock_path = None
-            if fd is not None:
-                os.close(fd)
-            else:
-                lock_file.close()
-            raise
-
     @staticmethod
-    def _write_runtime_workspace(lock_file, workspace: str) -> None:
-        """Durably replace the workspace stored in an acquired runtime lock."""
-        lock_file.seek(0)
-        lock_file.truncate()
-        lock_file.write(workspace)
-        lock_file.flush()
-        os.fsync(lock_file.fileno())
-
-    def _record_runtime_workspace(self) -> None:
-        """Durably record the workspace whose services may own the runtime slot."""
-        lock_file = self._runtime_lock_file
-        if lock_file is None:
-            raise RuntimeError("Recipe POC runtime lock is not held")
-        self._write_runtime_workspace(lock_file, os.path.abspath(self.poc_workspace))
-
-    def _release_runtime_lock(self, clear_workspace: bool = False) -> None:
-        """Release this environment's Recipe POC runtime slot, if held."""
-        lock_file = self._runtime_lock_file
-        if lock_file is None:
-            return
-        self._runtime_lock_file = None
-        self._runtime_lock_path = None
-        try:
-            if clear_workspace:
-                self._write_runtime_workspace(lock_file, "")
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-        finally:
-            lock_file.close()
-
-    @staticmethod
-    def _is_docker_service_running(service_name: str) -> bool:
-        """Return whether Docker reports the named POC container as running."""
+    def _get_docker_service_state(service_name: str) -> Optional[bool]:
+        """Return a Docker POC container's running state, or None if it does not exist."""
         try:
             result = subprocess.run(
                 ["docker", "inspect", "--format", "{{.State.Running}}", service_name],
@@ -416,12 +242,41 @@ class PocEnv(ExecEnv):
         if result.returncode != 0 and any(
             marker in error_message.lower() for marker in ("no such object", "no such container")
         ):
-            return False
+            return None
         detail = f": {error_message}" if error_message else ""
         raise RuntimeError(
             f"Could not determine Docker POC service state for {service_name!r} "
             f"(docker inspect exited {result.returncode}){detail}"
         )
+
+    @staticmethod
+    def _is_docker_service_running(service_name: str) -> bool:
+        """Return whether Docker reports the named POC container as running."""
+        return PocEnv._get_docker_service_state(service_name) is True
+
+    @staticmethod
+    def _ensure_shared_resources_available(project_config: dict, service_config: dict) -> None:
+        """Reject ports or Docker names already owned by another POC deployment."""
+        port_conflicts = _build_poc_port_preflight(project_config).get("conflicts", [])
+        if port_conflicts:
+            details = "; ".join(conflict.get("message", str(conflict)) for conflict in port_conflicts)
+            raise RuntimeError(
+                f"POC service port preflight failed: {details}. Stop the process using the configured port(s) "
+                "before starting this PocEnv."
+            )
+
+        if service_config.get(SC.IS_DOCKER_RUN):
+            service_names = [service_config[SC.FLARE_SERVER], *service_config.get(SC.FLARE_CLIENTS, [])]
+            existing_services = [
+                service_name
+                for service_name in service_names
+                if PocEnv._get_docker_service_state(service_name) is not None
+            ]
+            if existing_services:
+                raise RuntimeError(
+                    "Docker POC participant container name(s) already exist: "
+                    f"{', '.join(existing_services)}. Stop and remove them before starting this PocEnv."
+                )
 
     @staticmethod
     def _running_services(project_config: dict, service_config: dict, poc_workspace: str) -> list[str]:
@@ -499,20 +354,11 @@ class PocEnv(ExecEnv):
                 f"For PocEnv, all scripts must be present on the local machine."
             )
 
-        # Recipe POC workspaces have isolated files but share host ports and
-        # Docker participant names. The process-held lock closes the race
-        # between checking those resources and starting services. It is
-        # released only after this deployment's services have stopped.
-        self._acquire_runtime_lock()
-        try:
-            if self._is_poc_workspace_running(self._poc_workspace_root):
-                raise RuntimeError(
-                    f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
-                    "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
-                )
-        except BaseException:
-            self._release_runtime_lock()
-            raise
+        if self._is_poc_workspace_running(self._poc_workspace_root):
+            raise RuntimeError(
+                f"The configured CLI POC deployment is running at {self._poc_workspace_root}. "
+                "Stop it with 'nvflare poc stop' before starting a Recipe PocEnv deployment."
+            )
         self.logger.info(f"Preparing and starting POC services in new workspace: {self.poc_workspace}")
         try:
             # A PocEnv owns one provisioning lifecycle. Mark it consumed at
@@ -527,14 +373,14 @@ class PocEnv(ExecEnv):
                 project_conf_path=self.project_conf_path,
                 examples_dir=None,
             )
-            # Provisioning only creates files. Record the workspace after it
-            # succeeds but before startup can leave services behind, avoiding
-            # a stale missing-workspace record if the process exits during
-            # provisioning.
-            self._record_runtime_workspace()
+            project_config, service_config = setup_service_config(self.poc_workspace)
+            # Recipe workspaces isolate files, but POC servers still bind host
+            # ports and Docker mode still uses participant names as container
+            # names. Check those shared resources immediately before startup.
+            self._ensure_shared_resources_available(project_config, service_config)
             # Startup can leave some services running even if it raises. From
             # this point onward, missing service metadata is an unknown state
-            # and cleanup must preserve both the workspace and runtime lock.
+            # and cleanup must preserve the workspace.
             self._services_may_have_started = True
             _start_poc(
                 poc_workspace=self.poc_workspace,
@@ -542,7 +388,6 @@ class PocEnv(ExecEnv):
                 excluded=[self.username],
                 services_list=[],
             )
-            project_config, service_config = setup_service_config(self.poc_workspace)
             self._wait_for_services_ready(project_config, service_config)
             if not _wait_for_poc_system_ready(
                 self.poc_workspace,
@@ -587,8 +432,8 @@ class PocEnv(ExecEnv):
         Args:
             clean_up (bool, optional): Whether to clean the POC workspace. Defaults to False.
         """
-        # Wait for an in-progress deployment to finish before inspecting
-        # services or clearing its durable runtime record.
+        # Wait for an in-progress deployment to finish before inspecting its
+        # services or removing its workspace.
         with self._deployment_lock:
             self._stop(clean_up)
 
@@ -599,11 +444,6 @@ class PocEnv(ExecEnv):
             # POC already stopped or workspace doesn't exist
             self._session_manager = None  # Clear stale session manager
             self._services_may_have_started = False
-            # Once no service can still use this workspace, clear its durable
-            # record and release the runtime slot before removing files. A
-            # process exit during deletion can then leave only an inert,
-            # uniquely named directory rather than a blocking stale record.
-            self._release_runtime_lock(clear_workspace=True)
             if clean_up and os.path.exists(self.poc_workspace):
                 self.logger.info(f"Removing POC workspace: {self.poc_workspace}")
                 try:
@@ -659,7 +499,6 @@ class PocEnv(ExecEnv):
                     )
             else:
                 self._services_may_have_started = False
-                self._release_runtime_lock(clear_workspace=True)
                 if clean_up:
                     try:
                         self._remove_recipe_workspace()

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -57,9 +57,25 @@ _RECIPE_WORKSPACE_SUFFIX = ".recipe-"
 
 
 def _recipe_runtime_lock_path() -> str:
-    """Return the environment-independent runtime lock for the OS user."""
-    user_home = pwd.getpwuid(os.geteuid()).pw_dir
+    """Return the preferred runtime lock for the OS user."""
+    try:
+        user_home = pwd.getpwuid(os.geteuid()).pw_dir
+    except KeyError:
+        user_home = os.environ.get("HOME")
+    if not user_home:
+        raise RuntimeError("Could not determine a home directory for the Recipe POC runtime lock")
     return os.path.join(user_home, ".nvflare", "recipe-poc-runtime.lock")
+
+
+def _recipe_runtime_lock_paths() -> list[str]:
+    """Return preferred and environment-home fallback lock paths."""
+    paths = [_recipe_runtime_lock_path()]
+    env_home = os.environ.get("HOME")
+    if env_home:
+        fallback = os.path.join(env_home, ".nvflare", "recipe-poc-runtime.lock")
+        if fallback not in paths:
+            paths.append(fallback)
+    return paths
 
 
 # Internal — not part of the public API
@@ -165,6 +181,7 @@ class PocEnv(ExecEnv):
         self._deployment_started = False
         self._services_may_have_started = False
         self._runtime_lock_file = None
+        self._runtime_lock_path = None
         self._deployment_lock = threading.Lock()
 
     def _new_poc_workspace(self) -> str:
@@ -192,10 +209,11 @@ class PocEnv(ExecEnv):
 
     def _raise_unknown_service_state(self, workspace: str, error: Exception) -> None:
         """Raise recovery guidance when a Recipe workspace cannot be inspected."""
+        lock_path = self._runtime_lock_path or _recipe_runtime_lock_path()
         raise RuntimeError(
             f"Could not determine service state for the Recipe PocEnv workspace {workspace}: "
             f"{error}. Stop any remaining services, then remove the stale runtime record "
-            f"{_recipe_runtime_lock_path()} manually."
+            f"{lock_path} manually."
         ) from error
 
     def _clean_up_failed_deployment(self) -> None:
@@ -230,22 +248,32 @@ class PocEnv(ExecEnv):
         if self._runtime_lock_file is not None:
             return
 
-        lock_path = _recipe_runtime_lock_path()
-        lock_dir = os.path.dirname(lock_path)
-        os.makedirs(lock_dir, mode=0o700, exist_ok=True)
-        lock_dir_stat = os.stat(lock_dir)
-        if (
-            not stat.S_ISDIR(lock_dir_stat.st_mode)
-            or lock_dir_stat.st_uid != os.geteuid()
-            or lock_dir_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-        ):
-            raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
         flags = os.O_CREAT | os.O_RDWR
         if hasattr(os, "O_CLOEXEC"):
             flags |= os.O_CLOEXEC
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
-        fd = os.open(lock_path, flags, 0o600)
+
+        fd = None
+        location_errors = []
+        for lock_path in _recipe_runtime_lock_paths():
+            try:
+                lock_dir = os.path.dirname(lock_path)
+                os.makedirs(lock_dir, mode=0o700, exist_ok=True)
+                lock_dir_stat = os.stat(lock_dir)
+                if (
+                    not stat.S_ISDIR(lock_dir_stat.st_mode)
+                    or lock_dir_stat.st_uid != os.geteuid()
+                    or lock_dir_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+                ):
+                    raise RuntimeError(f"Refusing to use unsafe Recipe POC runtime lock directory {lock_dir}")
+                fd = os.open(lock_path, flags, 0o600)
+                break
+            except (OSError, RuntimeError) as e:
+                location_errors.append(f"{lock_path}: {e}")
+        if fd is None:
+            raise RuntimeError("Could not use a secure Recipe POC runtime lock location: " + "; ".join(location_errors))
+
         try:
             lock_stat = os.fstat(fd)
             if not stat.S_ISREG(lock_stat.st_mode) or lock_stat.st_uid != os.geteuid():
@@ -260,6 +288,7 @@ class PocEnv(ExecEnv):
                         "Stop it before starting this deployment."
                     ) from e
                 raise
+            self._runtime_lock_path = lock_path
             lock_file = os.fdopen(fd, "r+")
             fd = None
             previous_workspace = lock_file.read().strip()
@@ -270,6 +299,7 @@ class PocEnv(ExecEnv):
                 )
             self._runtime_lock_file = lock_file
         except BaseException:
+            self._runtime_lock_path = None
             if fd is not None:
                 os.close(fd)
             else:
@@ -293,6 +323,7 @@ class PocEnv(ExecEnv):
         if lock_file is None:
             return
         self._runtime_lock_file = None
+        self._runtime_lock_path = None
         try:
             if clear_workspace:
                 lock_file.seek(0)

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -320,8 +320,9 @@ class PocEnv(ExecEnv):
 
     @staticmethod
     def _docker_daemon_is_local() -> bool:
-        """Return whether Docker targets a verified local Unix-socket daemon."""
-        return _get_docker_endpoint(_docker_cli_env()).startswith("unix://")
+        """Return whether Docker startup targets the local Unix-socket daemon."""
+        endpoint = _get_docker_endpoint(_docker_cli_env())
+        return not endpoint or endpoint.startswith("unix://")
 
     @staticmethod
     def _ensure_ports_available(project_config: dict, is_docker: bool) -> None:

--- a/nvflare/recipe/poc_env.py
+++ b/nvflare/recipe/poc_env.py
@@ -205,19 +205,25 @@ class PocEnv(ExecEnv):
         }
         self._docker_network_name = f"nvflare-recipe-{deployment_id}"
 
-    def _remove_docker_network(self) -> None:
+    def _remove_docker_network(self, deadline: Optional[float] = None) -> None:
         """Remove the network, allowing time for auto-removed job containers to detach."""
         if not self._docker_network_name:
             return
+        if deadline is None:
+            deadline = time.monotonic() + STOP_POC_TIMEOUT
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"POC shutdown deadline expired before removing Docker network {self._docker_network_name!r}"
+            )
         docker_env = _docker_cli_env()
-        deadline = time.monotonic() + STOP_POC_TIMEOUT
-        error_message = "cleanup deadline reached"
+        error_message = None
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                detail = f": {error_message}" if error_message else ""
                 raise RuntimeError(
                     f"could not remove Docker network {self._docker_network_name!r} "
-                    f"within {STOP_POC_TIMEOUT} seconds: {error_message}"
+                    f"before the POC shutdown deadline{detail}"
                 )
             try:
                 result = subprocess.run(
@@ -628,10 +634,12 @@ class PocEnv(ExecEnv):
             _stop_poc(
                 **stop_args,
             )
-            count = 0
+            # Service exit and network teardown share one wait budget after the
+            # shutdown command; slow endpoint detachment must not add another one.
+            deadline = time.monotonic() + STOP_POC_TIMEOUT
             poc_running = True
             poc_state_error = None
-            while count < STOP_POC_TIMEOUT:
+            while time.monotonic() < deadline:
                 try:
                     if not self._running_services(project_config, service_config, self.poc_workspace):
                         poc_running = False
@@ -643,8 +651,7 @@ class PocEnv(ExecEnv):
                     # contains the configuration needed for manual cleanup.
                     poc_running = True
                     break
-                time.sleep(1)
-                count += 1
+                time.sleep(min(1, max(0, deadline - time.monotonic())))
 
             if poc_running:
                 if clean_up:
@@ -658,7 +665,7 @@ class PocEnv(ExecEnv):
                         "Stop any remaining services and remove it manually."
                     )
             else:
-                self._remove_docker_network()
+                self._remove_docker_network(deadline=deadline)
                 self._services_may_have_started = False
                 if clean_up:
                     try:

--- a/nvflare/tool/deploy/templates/docker/start_docker.sh
+++ b/nvflare/tool/deploy/templates/docker/start_docker.sh
@@ -4,6 +4,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 HOST_WORKSPACE="$(cd "$DIR/.." && pwd)"
 DOCKER_IMAGE=${NVFL_P_IMAGE:-@@NVFLARE_DOCKER_IMAGE@@}
+LOGICAL_CONTAINER_NAME=@@NVFLARE_CONTAINER_NAME@@
+CONTAINER_NAME=${NVFLARE_POC_CONTAINER_NAME:-$LOGICAL_CONTAINER_NAME}
 DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"
 DOCKER_ENDPOINT="${DOCKER_HOST:-}"
 
@@ -82,11 +84,19 @@ fi
 echo "Starting NVFlare @@NVFLARE_ROLE_LABEL@@ @@NVFLARE_SITE_NAME@@ with image $DOCKER_IMAGE"
 echo "Host workspace: $HOST_WORKSPACE"
 
-NETWORK_NAME=@@NVFLARE_NETWORK_NAME@@
-if ! docker "${DOCKER_CLI_ARGS[@]}" network ls --filter name="$NETWORK_NAME" --format "{{.Name}}" \
-    | grep -wq "$NETWORK_NAME"; then
-    docker "${DOCKER_CLI_ARGS[@]}" network create "$NETWORK_NAME"
-    echo "Created Docker network: $NETWORK_NAME"
+NETWORK_NAME=${NVFLARE_POC_NETWORK_NAME:-@@NVFLARE_NETWORK_NAME@@}
+if ! docker "${DOCKER_CLI_ARGS[@]}" network inspect "$NETWORK_NAME" > /dev/null 2>&1; then
+    if docker "${DOCKER_CLI_ARGS[@]}" network create "$NETWORK_NAME" > /dev/null 2>&1; then
+        echo "Created Docker network: $NETWORK_NAME"
+    elif ! docker "${DOCKER_CLI_ARGS[@]}" network inspect "$NETWORK_NAME" > /dev/null 2>&1; then
+        echo "ERROR: could not create Docker network: $NETWORK_NAME"
+        exit 1
+    fi
+fi
+
+NETWORK_ALIAS_ARGS=()
+if [ "$CONTAINER_NAME" != "$LOGICAL_CONTAINER_NAME" ]; then
+    NETWORK_ALIAS_ARGS=(--network-alias "$LOGICAL_CONTAINER_NAME")
 fi
 
 rm -f "$HOST_WORKSPACE/daemon_pid.fl"
@@ -131,12 +141,14 @@ else
     GROUP_ADD_ARGS+=(--group-add "$SOCK_GID")
 fi
 
-docker "${DOCKER_CLI_ARGS[@]}" run --name @@NVFLARE_CONTAINER_NAME@@ \
+docker "${DOCKER_CLI_ARGS[@]}" run --name "$CONTAINER_NAME" \
     --user "$(id -u):$(id -g)" \
     "${GROUP_ADD_ARGS[@]}" \
     --network "$NETWORK_NAME" \
+    "${NETWORK_ALIAS_ARGS[@]}" \
 @@NVFLARE_NETWORK_ALIAS@@    -v "$HOST_WORKSPACE":@@NVFLARE_WORKSPACE_MOUNT_PATH@@ \
     --mount "type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock" \
     -e NVFL_DOCKER_WORKSPACE="$HOST_WORKSPACE" \
+    -e NVFL_DOCKER_NETWORK="$NETWORK_NAME" \
 @@NVFLARE_PUBLISH_PORTS@@    --rm "$DOCKER_IMAGE" \
     @@NVFLARE_PARENT_COMMAND@@

--- a/nvflare/tool/poc/poc_commands.py
+++ b/nvflare/tool/poc/poc_commands.py
@@ -99,6 +99,8 @@ POC_DOCKER_IMAGE_KEY = "docker_image"
 POC_DOCKER_NETWORK_KEY = "network"
 POC_DOCKER_DEFAULT_NETWORK = "nvflare-network"
 POC_DOCKER_SERVER_ALIAS = "server"
+POC_DOCKER_CONTAINER_NAME_ENV = "NVFLARE_POC_CONTAINER_NAME"
+POC_DOCKER_NETWORK_NAME_ENV = "NVFLARE_POC_NETWORK_NAME"
 POC_DOCKER_DATA_STUDY = "default"
 POC_DOCKER_DATA_DATASET = "poc"
 POC_DOCKER_DATA_MOUNT = f"/data/{POC_DOCKER_DATA_STUDY}/{POC_DOCKER_DATA_DATASET}"
@@ -141,7 +143,12 @@ def client_gpu_assignments(clients: List[str], gpu_ids: List[int]) -> Dict[str, 
 
 
 def get_service_command(
-    cmd_type: str, prod_dir: str, service_dir, service_config: Dict, study: Optional[str] = None
+    cmd_type: str,
+    prod_dir: str,
+    service_dir,
+    service_config: Dict,
+    study: Optional[str] = None,
+    docker_container_name: Optional[str] = None,
 ) -> str:
     cmd = ""
     proj_admin_dir_name = service_config.get(SC.FLARE_PROJ_ADMIN, SC.FLARE_PROJ_ADMIN)
@@ -167,7 +174,7 @@ def get_service_command(
             if service_dir in admin_dirs:
                 cmd = get_stop_cmd(prod_dir, service_dir)
             else:
-                cmd = f"docker stop {service_dir}"
+                cmd = f"docker stop {docker_container_name or service_dir}"
 
     else:
         raise CLIException(f"unknown cmd_type: {cmd_type}")
@@ -803,6 +810,7 @@ def _is_local_port_available(port: int, host: str = POC_PORT_PREFLIGHT_HOST) -> 
 
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind((host, port))
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
@@ -1851,7 +1859,15 @@ def _get_server_url(project_config, service_config) -> str:
     return _build_poc_endpoint_info(project_config, service_config)["server_url"]
 
 
-def _start_poc(poc_workspace: str, gpu_ids: List[int], excluded=None, services_list=None, study: Optional[str] = None):
+def _start_poc(
+    poc_workspace: str,
+    gpu_ids: List[int],
+    excluded=None,
+    services_list=None,
+    study: Optional[str] = None,
+    docker_container_names: Optional[Dict[str, str]] = None,
+    docker_network_name: Optional[str] = None,
+):
     project_config, service_config = setup_service_config(poc_workspace)
     if services_list is None:
         services_list = []
@@ -1874,6 +1890,11 @@ def _start_poc(poc_workspace: str, gpu_ids: List[int], excluded=None, services_l
     validate_services(project_config, services_list, excluded)
     validate_poc_workspace(poc_workspace, service_config, project_config)
     _ensure_server_running_for_admin_console(project_config, service_config, services_list)
+    docker_args = {}
+    if docker_container_names:
+        docker_args["docker_container_names"] = docker_container_names
+    if docker_network_name:
+        docker_args["docker_network_name"] = docker_network_name
     _run_poc(
         SC.CMD_START,
         poc_workspace,
@@ -1883,6 +1904,7 @@ def _start_poc(poc_workspace: str, gpu_ids: List[int], excluded=None, services_l
         excluded=excluded,
         services_list=services_list,
         study=study,
+        **docker_args,
     )
 
 
@@ -1999,6 +2021,7 @@ def _stop_poc(
     project_config=None,
     service_config=None,
     wait: bool = True,
+    docker_container_names: Optional[Dict[str, str]] = None,
 ):
     if project_config is None or service_config is None:
         project_config, service_config = setup_service_config(poc_workspace)
@@ -2032,7 +2055,8 @@ def _stop_poc(
     has_service_exclusions = any(service not in admin_services for service in user_excluded)
     server = service_config[SC.FLARE_SERVER]
     server_only_selection = bool(services_list) and all(service == server for service in services_list)
-    if not has_service_exclusions and (not services_list or server_only_selection):
+    uses_recipe_docker_names = bool(service_config.get(SC.IS_DOCKER_RUN) and docker_container_names)
+    if not uses_recipe_docker_names and not has_service_exclusions and (not services_list or server_only_selection):
         from nvflare.tool.cli_output import print_human
 
         with _quiet_cli_streams(True):
@@ -2046,6 +2070,7 @@ def _stop_poc(
 
         print_human(f"Starting local shutdown of {services_list or 'default services'}")
 
+        docker_args = {"docker_container_names": docker_container_names} if docker_container_names else {}
         _run_poc(
             SC.CMD_STOP,
             poc_workspace,
@@ -2055,6 +2080,7 @@ def _stop_poc(
             excluded=excluded,
             services_list=services_list,
             wait=wait,
+            **docker_args,
         )
         return {"services": services_list}
 
@@ -2078,6 +2104,7 @@ def _build_commands(
     excluded: list,
     services_list=None,
     study: Optional[str] = None,
+    docker_container_names: Optional[Dict[str, str]] = None,
 ) -> list:
     """Builds commands.
 
@@ -2113,7 +2140,14 @@ def _build_commands(
             for service_dir_name in fl_dirs:
                 if service_dir_name not in excluded:
                     if len(services_list) == 0 or service_dir_name in services_list:
-                        cmd = get_service_command(cmd_type, prod_dir, service_dir_name, service_config, study=study)
+                        cmd = get_service_command(
+                            cmd_type,
+                            prod_dir,
+                            service_dir_name,
+                            service_config,
+                            study=study,
+                            docker_container_name=(docker_container_names or {}).get(service_dir_name),
+                        )
                         if cmd:
                             service_commands.append((service_dir_name, cmd))
     return _sort_service_cmds(cmd_type, service_commands, service_config)
@@ -2135,34 +2169,10 @@ def _docker_cli_env() -> Dict[str, str]:
     if not socket_override:
         return docker_env
 
-    docker_endpoint = docker_env.get("DOCKER_HOST", "")
-    if not docker_endpoint:
-        # Match start_docker.sh: an active remote context keeps controlling
-        # the outer Docker CLI, while a local context uses the explicit POC
-        # socket override as its endpoint.
-        try:
-            context_result = subprocess.run(
-                ["docker", "context", "show"],
-                env=docker_env,
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-            context_name = context_result.stdout.strip() if context_result.returncode == 0 else ""
-            if context_name:
-                endpoint_result = subprocess.run(
-                    ["docker", "context", "inspect", context_name, "--format", "{{.Endpoints.docker.Host}}"],
-                    env=docker_env,
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                    check=False,
-                )
-                if endpoint_result.returncode == 0:
-                    docker_endpoint = endpoint_result.stdout.strip()
-        except (OSError, subprocess.TimeoutExpired):
-            docker_endpoint = ""
+    # Match start_docker.sh: an active remote context keeps controlling the
+    # outer Docker CLI, while a local context uses the explicit POC socket
+    # override as its endpoint.
+    docker_endpoint = _get_docker_endpoint(docker_env)
 
     if not docker_endpoint or docker_endpoint.startswith("unix://"):
         docker_env["DOCKER_HOST"] = f"unix://{socket_override}"
@@ -2174,12 +2184,61 @@ def _docker_cli_env() -> Dict[str, str]:
     return docker_env
 
 
-def prepare_env(service_name, gpu_ids: Optional[List[int]], service_config: Dict):
+def _get_docker_endpoint(docker_env: Optional[Dict[str, str]] = None) -> str:
+    """Return the endpoint selected by DOCKER_HOST or the active Docker context."""
+    if docker_env is None:
+        docker_env = _env_with_cli_python_path()
+    docker_endpoint = docker_env.get("DOCKER_HOST", "")
+    if docker_endpoint:
+        return docker_endpoint
+
+    try:
+        context_result = subprocess.run(
+            ["docker", "context", "show"],
+            env=docker_env,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        context_name = context_result.stdout.strip() if context_result.returncode == 0 else ""
+        if not context_name:
+            return ""
+        endpoint_result = subprocess.run(
+            ["docker", "context", "inspect", context_name, "--format", "{{.Endpoints.docker.Host}}"],
+            env=docker_env,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if endpoint_result.returncode == 0:
+            return endpoint_result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def prepare_env(
+    service_name,
+    gpu_ids: Optional[List[int]],
+    service_config: Dict,
+    docker_container_name: Optional[str] = None,
+    docker_network_name: Optional[str] = None,
+):
     my_env = _docker_cli_env() if service_config.get(SC.IS_DOCKER_RUN) else _env_with_cli_python_path()
     if gpu_ids:
         my_env["CUDA_VISIBLE_DEVICES"] = ",".join([str(gid) for gid in gpu_ids])
 
     if service_config.get(SC.IS_DOCKER_RUN):
+        if docker_container_name:
+            my_env[POC_DOCKER_CONTAINER_NAME_ENV] = docker_container_name
+        else:
+            my_env.pop(POC_DOCKER_CONTAINER_NAME_ENV, None)
+        if docker_network_name:
+            my_env[POC_DOCKER_NETWORK_NAME_ENV] = docker_network_name
+        else:
+            my_env.pop(POC_DOCKER_NETWORK_NAME_ENV, None)
         if gpu_ids:
             my_env["GPU2USE"] = f'--gpus="device={my_env["CUDA_VISIBLE_DEVICES"]}"'
 
@@ -2215,8 +2274,21 @@ def _build_poc_console_logs(
     return logs
 
 
-def async_process(service_name, cmd_path, gpu_ids: Optional[List[int]], service_config: Dict):
-    my_env = prepare_env(service_name, gpu_ids, service_config)
+def async_process(
+    service_name,
+    cmd_path,
+    gpu_ids: Optional[List[int]],
+    service_config: Dict,
+    docker_container_name: Optional[str] = None,
+    docker_network_name: Optional[str] = None,
+):
+    my_env = prepare_env(
+        service_name,
+        gpu_ids,
+        service_config,
+        docker_container_name=docker_container_name,
+        docker_network_name=docker_network_name,
+    )
     console_log = _poc_service_console_log(cmd_path)
     os.makedirs(os.path.dirname(console_log), exist_ok=True)
     with open(console_log, "a", buffering=1) as output:
@@ -2285,11 +2357,21 @@ def _run_poc(
     services_list=None,
     study: Optional[str] = None,
     wait: bool = False,
+    docker_container_names: Optional[Dict[str, str]] = None,
+    docker_network_name: Optional[str] = None,
 ):
     if services_list is None:
         services_list = []
+    docker_args = {"docker_container_names": docker_container_names} if docker_container_names else {}
     service_commands = _build_commands(
-        cmd_type, poc_workspace, service_config, project_config, excluded, services_list, study=study
+        cmd_type,
+        poc_workspace,
+        service_config,
+        project_config,
+        excluded,
+        services_list,
+        study=study,
+        **docker_args,
     )
 
     if cmd_type == SC.CMD_STOP and wait:
@@ -2322,11 +2404,33 @@ def _run_poc(
                 time.sleep(2)
             sync_process(service_name, cmd_path)
         elif service_name == service_config[SC.FLARE_SERVER]:
-            async_process(service_name, cmd_path, None, service_config)
+            docker_args = {}
+            if docker_container_names:
+                docker_args["docker_container_name"] = docker_container_names.get(service_name)
+            if docker_network_name:
+                docker_args["docker_network_name"] = docker_network_name
+            async_process(
+                service_name,
+                cmd_path,
+                None,
+                service_config,
+                **docker_args,
+            )
         else:
             time.sleep(1)
             client_gpu_ids = gpu_assignments[service_name] if service_name in clients else None
-            async_process(service_name, cmd_path, client_gpu_ids, service_config)
+            docker_args = {}
+            if docker_container_names:
+                docker_args["docker_container_name"] = docker_container_names.get(service_name)
+            if docker_network_name:
+                docker_args["docker_network_name"] = docker_network_name
+            async_process(
+                service_name,
+                cmd_path,
+                client_gpu_ids,
+                service_config,
+                **docker_args,
+            )
 
 
 def clean_poc(cmd_args):

--- a/tests/integration_test/slow/recipe_system_test.py
+++ b/tests/integration_test/slow/recipe_system_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,11 @@ TODO: Decide if these should be added to an existing test category or run in a s
 
 import json
 import os
+import shutil
+import time
 
 import numpy as np
+import pytest
 
 from nvflare.apis.fl_constant import WorkspaceConstants
 from nvflare.apis.job_def import RunStatus
@@ -35,6 +38,8 @@ from nvflare.app_common.default_component_policy import DEFAULT_CLASS_ALLOW_LIST
 from nvflare.app_common.np.recipes import NumpyCrossSiteEvalRecipe, NumpyFedAvgRecipe
 from nvflare.recipe import PocEnv, SimEnv
 from nvflare.recipe.utils import add_cross_site_evaluation
+from nvflare.tool.poc.poc_commands import _start_poc, _stop_poc, prepare_poc_provision, setup_service_config
+from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
 INTEGRATION_TEST_ROOT = os.path.dirname(os.path.dirname(__file__))
 REPO_ROOT = os.path.dirname(os.path.dirname(INTEGRATION_TEST_ROOT))
@@ -74,6 +79,72 @@ class TestRecipeSystemIntegration:
         run = recipe.execute(env)
         run.get_result()
         assert run.get_status() == "FINISHED:COMPLETED"
+
+    @pytest.mark.timeout(90)
+    def test_recipe_poc_rejects_running_cli_poc(self, tmp_path, monkeypatch):
+        """A Recipe must not compete with the configured CLI POC for ports or service names."""
+        cli_workspace = tmp_path / "cli-poc"
+        monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(cli_workspace))
+        prepare_poc_provision(
+            clients=[],
+            number_of_clients=2,
+            workspace=str(cli_workspace),
+            docker_image=None,
+        )
+        project_config, service_config = setup_service_config(str(cli_workspace))
+        cleanup_env = PocEnv(num_clients=2)
+        cleanup_env.poc_workspace = str(cli_workspace)
+        expected_services = {
+            service_config[SC.FLARE_SERVER],
+            *service_config.get(SC.FLARE_CLIENTS, []),
+        }
+
+        try:
+            _start_poc(
+                poc_workspace=str(cli_workspace),
+                gpu_ids=[],
+                excluded=["admin@nvidia.com"],
+                services_list=[],
+            )
+            deadline = time.monotonic() + 30
+            running_services = set()
+            while time.monotonic() < deadline:
+                running_services = set(PocEnv._running_services(project_config, service_config, str(cli_workspace)))
+                if running_services == expected_services:
+                    break
+                time.sleep(0.2)
+            assert running_services == expected_services
+
+            recipe_env = PocEnv(num_clients=2)
+            recipe = NumpyFedAvgRecipe(
+                name="test_active_cli_poc",
+                min_clients=2,
+                train_script=self.client_script_path,
+                model=np.array([0.0] * 10),
+            )
+
+            with pytest.raises(RuntimeError, match="nvflare poc stop"):
+                recipe.execute(recipe_env)
+
+            assert cli_workspace.is_dir()
+            assert not os.path.exists(recipe_env.poc_workspace)
+        finally:
+            cleanup_env.stop(clean_up=False)
+            if cleanup_env._check_poc_running():
+                # If coordinated shutdown loses the server before every client
+                # exits, stop the known temporary-test participants directly.
+                _stop_poc(
+                    poc_workspace=str(cli_workspace),
+                    excluded=["admin@nvidia.com"],
+                    services_list=sorted(expected_services),
+                    project_config=project_config,
+                    service_config=service_config,
+                )
+            shutdown_deadline = time.monotonic() + 15
+            while cleanup_env._check_poc_running() and time.monotonic() < shutdown_deadline:
+                time.sleep(0.2)
+            assert not cleanup_env._check_poc_running()
+            shutil.rmtree(cli_workspace, ignore_errors=True)
 
     def test_hello_numpy_cross_val_training_and_cse(self, tmp_path):
         """End-to-end: training + CSE with hello-numpy-cross-val client (model required; fail-fast on missing params).

--- a/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
+++ b/tests/unit_test/app_opt/job_launcher/docker_launcher_test.py
@@ -453,6 +453,12 @@ class TestDockerJobLauncherInit:
                 DockerJobLauncher.__init__(launcher, workspace=None)
         assert launcher.workspace == "/host/ws"
 
+    def test_network_read_from_parent_runtime_env(self):
+        with patch.dict("os.environ", {"NVFL_DOCKER_NETWORK": "nvflare-recipe-run"}):
+            launcher = _make_launcher(network="configured-network")
+
+        assert launcher.network == "nvflare-recipe-run"
+
     def test_raises_if_default_job_container_kwargs_contains_reserved_key(self):
         for reserved in (
             "volumes",

--- a/tests/unit_test/lighter/poc_commands_test.py
+++ b/tests/unit_test/lighter/poc_commands_test.py
@@ -15,6 +15,8 @@ import collections
 import copy
 import json
 import os
+import socket
+import subprocess
 import sys
 
 import pytest
@@ -77,6 +79,30 @@ class TestPOCCommands:
             # gpu id =1 is not valid GPU ID as the host only has 1 gpu where id = 0
             gpu_ids = get_gpu_ids([0, 1], host_gpu_ids)
 
+    def test_local_port_probe_matches_listener_reuse_behavior(self, monkeypatch):
+        calls = []
+
+        class ProbeSocket:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def setsockopt(self, *args):
+                calls.append(("setsockopt", args))
+
+            def bind(self, address):
+                calls.append(("bind", address))
+
+        monkeypatch.setattr(poc_commands.socket, "socket", lambda *_args: ProbeSocket())
+
+        assert poc_commands._is_local_port_available(8002) == (True, None)
+        assert calls == [
+            ("setsockopt", (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)),
+            ("bind", ("127.0.0.1", 8002)),
+        ]
+
     def test_prepare_env_docker_single_gpu(self):
         my_env = prepare_env("site-1", [0], {SC.IS_DOCKER_RUN: True})
         assert my_env["CUDA_VISIBLE_DEVICES"] == "0"
@@ -95,6 +121,24 @@ class TestPOCCommands:
         assert "GPU2USE" not in my_env
         assert my_env["SVR_NAME"] == "site-1"
         assert "MY_DATA_DIR" in my_env
+
+    def test_prepare_env_sets_recipe_docker_identities_and_discards_unrequested_overrides(self, monkeypatch):
+        monkeypatch.setenv("NVFLARE_POC_CONTAINER_NAME", "inherited-container")
+        monkeypatch.setenv("NVFLARE_POC_NETWORK_NAME", "inherited-network")
+
+        recipe_env = prepare_env(
+            "site-1",
+            [],
+            {SC.IS_DOCKER_RUN: True},
+            docker_container_name="recipe-container",
+            docker_network_name="recipe-network",
+        )
+        cli_env = prepare_env("site-1", [], {SC.IS_DOCKER_RUN: True})
+
+        assert recipe_env["NVFLARE_POC_CONTAINER_NAME"] == "recipe-container"
+        assert recipe_env["NVFLARE_POC_NETWORK_NAME"] == "recipe-network"
+        assert "NVFLARE_POC_CONTAINER_NAME" not in cli_env
+        assert "NVFLARE_POC_NETWORK_NAME" not in cli_env
 
     def test_prepare_env_non_docker_with_gpu(self, monkeypatch):
         monkeypatch.delenv("GPU2USE", raising=False)
@@ -131,6 +175,91 @@ class TestPOCCommands:
 
         with pytest.raises(poc_commands.PocServiceStartError, match="server is not running"):
             poc_commands._start_poc(str(tmp_path), [], services_list=["admin@nvidia.com"])
+
+    def test_start_poc_forwards_recipe_docker_identities(self, monkeypatch, tmp_path):
+        project_config = {
+            "participants": [
+                {"name": "server", "type": "server", "fed_learn_port": 8002},
+                {"name": "site-1", "type": "client"},
+                {"name": "admin@nvidia.com", "type": "admin"},
+            ]
+        }
+        service_config = {
+            SC.FLARE_SERVER: "server",
+            SC.FLARE_CLIENTS: ["site-1"],
+            SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+            SC.FLARE_OTHER_ADMINS: [],
+            SC.IS_DOCKER_RUN: True,
+        }
+        container_names = {"server": "recipe-server", "site-1": "recipe-site-1"}
+        run_calls = []
+        monkeypatch.setattr(poc_commands, "setup_service_config", lambda _workspace: (project_config, service_config))
+        monkeypatch.setattr(poc_commands, "validate_poc_workspace", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(poc_commands, "_run_poc", lambda *args, **kwargs: run_calls.append((args, kwargs)))
+
+        poc_commands._start_poc(
+            str(tmp_path),
+            [],
+            docker_container_names=container_names,
+            docker_network_name="recipe-network",
+        )
+
+        assert run_calls[0][1]["docker_container_names"] == container_names
+        assert run_calls[0][1]["docker_network_name"] == "recipe-network"
+
+    def test_stop_poc_with_recipe_docker_names_bypasses_coordinated_shutdown(self, monkeypatch, tmp_path):
+        project_config = {
+            "name": "example_project",
+            "participants": [
+                {"name": "server", "type": "server"},
+                {"name": "site-1", "type": "client"},
+                {"name": "admin@nvidia.com", "type": "admin"},
+            ],
+        }
+        service_config = {
+            SC.FLARE_SERVER: "server",
+            SC.FLARE_CLIENTS: ["site-1"],
+            SC.FLARE_PROJ_ADMIN: "admin@nvidia.com",
+            SC.FLARE_OTHER_ADMINS: [],
+            SC.IS_DOCKER_RUN: True,
+        }
+        container_names = {"server": "recipe-server", "site-1": "recipe-site-1"}
+        shutdown_calls = []
+        run_calls = []
+        monkeypatch.setattr(poc_commands, "validate_poc_workspace", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(
+            poc_commands,
+            "shutdown_system",
+            lambda *args, **kwargs: shutdown_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(poc_commands, "_run_poc", lambda *args, **kwargs: run_calls.append((args, kwargs)))
+
+        poc_commands._stop_poc(
+            str(tmp_path),
+            project_config=project_config,
+            service_config=service_config,
+            docker_container_names=container_names,
+        )
+
+        assert shutdown_calls == []
+        assert run_calls[0][0][0] == SC.CMD_STOP
+        assert run_calls[0][1]["docker_container_names"] == container_names
+
+    def test_get_docker_endpoint_resolves_remote_context(self, monkeypatch):
+        calls = []
+
+        def run(command, **kwargs):
+            calls.append(command)
+            stdout = "remote-builder\n" if command[1:3] == ["context", "show"] else "ssh://docker.example\n"
+            return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(poc_commands.subprocess, "run", run)
+
+        assert poc_commands._get_docker_endpoint({}) == "ssh://docker.example"
+        assert calls == [
+            ["docker", "context", "show"],
+            ["docker", "context", "inspect", "remote-builder", "--format", "{{.Endpoints.docker.Host}}"],
+        ]
 
     def test_get_package_command(self):
         cmd = get_service_command(SC.CMD_START, "/tmp/nvflare/poc", SC.FLARE_SERVER, {})
@@ -211,6 +340,15 @@ class TestPOCCommands:
 
         cmd = get_service_command(SC.CMD_STOP, "/tmp/nvflare/poc", "site-1", global_packages)
         assert "docker stop site-1" == cmd
+
+        cmd = get_service_command(
+            SC.CMD_STOP,
+            "/tmp/nvflare/poc",
+            "site-1",
+            global_packages,
+            docker_container_name="nvflare-recipe-run-site-1",
+        )
+        assert "docker stop nvflare-recipe-run-site-1" == cmd
 
     def test_add_poc_docker_runtime_preserves_static_builder(self):
         project_config = collections.OrderedDict(

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -21,11 +21,19 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.recipe.poc_env import PocEnv
+from nvflare.recipe.poc_env import PocEnv, _recipe_runtime_lock_path
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
 PROJECT_CONFIG = {"name": "poc"}
 SERVICE_CONFIG = {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
+    """Keep process-held Recipe POC locks independent across unit tests."""
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(tmp_path / "recipe-poc.lock"))
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -62,6 +70,41 @@ def test_poc_env_initialization():
     assert env.gpu_ids == []
     assert env.study == "default"
     assert env.poc_workspace.startswith(f"{env._poc_workspace_root}.recipe-")
+
+
+def test_recipe_runtime_lock_path_is_host_and_user_scoped():
+    assert _recipe_runtime_lock_path() == os.path.join(
+        tempfile.gettempdir(), f".nvflare-recipe-poc-{os.geteuid()}.lock"
+    )
+
+
+def test_runtime_lock_rejects_unsafe_lock_file(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    env = PocEnv()
+    monkeypatch.setattr(poc_env_module.stat, "S_ISREG", lambda mode: False)
+
+    with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock"):
+        env._acquire_runtime_lock()
+
+    assert env._runtime_lock_file is None
+
+
+def test_runtime_lock_propagates_unexpected_lock_error(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    env = PocEnv()
+    monkeypatch.setattr(
+        poc_env_module.fcntl,
+        "flock",
+        lambda fd, operation: (_ for _ in ()).throw(OSError("lock failed")),
+    )
+
+    with pytest.raises(OSError, match="lock failed"):
+        env._acquire_runtime_lock()
+
+    assert env._runtime_lock_file is None
+    env._release_runtime_lock()
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
@@ -210,6 +253,38 @@ def test_deploy_rejects_running_configured_cli_workspace(tmp_path, monkeypatch):
     assert provision_calls == []
     assert retained_result.read_text() == "keep me"
     assert not os.path.exists(env.poc_workspace)
+    assert env._runtime_lock_file is None
+
+
+def test_deploy_rejects_another_active_recipe_environment(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    first = PocEnv()
+    second = PocEnv()
+    provisioned_workspaces = []
+
+    def prepare(**kwargs):
+        provisioned_workspaces.append(kwargs["workspace"])
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    _configure_successful_deploy(monkeypatch, first, prepare=prepare)
+    assert first.deploy(object()) == "job-id"
+    held_lock = first._runtime_lock_file
+    first._acquire_runtime_lock()
+    assert first._runtime_lock_file is held_lock
+
+    _configure_successful_deploy(monkeypatch, second, prepare=prepare)
+    with pytest.raises(RuntimeError, match="Another Recipe PocEnv deployment is active"):
+        second.deploy(object())
+
+    assert provisioned_workspaces == [first.poc_workspace]
+
+    first.stop(clean_up=False)
+    assert second.deploy(object()) == "job-id"
+    assert provisioned_workspaces == [first.poc_workspace, second.poc_workspace]
+    second.stop(clean_up=False)
 
 
 def test_deploy_does_not_modify_configured_cli_workspace(tmp_path, monkeypatch):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -537,7 +537,7 @@ def test_stop_poc(mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup):
 @patch("nvflare.recipe.poc_env._clean_poc")
 @patch("nvflare.recipe.poc_env.is_poc_running")
 def test_stop_preserves_workspace_when_service_state_is_unknown(
-    mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup
+    mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup, caplog
 ):
     mock_setup.return_value = ({"name": "test"}, {SC.FLARE_SERVER: "server"})
     mock_is_running.return_value = True
@@ -552,6 +552,7 @@ def test_stop_preserves_workspace_when_service_state_is_unknown(
 
     mock_stop_poc.assert_called_once()
     mock_clean_poc.assert_not_called()
+    assert "Stop any remaining services and remove it manually" in caplog.text
 
 
 @patch("nvflare.recipe.poc_env.SessionManager")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -532,6 +532,28 @@ def test_stop_poc(mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup):
     mock_clean_poc.assert_called_once_with(env.poc_workspace)
 
 
+@patch("nvflare.recipe.poc_env.setup_service_config")
+@patch("nvflare.recipe.poc_env._stop_poc")
+@patch("nvflare.recipe.poc_env._clean_poc")
+@patch("nvflare.recipe.poc_env.is_poc_running")
+def test_stop_preserves_workspace_when_service_state_is_unknown(
+    mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup
+):
+    mock_setup.return_value = ({"name": "test"}, {SC.FLARE_SERVER: "server"})
+    mock_is_running.return_value = True
+    env = PocEnv()
+
+    with patch.object(
+        PocEnv,
+        "_running_services",
+        side_effect=[["server"], RuntimeError("Docker inspection unavailable")],
+    ):
+        env.stop(clean_up=True)
+
+    mock_stop_poc.assert_called_once()
+    mock_clean_poc.assert_not_called()
+
+
 @patch("nvflare.recipe.poc_env.SessionManager")
 @patch("nvflare.recipe.poc_env.setup_service_config")
 @patch("nvflare.recipe.poc_env.get_prod_dir")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 import os
 import subprocess
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -23,73 +24,97 @@ import pytest
 from nvflare.recipe.poc_env import PocEnv
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
+PROJECT_CONFIG = {"name": "poc"}
+SERVICE_CONFIG = {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}
+
+
+def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    if prepare is None:
+
+        def prepare(**kwargs):
+            Path(kwargs["workspace"]).mkdir(parents=True)
+
+    if submit is None:
+
+        def submit(job):
+            return "job-id"
+
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, SERVICE_CONFIG),
+    )
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(env, "_wait_for_services_ready", lambda *args, **kwargs: None)
+    monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=submit))
+
 
 def test_poc_env_initialization():
     """Test PocEnv initialization with default values."""
     env = PocEnv()
+
     assert env.num_clients == 2
     assert env.gpu_ids == []
     assert env.study == "default"
-    assert env.deployment_started is False
-    assert env.workspace_owned is False
+    assert env.poc_workspace.startswith(f"{env._poc_workspace_root}.recipe-")
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
-def test_poc_env_initialization_with_custom_values(mock_get_workspace):
+def test_poc_env_initialization_with_custom_values(mock_get_workspace, tmp_path):
     """Test PocEnv initialization with custom values."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        mock_get_workspace.return_value = temp_dir
-        env = PocEnv(
-            num_clients=3,
-            gpu_ids=[0, 1],
-        )
-        assert env.poc_workspace == temp_dir
-        assert env.num_clients == 3
-        assert env.gpu_ids == [0, 1]
+    configured_workspace = tmp_path / "poc"
+    mock_get_workspace.return_value = str(configured_workspace)
+
+    env = PocEnv(num_clients=3, gpu_ids=[0, 1])
+
+    assert env._poc_workspace_root == str(configured_workspace)
+    assert env.poc_workspace.startswith(f"{configured_workspace}.recipe-")
+    assert env.poc_workspace != str(configured_workspace)
+    assert env.num_clients == 3
+    assert env.gpu_ids == [0, 1]
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
 def test_poc_env_normalizes_workspace_trailing_separator(mock_get_workspace, tmp_path):
-    workspace = tmp_path / "poc-workspace"
-    mock_get_workspace.return_value = f"{workspace}{os.sep}"
+    configured_workspace = tmp_path / "poc-workspace"
+    mock_get_workspace.return_value = f"{configured_workspace}{os.sep}"
 
     env = PocEnv()
 
-    assert env.poc_workspace == str(workspace)
+    assert env._poc_workspace_root == str(configured_workspace)
+    assert env.poc_workspace.startswith(f"{configured_workspace}.recipe-")
+    assert os.path.dirname(env.poc_workspace) == str(tmp_path)
 
 
-def test_backup_with_normalized_workspace_is_created_as_sibling(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
+@patch("nvflare.recipe.poc_env.get_poc_workspace")
+def test_poc_env_instances_use_distinct_workspaces(mock_get_workspace, tmp_path):
+    configured_workspace = tmp_path / "poc"
+    mock_get_workspace.return_value = str(configured_workspace)
 
-    workspace = tmp_path / "poc-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: f"{workspace}{os.sep}")
-    env = PocEnv()
+    first = PocEnv()
+    second = PocEnv()
 
-    backup = env._backup_existing_workspace()
-
-    assert backup is not None
-    assert os.path.dirname(backup) == str(tmp_path)
-    assert os.path.basename(backup).startswith("poc-workspace.nvflare-recipe-backup-")
-    assert os.path.exists(os.path.join(backup, "prior-result.txt"))
+    assert first.poc_workspace != second.poc_workspace
+    assert first.poc_workspace.startswith(f"{configured_workspace}.recipe-")
+    assert second.poc_workspace.startswith(f"{configured_workspace}.recipe-")
 
 
 def test_poc_env_validation():
     """Test PocEnv validation for invalid configurations."""
-    # Test with zero clients (invalid)
     with pytest.raises(ValueError, match="Input should be greater than 0"):
         PocEnv(num_clients=0)
 
-    # Test with negative clients (invalid)
     with pytest.raises(ValueError, match="Input should be greater than 0"):
         PocEnv(num_clients=-1)
 
-    # Test with empty clients list (invalid)
     with pytest.raises(ValueError, match="clients list cannot be empty"):
         PocEnv(clients=[])
 
-    # Test with inconsistent num_clients and clients
     with pytest.raises(ValueError, match="Inconsistent"):
         PocEnv(num_clients=3, clients=["site1", "site2"])
 
@@ -102,30 +127,27 @@ def test_poc_env_none_num_clients_raises():
 
 def test_poc_env_client_names():
     """Test PocEnv client name generation and validation."""
-    # Test auto-generated client names (delegated to prepare_poc_provision)
     env = PocEnv(num_clients=3)
-    assert env.clients is None  # Will be generated by prepare_poc_provision
+    assert env.clients is None
     assert env.num_clients == 3
 
-    # Test custom client names
     custom_clients = ["client-a", "client-b"]
     env = PocEnv(clients=custom_clients)
     assert env.clients == custom_clients
     assert env.num_clients == 2
 
-    # Test consistent num_clients and clients
     env = PocEnv(num_clients=2, clients=["site-x", "site-y"])
     assert env.clients == ["site-x", "site-y"]
     assert env.num_clients == 2
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
-def test_poc_env_initialization_with_study(mock_get_workspace):
-    with tempfile.TemporaryDirectory() as temp_dir:
-        mock_get_workspace.return_value = temp_dir
-        env = PocEnv(num_clients=2, study="cancer-research")
+def test_poc_env_initialization_with_study(mock_get_workspace, tmp_path):
+    mock_get_workspace.return_value = str(tmp_path / "poc")
 
-        assert env.study == "cancer-research"
+    env = PocEnv(num_clients=2, study="cancer-research")
+
+    assert env.study == "cancer-research"
 
 
 def test_poc_env_rejects_invalid_study_name():
@@ -133,372 +155,199 @@ def test_poc_env_rejects_invalid_study_name():
         PocEnv(study="Bad Study")
 
 
-@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=["missing.py"])
-def test_deploy_preflight_failure_does_not_start_lifecycle(mock_collect_non_local_scripts):
+def test_deploy_preflight_failure_does_not_create_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: ["missing.py"])
     env = PocEnv()
 
     with pytest.raises(ValueError, match="scripts do not exist locally"):
         env.deploy(object())
 
-    assert env.deployment_started is False
-    assert env.workspace_owned is False
-
-
-def test_deploy_rejects_project_config_inside_workspace_before_replacement(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "poc-workspace"
-    workspace.mkdir()
-    project_conf = workspace / "project.yml"
-    project_conf.write_text("name: retained")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    env = PocEnv(project_conf_path=str(project_conf))
-
-    with pytest.raises(ValueError, match="project_conf_path must be outside"):
-        env.deploy(object())
-
-    assert env.deployment_started is False
-    assert env.workspace_owned is False
-    assert project_conf.read_text() == "name: retained"
-    assert not list(tmp_path.glob("poc-workspace.nvflare-recipe-backup-*"))
-
-
-@patch("nvflare.recipe.poc_env.get_poc_workspace")
-@patch("nvflare.recipe.poc_env.prepare_poc_provision", side_effect=RuntimeError("provisioning failed"))
-@patch.object(PocEnv, "_check_poc_running", return_value=False)
-@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=[])
-def test_deploy_marks_lifecycle_started_before_provisioning(
-    mock_collect_non_local_scripts, mock_check_poc_running, mock_prepare_poc_provision, mock_get_workspace, tmp_path
-):
-    mock_get_workspace.return_value = str(tmp_path / "new-poc-workspace")
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="provisioning failed"):
-        env.deploy(object())
-
-    assert env.deployment_started is True
-    assert env.workspace_owned is True
-
-
-@patch("nvflare.recipe.poc_env.prepare_poc_provision", side_effect=RuntimeError("provisioning failed"))
-@patch.object(PocEnv, "_check_poc_running", return_value=False)
-@patch("nvflare.recipe.poc_env.collect_non_local_scripts", return_value=[])
-@patch("nvflare.recipe.poc_env.get_poc_workspace")
-def test_failed_provisioning_does_not_claim_existing_workspace(
-    mock_get_workspace, mock_collect_non_local_scripts, mock_check_poc_running, mock_prepare_poc_provision, tmp_path
-):
-    workspace = tmp_path / "retained-poc-workspace"
-    workspace.mkdir()
-    retained_result = workspace / "prior-result.txt"
-    retained_result.write_text("keep me")
-    mock_get_workspace.return_value = str(workspace)
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="provisioning failed"):
-        env.deploy(object())
-
-    assert env.deployment_started is True
-    assert env.workspace_owned is False
     assert retained_result.read_text() == "keep me"
-    assert not list(tmp_path.glob("retained-poc-workspace.nvflare-recipe-backup-*"))
+    assert not os.path.exists(env.poc_workspace)
 
 
-def test_failed_provisioning_restores_workspace_after_partial_writes(tmp_path, monkeypatch):
+def test_deploy_does_not_modify_configured_cli_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
-    workspace = tmp_path / "replaced-poc-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
-
-    def write_then_fail(**kwargs):
-        workspace.mkdir()
-        (workspace / "partial-result.txt").write_text("partial")
-        raise RuntimeError("provisioning failed after partial writes")
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
     env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="failed after partial writes"):
-        env.deploy(object())
-
-    assert env.deployment_started is True
-    assert env.workspace_owned is False
-    assert (workspace / "prior-result.txt").read_text() == "old"
-    assert not (workspace / "partial-result.txt").exists()
-    assert not list(tmp_path.glob("replaced-poc-workspace.nvflare-recipe-backup-*"))
-
-
-def test_rollback_state_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "unknown-rollback-state-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-
-    def write_then_fail(**kwargs):
-        workspace.mkdir()
-        (workspace / "partial-result.txt").write_text("partial")
-        raise RuntimeError("provisioning failed after partial writes")
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
-    env = PocEnv()
-    state_checks = iter([False, RuntimeError("Docker inspection unavailable")])
-
-    def check_state():
-        result = next(state_checks)
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    monkeypatch.setattr(env, "_check_poc_running", check_state)
-
-    with pytest.raises(RuntimeError, match="state of partially started services could not be determined") as exc_info:
-        env.deploy(object())
-
-    backups = list(tmp_path.glob("unknown-rollback-state-workspace.nvflare-recipe-backup-*"))
-    assert len(backups) == 1
-    assert str(backups[0]) in str(exc_info.value)
-    assert str(workspace) in str(exc_info.value)
-    assert isinstance(exc_info.value.__cause__, RuntimeError)
-    assert "Docker inspection unavailable" in str(exc_info.value.__cause__)
-    assert env.workspace_owned is True
-    assert (workspace / "partial-result.txt").read_text() == "partial"
-    assert (backups[0] / "prior-result.txt").read_text() == "old"
-
-
-def test_post_stop_state_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "unknown-post-stop-state-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-
-    def write_then_fail(**kwargs):
-        workspace.mkdir()
-        (workspace / "partial-result.txt").write_text("partial")
-        raise RuntimeError("provisioning failed after partial writes")
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
-    env = PocEnv()
-    state_checks = iter([False, True, RuntimeError("Docker inspection unavailable after stop")])
-
-    def check_state():
-        result = next(state_checks)
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    stop_calls = []
-    monkeypatch.setattr(env, "_check_poc_running", check_state)
-    monkeypatch.setattr(env, "stop", lambda clean_up: stop_calls.append(clean_up))
-
-    with pytest.raises(RuntimeError, match="could not be determined after stopping") as exc_info:
-        env.deploy(object())
-
-    backups = list(tmp_path.glob("unknown-post-stop-state-workspace.nvflare-recipe-backup-*"))
-    assert stop_calls == [False]
-    assert len(backups) == 1
-    assert str(backups[0]) in str(exc_info.value)
-    assert env.workspace_owned is True
-    assert (workspace / "partial-result.txt").read_text() == "partial"
-    assert (backups[0] / "prior-result.txt").read_text() == "old"
-
-
-def test_rollback_stop_error_preserves_partial_workspace_and_backup(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "failed-rollback-stop-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-
-    def write_then_fail(**kwargs):
-        workspace.mkdir()
-        (workspace / "partial-result.txt").write_text("partial")
-        raise RuntimeError("provisioning failed after partial writes")
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
-    env = PocEnv()
-    state_checks = iter([False, True])
-    monkeypatch.setattr(env, "_check_poc_running", lambda: next(state_checks))
-    monkeypatch.setattr(
-        env,
-        "stop",
-        lambda clean_up: (_ for _ in ()).throw(RuntimeError("Docker stop failed")),
-    )
-
-    with pytest.raises(RuntimeError, match="could not be safely stopped") as exc_info:
-        env.deploy(object())
-
-    backups = list(tmp_path.glob("failed-rollback-stop-workspace.nvflare-recipe-backup-*"))
-    assert len(backups) == 1
-    assert str(backups[0]) in str(exc_info.value)
-    assert env.workspace_owned is True
-    assert (workspace / "partial-result.txt").read_text() == "partial"
-    assert (backups[0] / "prior-result.txt").read_text() == "old"
-
-
-def test_failed_start_restores_retained_workspace(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "start-failure-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", lambda **kwargs: workspace.mkdir())
-
-    def fail_start(**kwargs):
-        raise RuntimeError("start failed")
-
-    monkeypatch.setattr(poc_env_module, "_start_poc", fail_start)
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="start failed"):
-        env.deploy(object())
-
-    assert env.deployment_started is True
-    assert env.workspace_owned is False
-    assert (workspace / "prior-result.txt").read_text() == "old"
-    assert not list(tmp_path.glob("start-failure-workspace.nvflare-recipe-backup-*"))
-
-
-def test_failed_readiness_restores_retained_workspace(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "readiness-failure-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
-
-    def prepare_replacement(**kwargs):
-        workspace.mkdir()
-        (workspace / "partial-result.txt").write_text("partial")
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
-    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
-    monkeypatch.setattr(
-        poc_env_module,
-        "setup_service_config",
-        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
-    )
-    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
-    env = PocEnv()
-    monkeypatch.setattr(
-        env,
-        "_wait_for_services_ready",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("POC did not become ready")),
-    )
-
-    with pytest.raises(RuntimeError, match="did not become ready"):
-        env.deploy(object())
-
-    assert env.deployment_started is True
-    assert env.workspace_owned is False
-    assert (workspace / "prior-result.txt").read_text() == "old"
-    assert not (workspace / "partial-result.txt").exists()
-    assert not list(tmp_path.glob("readiness-failure-workspace.nvflare-recipe-backup-*"))
-
-
-def test_successful_submission_discards_backup_only_after_health_check(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "healthy-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
-
-    def prepare_replacement(**kwargs):
-        workspace.mkdir()
-        (workspace / "new-workspace.txt").write_text("new")
-
-    def assert_backup_retained():
-        backups = list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
-        assert len(backups) == 1
-        assert (backups[0] / "prior-result.txt").read_text() == "old"
-
-    def verify_ready(*args, **kwargs):
-        assert_backup_retained()
-
-    def verify_registered(*args, **kwargs):
-        assert_backup_retained()
-        return True
-
-    def submit_job(job):
-        assert_backup_retained()
-        return "job-id"
-
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
-    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
-    monkeypatch.setattr(
-        poc_env_module,
-        "setup_service_config",
-        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
-    )
-    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", verify_registered)
-    env = PocEnv()
-    monkeypatch.setattr(env, "_wait_for_services_ready", verify_ready)
-    monkeypatch.setattr(env, "_get_session_manager", lambda: SimpleNamespace(submit_job=submit_job))
+    _configure_successful_deploy(monkeypatch, env)
 
     assert env.deploy(object()) == "job-id"
 
-    assert env.workspace_owned is True
-    assert (workspace / "new-workspace.txt").read_text() == "new"
-    assert not (workspace / "prior-result.txt").exists()
-    assert not list(tmp_path.glob("healthy-workspace.nvflare-recipe-backup-*"))
+    assert env.poc_workspace != str(configured_workspace)
+    assert Path(env.poc_workspace).is_dir()
+    assert retained_result.read_text() == "keep me"
 
 
-def test_failed_submission_restores_retained_workspace(tmp_path, monkeypatch):
+def test_project_config_may_live_in_configured_cli_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
-    workspace = tmp_path / "submission-failure-workspace"
-    workspace.mkdir()
-    (workspace / "prior-result.txt").write_text("old")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    project_conf = configured_workspace / "project.yml"
+    project_conf.write_text("name: retained")
+    prepared = {}
+
+    def prepare(**kwargs):
+        prepared.update(kwargs)
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv(project_conf_path=str(project_conf))
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
+
+    assert env.deploy(object()) == "job-id"
+
+    assert prepared["project_conf_path"] == str(project_conf)
+    assert prepared["workspace"] == env.poc_workspace
+    assert project_conf.read_text() == "name: retained"
+
+
+def test_failed_provisioning_cleans_only_run_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
     monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(PocEnv, "_check_poc_running", lambda self: False)
 
-    def prepare_replacement(**kwargs):
-        workspace.mkdir()
+    def write_then_fail(**kwargs):
+        workspace = Path(kwargs["workspace"])
+        workspace.mkdir(parents=True)
         (workspace / "partial-result.txt").write_text("partial")
+        raise RuntimeError("provisioning failed")
 
-    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare_replacement)
-    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
-    monkeypatch.setattr(
-        poc_env_module,
-        "setup_service_config",
-        lambda path: ({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}),
-    )
-    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", write_then_fail)
     env = PocEnv()
-    monkeypatch.setattr(env, "_wait_for_services_ready", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        env,
-        "_get_session_manager",
-        lambda: SimpleNamespace(submit_job=lambda job: (_ for _ in ()).throw(RuntimeError("job submission failed"))),
-    )
+    run_workspace = env.poc_workspace
 
-    with pytest.raises(RuntimeError, match="job submission failed"):
+    with pytest.raises(RuntimeError, match="provisioning failed"):
         env.deploy(object())
 
-    assert env.workspace_owned is False
-    assert (workspace / "prior-result.txt").read_text() == "old"
-    assert not (workspace / "partial-result.txt").exists()
-    assert not list(tmp_path.glob("submission-failure-workspace.nvflare-recipe-backup-*"))
+    assert retained_result.read_text() == "keep me"
+    assert not os.path.exists(run_workspace)
+
+
+@pytest.mark.parametrize("failure_stage", ["start", "readiness", "submission"])
+def test_deploy_failure_cleans_only_run_workspace(tmp_path, monkeypatch, failure_stage):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+
+    def prepare(**kwargs):
+        workspace = Path(kwargs["workspace"])
+        workspace.mkdir(parents=True)
+        (workspace / "partial-result.txt").write_text("partial")
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
+    monkeypatch.setattr(env, "_check_poc_running", lambda: False)
+    if failure_stage == "start":
+        monkeypatch.setattr(
+            poc_env_module,
+            "_start_poc",
+            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("start failed")),
+        )
+    elif failure_stage == "readiness":
+        monkeypatch.setattr(
+            env,
+            "_wait_for_services_ready",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("readiness failed")),
+        )
+    else:
+        monkeypatch.setattr(
+            env,
+            "_get_session_manager",
+            lambda: SimpleNamespace(submit_job=lambda job: (_ for _ in ()).throw(RuntimeError("submission failed"))),
+        )
+    run_workspace = env.poc_workspace
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        env.deploy(object())
+
+    assert retained_result.read_text() == "keep me"
+    assert not os.path.exists(run_workspace)
+
+
+def test_reusing_stopped_env_creates_new_workspace_and_preserves_prior_result(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+
+    def prepare(**kwargs):
+        workspace = Path(kwargs["workspace"])
+        workspace.mkdir(parents=True)
+        (workspace / "run-result.txt").write_text("complete")
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
+
+    assert env.deploy(object()) == "job-id"
+    first_workspace = env.poc_workspace
+    env.stop(clean_up=False)
+    assert (Path(first_workspace) / "run-result.txt").read_text() == "complete"
+
+    assert env.deploy(object()) == "job-id"
+    second_workspace = env.poc_workspace
+
+    assert second_workspace != first_workspace
+    assert Path(second_workspace).is_dir()
+    assert (Path(first_workspace) / "run-result.txt").read_text() == "complete"
+
+
+def test_redeploy_rejects_running_workspace_without_rotating(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv()
+    _configure_successful_deploy(monkeypatch, env)
+    assert env.deploy(object()) == "job-id"
+    active_workspace = env.poc_workspace
+    monkeypatch.setattr(env, "_check_poc_running", lambda: True)
+
+    with pytest.raises(RuntimeError, match="already has a running deployment"):
+        env.deploy(object())
+
+    assert env.poc_workspace == active_workspace
+
+
+def test_stop_cleanup_removes_only_run_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+    run_workspace = Path(env.poc_workspace)
+    run_workspace.mkdir()
+    (run_workspace / "result.txt").write_text("temporary")
+    monkeypatch.setattr(env, "_check_poc_running", lambda: False)
+
+    env.stop(clean_up=True)
+
+    assert not run_workspace.exists()
+    assert retained_result.read_text() == "keep me"
 
 
 def test_wait_for_services_ready_rejects_an_exited_client(monkeypatch):
@@ -510,7 +359,7 @@ def test_wait_for_services_ready_rejects_an_exited_client(monkeypatch):
     monkeypatch.setattr(env, "_running_services", lambda *args: ["server"])
 
     with pytest.raises(RuntimeError, match="not running: site-1"):
-        env._wait_for_services_ready({"name": "poc"}, {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]})
+        env._wait_for_services_ready(PROJECT_CONFIG, SERVICE_CONFIG)
 
 
 def test_running_services_uses_docker_container_state(monkeypatch):
@@ -531,7 +380,7 @@ def test_running_services_uses_docker_container_state(monkeypatch):
         SC.IS_DOCKER_RUN: True,
     }
 
-    assert PocEnv._running_services({"name": "poc"}, service_config, "/unused") == ["server", "site-2"]
+    assert PocEnv._running_services(PROJECT_CONFIG, service_config, "/unused") == ["server", "site-2"]
     assert [command[-1] for command in inspected] == ["server", "site-1", "site-2"]
 
 
@@ -585,39 +434,6 @@ def test_docker_liveness_distinguishes_missing_container_from_inspection_error(m
         PocEnv._is_docker_service_running("server")
 
 
-def test_deploy_does_not_move_workspace_when_docker_state_is_unknown(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    workspace = tmp_path / "retained-docker-workspace"
-    workspace.mkdir()
-    retained_result = workspace / "prior-result.txt"
-    retained_result.write_text("keep me")
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(
-        poc_env_module,
-        "setup_service_config",
-        lambda path: (
-            {"name": "poc"},
-            {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"], SC.IS_DOCKER_RUN: True},
-        ),
-    )
-    monkeypatch.setattr(
-        PocEnv,
-        "_is_docker_service_running",
-        lambda service_name: (_ for _ in ()).throw(RuntimeError("Docker state is unknown")),
-    )
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="Docker state is unknown"):
-        env.deploy(object())
-
-    assert env.deployment_started is False
-    assert env.workspace_owned is False
-    assert retained_result.read_text() == "keep me"
-    assert not list(tmp_path.glob("retained-docker-workspace.nvflare-recipe-backup-*"))
-
-
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
 @patch("nvflare.recipe.poc_env.get_prod_dir")
 @patch("nvflare.recipe.poc_env.setup_service_config")
@@ -628,15 +444,11 @@ def test_get_admin_startup_kit_path(mock_setup, mock_get_prod_dir, mock_get_work
         prod_dir = os.path.join(temp_dir, "prod_00")
         mock_get_prod_dir.return_value = prod_dir
         mock_setup.return_value = ({"name": "test_project"}, {SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"})
-
         env = PocEnv()
-
-        # Create the expected admin directory structure
         admin_dir = os.path.join(prod_dir, "admin@nvidia.com")
         os.makedirs(admin_dir, exist_ok=True)
 
-        result = env._get_admin_startup_kit_path()
-        assert result == admin_dir
+        assert env._get_admin_startup_kit_path() == admin_dir
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
@@ -649,7 +461,6 @@ def test_get_admin_startup_kit_path_not_found(mock_setup, mock_get_prod_dir, moc
         prod_dir = os.path.join(temp_dir, "prod_00")
         mock_get_prod_dir.return_value = prod_dir
         mock_setup.return_value = ({"name": "test_project"}, {SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"})
-
         env = PocEnv()
 
         with pytest.raises(RuntimeError, match="Admin startup kit not found"):
@@ -662,17 +473,18 @@ def test_get_admin_startup_kit_path_not_found(mock_setup, mock_get_prod_dir, moc
 @patch("nvflare.recipe.poc_env.is_poc_running")
 def test_stop_poc(mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup):
     """Test stop and clean POC functionality."""
-    mock_setup.return_value = ({"name": "test"}, {"server": "server"})
+    mock_setup.return_value = ({"name": "test"}, {SC.FLARE_SERVER: "server"})
     mock_is_running.return_value = True
-
     env = PocEnv()
+
     with patch.object(PocEnv, "_running_services", side_effect=[["server"], []]):
         env.stop(clean_up=True)
 
     mock_stop_poc.assert_called_once_with(
-        poc_workspace=env.poc_workspace, excluded=["admin@nvidia.com"], services_list=[]
+        poc_workspace=env.poc_workspace,
+        excluded=["admin@nvidia.com"],
+        services_list=[],
     )
-    # _clean_poc handles workspace removal internally via shutil.rmtree
     mock_clean_poc.assert_called_once_with(env.poc_workspace)
 
 
@@ -686,11 +498,10 @@ def test_poc_env_session_manager_passes_study(mock_get_workspace, mock_get_prod_
         prod_dir = os.path.join(temp_dir, "prod_00")
         mock_get_prod_dir.return_value = prod_dir
         mock_setup.return_value = ({"name": "test_project"}, {SC.FLARE_PROJ_ADMIN: "admin@nvidia.com"})
-
         admin_dir = os.path.join(prod_dir, "admin@nvidia.com")
         os.makedirs(admin_dir, exist_ok=True)
-
         env = PocEnv(study="cancer-research")
+
         env._get_session_manager()
 
         session_params = mock_session_manager.call_args[0][0]

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -197,6 +197,42 @@ def test_deploy_fails_closed_when_prior_runtime_workspace_is_unreadable(tmp_path
     assert env._runtime_lock_file is None
 
 
+def test_deploy_fails_closed_when_prior_runtime_service_state_is_unreadable(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "current-poc"
+    prior_workspace = tmp_path / f"prior-poc.recipe-{'c' * 32}"
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path.write_text(str(prior_workspace))
+    provision_calls = []
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: (object(), object()))
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: provision_calls.append(kwargs),
+    )
+    env = PocEnv()
+    monkeypatch.setattr(
+        env,
+        "_running_services",
+        lambda project_config, service_config, workspace: (_ for _ in ()).throw(
+            ValueError("service configuration is unusable")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not determine service state") as exc_info:
+        env.deploy(object())
+
+    assert str(prior_workspace) in str(exc_info.value)
+    assert str(lock_path) in str(exc_info.value)
+    assert provision_calls == []
+    assert lock_path.read_text() == str(prior_workspace)
+    assert env._runtime_lock_file is None
+
+
 def test_deploy_rejects_overlapping_calls_on_same_environment():
     env = PocEnv()
     assert env._deployment_lock.acquire(blocking=False)

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -173,6 +173,45 @@ def test_deploy_preflight_failure_does_not_create_workspace(tmp_path, monkeypatc
     assert not os.path.exists(env.poc_workspace)
 
 
+def test_deploy_rejects_running_configured_cli_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    configured_workspace.mkdir()
+    retained_result = configured_workspace / "prior-result.txt"
+    retained_result.write_text("keep me")
+    provision_calls = []
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, SERVICE_CONFIG),
+    )
+    monkeypatch.setattr(
+        PocEnv,
+        "_running_services",
+        staticmethod(
+            lambda project_config, service_config, workspace: (
+                ["server"] if workspace == str(configured_workspace) else []
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: provision_calls.append(kwargs),
+    )
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="nvflare poc stop"):
+        env.deploy(object())
+
+    assert provision_calls == []
+    assert retained_result.read_text() == "keep me"
+    assert not os.path.exists(env.poc_workspace)
+
+
 def test_deploy_does_not_modify_configured_cli_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
@@ -313,6 +352,30 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
     assert "remove this workspace manually" in str(exc_info.value)
     assert "POC services remain running" in str(exc_info.value.__cause__)
     assert os.path.isdir(run_workspace)
+
+
+@pytest.mark.parametrize("interruption", [KeyboardInterrupt(), SystemExit(2)])
+def test_cleanup_interruption_is_not_converted_to_runtime_error(tmp_path, monkeypatch, interruption):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv()
+
+    def prepare(**kwargs):
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    def fail_submission(job):
+        raise RuntimeError("submission failed")
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare, submit=fail_submission)
+    monkeypatch.setattr(
+        env,
+        "_clean_up_failed_deployment",
+        lambda: (_ for _ in ()).throw(interruption),
+    )
+
+    with pytest.raises(type(interruption)):
+        env.deploy(object())
 
 
 def test_new_env_preserves_retained_recipe_workspace(tmp_path, monkeypatch):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -107,6 +107,72 @@ def test_runtime_lock_propagates_unexpected_lock_error(monkeypatch):
     env._release_runtime_lock()
 
 
+def test_runtime_workspace_record_requires_lock():
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="runtime lock is not held"):
+        env._record_runtime_workspace()
+
+
+def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "current-poc"
+    prior_workspace = tmp_path / f"prior-poc.recipe-{'a' * 32}"
+    prior_workspace.mkdir()
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path.write_text(str(prior_workspace))
+    provisioned_workspaces = []
+    active_workspaces = {str(prior_workspace)}
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: (PROJECT_CONFIG, SERVICE_CONFIG))
+    monkeypatch.setattr(
+        PocEnv,
+        "_running_services",
+        staticmethod(
+            lambda project_config, service_config, workspace: ["server"] if workspace in active_workspaces else []
+        ),
+    )
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: provisioned_workspaces.append(kwargs["workspace"]),
+    )
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="prior Recipe PocEnv deployment is still active") as exc_info:
+        env.deploy(object())
+
+    assert str(prior_workspace) in str(exc_info.value)
+    assert provisioned_workspaces == []
+    assert lock_path.read_text() == str(prior_workspace)
+    assert env._runtime_lock_file is None
+
+    active_workspaces.clear()
+
+    def prepare(**kwargs):
+        provisioned_workspaces.append(kwargs["workspace"])
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
+    assert env.deploy(object()) == "job-id"
+    assert lock_path.read_text() == os.path.abspath(env.poc_workspace)
+    env.stop(clean_up=False)
+    assert lock_path.read_text() == ""
+
+
+def test_deploy_rejects_overlapping_calls_on_same_environment():
+    env = PocEnv()
+    assert env._deployment_lock.acquire(blocking=False)
+    try:
+        with pytest.raises(RuntimeError, match="deployment in progress"):
+            env.deploy(object())
+    finally:
+        env._deployment_lock.release()
+
+
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
 def test_poc_env_initialization_with_custom_values(mock_get_workspace, tmp_path):
     """Test PocEnv initialization with custom values."""

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -287,6 +287,33 @@ def test_deploy_failure_cleans_only_run_workspace(tmp_path, monkeypatch, failure
     assert not os.path.exists(run_workspace)
 
 
+def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+
+    def prepare(**kwargs):
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    def fail_submission(job):
+        raise RuntimeError("submission failed")
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare, submit=fail_submission)
+    monkeypatch.setattr(env, "stop", lambda clean_up: None)
+    monkeypatch.setattr(env, "_check_poc_running", lambda: True)
+    run_workspace = env.poc_workspace
+
+    with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:
+        env.deploy(object())
+
+    assert "submission failed" in str(exc_info.value)
+    assert run_workspace in str(exc_info.value)
+    assert "POC services remain running" in str(exc_info.value.__cause__)
+    assert os.path.isdir(run_workspace)
+
+
 def test_reusing_stopped_env_creates_new_workspace_and_preserves_prior_result(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -15,6 +15,7 @@
 import os
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -171,6 +172,36 @@ def test_deploy_rejects_overlapping_calls_on_same_environment():
             env.deploy(object())
     finally:
         env._deployment_lock.release()
+
+
+def test_stop_waits_for_deployment_to_leave_instance_guard(monkeypatch):
+    env = PocEnv()
+    stop_called = threading.Event()
+    stop_completed = threading.Event()
+    stop_args = []
+
+    def stop_impl(clean_up):
+        stop_args.append(clean_up)
+
+    def call_stop():
+        stop_called.set()
+        env.stop(clean_up=True)
+        stop_completed.set()
+
+    monkeypatch.setattr(env, "_stop", stop_impl)
+    assert env._deployment_lock.acquire(blocking=False)
+    stop_thread = threading.Thread(target=call_stop)
+    stop_thread.start()
+    try:
+        assert stop_called.wait(timeout=1)
+        assert not stop_completed.wait(timeout=0.05)
+    finally:
+        env._deployment_lock.release()
+    stop_thread.join(timeout=1)
+
+    assert not stop_thread.is_alive()
+    assert stop_completed.is_set()
+    assert stop_args == [True]
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -310,8 +310,25 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
 
     assert "submission failed" in str(exc_info.value)
     assert run_workspace in str(exc_info.value)
+    assert "remove this workspace manually" in str(exc_info.value)
     assert "POC services remain running" in str(exc_info.value.__cause__)
     assert os.path.isdir(run_workspace)
+
+
+def test_new_env_preserves_retained_recipe_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    retained_workspace = tmp_path / f"poc.recipe-{'b' * 32}"
+    retained_workspace.mkdir()
+    retained_result = retained_workspace / "result.txt"
+    retained_result.write_text("keep me")
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+    _configure_successful_deploy(monkeypatch, env)
+
+    assert env.deploy(object()) == "job-id"
+    assert retained_result.read_text() == "keep me"
 
 
 def test_reusing_stopped_env_creates_new_workspace_and_preserves_prior_result(tmp_path, monkeypatch):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -164,6 +164,39 @@ def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypa
     assert lock_path.read_text() == ""
 
 
+def test_deploy_fails_closed_when_prior_runtime_workspace_is_unreadable(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "current-poc"
+    missing_prior_workspace = tmp_path / f"missing-poc.recipe-{'b' * 32}"
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path.write_text(str(missing_prior_workspace))
+    provision_calls = []
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (_ for _ in ()).throw(ValueError("project configuration is unavailable")),
+    )
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: provision_calls.append(kwargs),
+    )
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="Could not determine service state") as exc_info:
+        env.deploy(object())
+
+    assert str(missing_prior_workspace) in str(exc_info.value)
+    assert str(lock_path) in str(exc_info.value)
+    assert provision_calls == []
+    assert lock_path.read_text() == str(missing_prior_workspace)
+    assert env._runtime_lock_file is None
+
+
 def test_deploy_rejects_overlapping_calls_on_same_environment():
     env = PocEnv()
     assert env._deployment_lock.acquire(blocking=False)

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -364,12 +364,13 @@ def test_remote_docker_daemon_skips_local_loopback_port_preflight(monkeypatch):
     PocEnv._ensure_shared_resources_available(PROJECT_CONFIG, docker_service_config)
 
 
-def test_local_docker_daemon_keeps_local_loopback_port_preflight(monkeypatch):
+@pytest.mark.parametrize("endpoint", ["", "unix:///var/run/docker.sock"])
+def test_local_or_unknown_docker_endpoint_keeps_local_loopback_port_preflight(monkeypatch, endpoint):
     import nvflare.recipe.poc_env as poc_env_module
 
     docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
     port_checks = []
-    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: "unix:///var/run/docker.sock")
+    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: endpoint)
     monkeypatch.setattr(
         poc_env_module,
         "_build_poc_port_preflight",

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -43,6 +43,7 @@ def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
             return "job-id"
 
     monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(env, "_preflight_ports_before_provision", lambda: None)
     monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
     monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
     monkeypatch.setattr(
@@ -253,7 +254,47 @@ def test_deploy_rejects_running_configured_cli_workspace(tmp_path, monkeypatch):
     assert not os.path.exists(env.poc_workspace)
 
 
-def test_deploy_rejects_unavailable_shared_port_before_start(tmp_path, monkeypatch):
+def test_deploy_rejects_unavailable_custom_port_before_provision(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+    import nvflare.tool.poc.poc_commands as poc_commands
+
+    configured_workspace = tmp_path / "poc"
+    project_conf = tmp_path / "project.yml"
+    project_conf.write_text(
+        "participants:\n"
+        "  - name: server\n"
+        "    type: server\n"
+        "    fed_learn_port: 18002\n"
+        "    admin_port: 18003\n"
+    )
+    provision_calls = []
+    checked_ports = []
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: provision_calls.append(kwargs),
+    )
+
+    def check_port(port, host):
+        checked_ports.append((port, host))
+        return (False, "in_use") if port == 18002 else (True, None)
+
+    monkeypatch.setattr(poc_commands, "_is_local_port_available", check_port)
+    env = PocEnv(project_conf_path=str(project_conf))
+
+    with pytest.raises(RuntimeError, match="other Recipe PocEnv") as exc_info:
+        env.deploy(object())
+
+    assert "18002" in str(exc_info.value)
+    assert checked_ports == [(18002, "127.0.0.1"), (18003, "127.0.0.1")]
+    assert provision_calls == []
+    assert env._deployment_started is False
+    assert not os.path.exists(env.poc_workspace)
+
+
+def test_deploy_rechecks_ports_after_provision(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
     import nvflare.tool.poc.poc_commands as poc_commands
 
@@ -294,10 +335,51 @@ def test_deploy_rejects_unavailable_shared_port_before_start(tmp_path, monkeypat
         env.deploy(object())
 
     assert "18002" in str(exc_info.value)
-    assert checked_ports == [(18002, "127.0.0.1"), (18003, "127.0.0.1")]
+    assert checked_ports == [
+        (8002, "127.0.0.1"),
+        (8003, "127.0.0.1"),
+        (18002, "127.0.0.1"),
+        (18003, "127.0.0.1"),
+    ]
     assert provisioned_workspaces == [env.poc_workspace]
+    assert env._deployment_started is True
     assert start_calls == []
     assert not os.path.exists(env.poc_workspace)
+
+
+def test_remote_docker_daemon_skips_local_loopback_port_preflight(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
+    monkeypatch.setenv("DOCKER_CONTEXT", "remote-builder")
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: "ssh://docker.example")
+    monkeypatch.setattr(
+        poc_env_module,
+        "_build_poc_port_preflight",
+        lambda project_config: pytest.fail("local port preflight must not inspect a remote Docker host"),
+    )
+    monkeypatch.setattr(PocEnv, "_get_docker_service_state", staticmethod(lambda _container_name: None))
+
+    PocEnv._ensure_shared_resources_available(PROJECT_CONFIG, docker_service_config)
+
+
+def test_local_docker_daemon_keeps_local_loopback_port_preflight(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
+    port_checks = []
+    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: "unix:///var/run/docker.sock")
+    monkeypatch.setattr(
+        poc_env_module,
+        "_build_poc_port_preflight",
+        lambda project_config: port_checks.append(project_config) or {"conflicts": []},
+    )
+    monkeypatch.setattr(PocEnv, "_get_docker_service_state", staticmethod(lambda _container_name: None))
+
+    PocEnv._ensure_shared_resources_available(PROJECT_CONFIG, docker_service_config)
+
+    assert port_checks == [PROJECT_CONFIG]
 
 
 def test_deploy_rejects_existing_docker_participant_name_without_stopping_it(tmp_path, monkeypatch):
@@ -320,22 +402,113 @@ def test_deploy_rejects_existing_docker_participant_name_without_stopping_it(tmp
         "setup_service_config",
         lambda path: (PROJECT_CONFIG, docker_service_config),
     )
-    monkeypatch.setattr(poc_env_module, "_build_poc_port_preflight", lambda project_config: {"conflicts": []})
-    monkeypatch.setattr(
-        PocEnv,
-        "_get_docker_service_state",
-        staticmethod(lambda service_name: False if service_name == "server" else None),
-    )
+    monkeypatch.setattr(PocEnv, "_docker_daemon_is_local", staticmethod(lambda: False))
+    inspected_names = []
+
+    def container_state(container_name):
+        inspected_names.append(container_name)
+        return False if container_name.startswith("nvflare-recipe-") else None
+
+    monkeypatch.setattr(PocEnv, "_get_docker_service_state", staticmethod(container_state))
     monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: start_calls.append(kwargs))
     monkeypatch.setattr(poc_env_module, "_stop_poc", lambda **kwargs: stop_calls.append(kwargs))
 
     with pytest.raises(RuntimeError, match=r"container name\(s\) already exist") as exc_info:
         env.deploy(object())
 
-    assert "server" in str(exc_info.value)
+    assert env._docker_container_names["server"] in str(exc_info.value)
+    assert env._docker_container_names["server"] in inspected_names
     assert start_calls == []
     assert stop_calls == []
     assert not os.path.exists(env.poc_workspace)
+
+
+def test_concurrent_docker_deploy_failure_stops_only_its_own_containers(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    first = PocEnv(docker_image="nvflare:test")
+    second = PocEnv(docker_image="nvflare:test")
+    start_barrier = threading.Barrier(2)
+    state_lock = threading.Lock()
+    running_containers = set()
+    stop_calls = []
+    removed_networks = []
+
+    def prepare(**kwargs):
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    def container_state(container_name):
+        with state_lock:
+            return True if container_name in running_containers else None
+
+    def start(**kwargs):
+        with state_lock:
+            running_containers.update(kwargs["docker_container_names"].values())
+        start_barrier.wait(timeout=2)
+        if kwargs["poc_workspace"] == second.poc_workspace:
+            raise RuntimeError("simulated losing Docker startup")
+
+    def stop(**kwargs):
+        names = dict(kwargs["docker_container_names"])
+        stop_calls.append(names)
+        with state_lock:
+            for container_name in names.values():
+                running_containers.discard(container_name)
+
+    def remove_network(env):
+        removed_networks.append(env._docker_network_name)
+        env._docker_network_name = None
+
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, docker_service_config),
+    )
+    monkeypatch.setattr(PocEnv, "_docker_daemon_is_local", staticmethod(lambda: False))
+    monkeypatch.setattr(PocEnv, "_get_docker_service_state", staticmethod(container_state))
+    monkeypatch.setattr(PocEnv, "_wait_for_services_ready", lambda *args, **kwargs: None)
+    monkeypatch.setattr(PocEnv, "_remove_docker_network", remove_network)
+    monkeypatch.setattr(poc_env_module, "_wait_for_poc_system_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(poc_env_module, "_start_poc", start)
+    monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
+    monkeypatch.setattr(
+        PocEnv,
+        "_get_session_manager",
+        lambda self: SimpleNamespace(submit_job=lambda job: "job-id"),
+    )
+
+    results = {}
+
+    def deploy(name, env):
+        try:
+            results[name] = env.deploy(object())
+        except BaseException as error:
+            results[name] = error
+
+    first_thread = threading.Thread(target=deploy, args=("first", first))
+    second_thread = threading.Thread(target=deploy, args=("second", second))
+    first_thread.start()
+    second_thread.start()
+    first_thread.join(timeout=3)
+    second_thread.join(timeout=3)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert results["first"] == "job-id"
+    assert isinstance(results["second"], RuntimeError)
+    assert "simulated losing Docker startup" in str(results["second"])
+    assert set(first._docker_container_names.values()).isdisjoint(second._docker_container_names.values())
+    assert first._docker_network_name != removed_networks[0]
+    assert stop_calls == [second._docker_container_names]
+    assert running_containers == set(first._docker_container_names.values())
+    second_service_config = second._with_docker_container_names(second.poc_workspace, docker_service_config)
+    assert second._running_services(PROJECT_CONFIG, second_service_config, second.poc_workspace) == []
+    assert not os.path.exists(second.poc_workspace)
 
 
 def test_deploy_does_not_modify_configured_cli_workspace(tmp_path, monkeypatch):
@@ -690,6 +863,28 @@ def test_docker_liveness_distinguishes_missing_container_from_inspection_error(m
         PocEnv._is_docker_service_running("server")
 
 
+def test_remove_docker_network_uses_selected_daemon_and_clears_identity(monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    env = PocEnv()
+    env._docker_network_name = "nvflare-recipe-run"
+    docker_env = {"DOCKER_HOST": "ssh://docker.example"}
+    completed = SimpleNamespace(returncode=0, stdout="nvflare-recipe-run\n", stderr="")
+    calls = []
+    monkeypatch.setattr(poc_env_module, "_docker_cli_env", lambda: docker_env)
+    monkeypatch.setattr(
+        poc_env_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or completed,
+    )
+
+    env._remove_docker_network()
+
+    assert calls[0][0][0] == ["docker", "network", "rm", "nvflare-recipe-run"]
+    assert calls[0][1]["env"] is docker_env
+    assert env._docker_network_name is None
+
+
 @patch("nvflare.recipe.poc_env.get_poc_workspace")
 @patch("nvflare.recipe.poc_env.get_prod_dir")
 @patch("nvflare.recipe.poc_env.setup_service_config")
@@ -767,6 +962,74 @@ def test_stop_preserves_workspace_when_service_state_is_unknown(
     mock_stop_poc.assert_called_once()
     mock_remove_workspace.assert_not_called()
     assert "Stop any remaining services and remove it manually" in caplog.text
+
+
+def test_stop_with_unreadable_service_metadata_is_repeatable_and_attempts_shutdown(tmp_path, monkeypatch, caplog):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv()
+    Path(env.poc_workspace).mkdir(parents=True)
+    env._services_may_have_started = True
+    env._session_manager = object()
+    stop_calls = []
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda _workspace: (_ for _ in ()).throw(RuntimeError("service metadata unreadable")),
+    )
+
+    def stop(**kwargs):
+        stop_calls.append(kwargs)
+        raise RuntimeError("shutdown metadata unreadable")
+
+    monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
+
+    env.stop(clean_up=True)
+    env.stop(clean_up=True)
+
+    assert len(stop_calls) == 2
+    assert all(call["poc_workspace"] == env.poc_workspace for call in stop_calls)
+    assert Path(env.poc_workspace).is_dir()
+    assert env._services_may_have_started is True
+    assert env._session_manager is None
+    assert "preserving workspace" in caplog.text
+
+
+def test_stop_is_idempotent_after_successful_deploy(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+    runtime_running = {"value": False}
+    stop_calls = []
+    _configure_successful_deploy(monkeypatch, env)
+    monkeypatch.setattr(
+        poc_env_module,
+        "_start_poc",
+        lambda **kwargs: runtime_running.update(value=True),
+    )
+    monkeypatch.setattr(
+        PocEnv,
+        "_running_services",
+        staticmethod(lambda *_args: ["server"] if runtime_running["value"] else []),
+    )
+    monkeypatch.setattr(poc_env_module, "is_poc_running", lambda *_args: True)
+
+    def stop(**kwargs):
+        stop_calls.append(kwargs)
+        runtime_running["value"] = False
+
+    monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
+
+    assert env.deploy(object()) == "job-id"
+    env.stop(clean_up=True)
+    env.stop(clean_up=True)
+
+    assert len(stop_calls) == 1
+    assert not Path(env.poc_workspace).exists()
+    assert env._services_may_have_started is False
 
 
 @patch("nvflare.recipe.poc_env.SessionManager")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -34,9 +34,7 @@ def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
     """Keep process-held Recipe POC locks independent across unit tests."""
     import nvflare.recipe.poc_env as poc_env_module
 
-    monkeypatch.setattr(
-        poc_env_module, "_recipe_runtime_lock_path", lambda _workspace_root: str(tmp_path / "recipe-poc.lock")
-    )
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(tmp_path / "recipe-poc.lock"))
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -75,16 +73,17 @@ def test_poc_env_initialization():
     assert env.poc_workspace.startswith(f"{env._poc_workspace_root}.recipe-")
 
 
-def test_recipe_runtime_lock_path_is_independent_of_process_temp_dir(tmp_path, monkeypatch):
-    configured_workspace = tmp_path / "shared" / "poc"
-    expected = f"{configured_workspace}.recipe-{os.geteuid()}.lock"
+def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_path, monkeypatch):
+    expected = os.path.join(os.path.realpath("/tmp"), f".nvflare-recipe-poc-{os.geteuid()}.lock")
 
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
-    first_path = _recipe_runtime_lock_path(str(configured_workspace))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
+    first_path = _recipe_runtime_lock_path()
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
 
     assert first_path == expected
-    assert _recipe_runtime_lock_path(str(configured_workspace)) == expected
+    assert _recipe_runtime_lock_path() == expected
 
 
 def test_runtime_lock_rejects_unsafe_lock_file(tmp_path, monkeypatch):
@@ -129,7 +128,7 @@ def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypa
     configured_workspace = tmp_path / "current-poc"
     prior_workspace = tmp_path / f"prior-poc.recipe-{'a' * 32}"
     prior_workspace.mkdir()
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
     lock_path.write_text(str(prior_workspace))
     provisioned_workspaces = []
     active_workspaces = {str(prior_workspace)}
@@ -177,7 +176,7 @@ def test_deploy_fails_closed_when_prior_runtime_workspace_is_unreadable(tmp_path
 
     configured_workspace = tmp_path / "current-poc"
     missing_prior_workspace = tmp_path / f"missing-poc.recipe-{'b' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
     lock_path.write_text(str(missing_prior_workspace))
     provision_calls = []
 
@@ -210,7 +209,7 @@ def test_deploy_fails_closed_when_prior_runtime_service_state_is_unreadable(tmp_
 
     configured_workspace = tmp_path / "current-poc"
     prior_workspace = tmp_path / f"prior-poc.recipe-{'c' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
     lock_path.write_text(str(prior_workspace))
     provision_calls = []
 
@@ -629,7 +628,7 @@ def test_deploy_preserves_workspace_and_lock_when_metadata_is_lost_after_start(t
     monkeypatch.setattr(PocEnv, "_running_services", staticmethod(lambda *args: []))
     env = PocEnv()
     run_workspace = env.poc_workspace
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
 
     try:
         with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -35,7 +35,8 @@ def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
     """Keep process-held Recipe POC locks independent across unit tests."""
     import nvflare.recipe.poc_env as poc_env_module
 
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(tmp_path / "recipe-poc.lock"))
+    lock_path = str(tmp_path / "recipe-poc.lock")
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: lock_path)
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -89,13 +90,42 @@ def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_pa
     assert _recipe_runtime_lock_path() == expected
 
 
+def test_recipe_runtime_lock_path_uses_environment_home_without_passwd_entry(tmp_path, monkeypatch):
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+    monkeypatch.setenv("HOME", str(tmp_path / "container-home"))
+
+    assert _recipe_runtime_lock_path() == str(tmp_path / "container-home" / ".nvflare" / "recipe-poc-runtime.lock")
+
+
+def test_runtime_lock_falls_back_when_preferred_home_is_not_writable(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    preferred = str(tmp_path / "read-only-home" / ".nvflare" / "recipe-poc-runtime.lock")
+    fallback = str(tmp_path / "writable-home" / ".nvflare" / "recipe-poc-runtime.lock")
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [preferred, fallback])
+    original_open = os.open
+
+    def open_lock(path, flags, mode=0o777):
+        if path == preferred:
+            raise PermissionError("preferred home is read-only")
+        return original_open(path, flags, mode)
+
+    monkeypatch.setattr(poc_env_module.os, "open", open_lock)
+    env = PocEnv()
+
+    env._acquire_runtime_lock()
+
+    assert env._runtime_lock_path == fallback
+    env._release_runtime_lock()
+
+
 def test_runtime_lock_rejects_unsafe_lock_directory(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
     unsafe_dir = tmp_path / "unsafe-lock-dir"
     unsafe_dir.mkdir(mode=0o777)
     unsafe_dir.chmod(0o777)
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(unsafe_dir / "recipe.lock"))
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [str(unsafe_dir / "recipe.lock")])
     env = PocEnv()
 
     with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock directory"):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -985,8 +985,8 @@ def test_remove_docker_network_uses_selected_daemon_and_clears_identity(monkeypa
 
 
 @pytest.mark.parametrize("initially_running", [False, True])
-@pytest.mark.parametrize("failure", ["active_endpoints", "daemon_error", "os_error", "timeout"])
-def test_stop_preserves_workspace_on_network_failure_and_can_retry(
+@pytest.mark.parametrize("failure", ["active_endpoints", "persistent_endpoints", "daemon_error", "os_error", "timeout"])
+def test_stop_retries_busy_docker_network_and_preserves_on_failure(
     tmp_path, monkeypatch, caplog, initially_running, failure
 ):
     import nvflare.recipe.poc_env as poc_env_module
@@ -1017,22 +1017,44 @@ def test_stop_preserves_workspace_on_network_failure_and_can_retry(
     monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
     # Exercise network removal itself; other Docker environment probes are unrelated here.
     monkeypatch.setattr(poc_env_module, "_docker_cli_env", lambda: {})
+    clock = {"now": 0.0}
+    monkeypatch.setattr(poc_env_module, "STOP_POC_TIMEOUT", 0.4)
+    monkeypatch.setattr(
+        poc_env_module,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda duration: clock.update(now=clock["now"] + duration),
+        ),
+    )
     network_calls = []
+    network_recovered = False
 
     def remove_network(command, **kwargs):
         network_calls.append(command)
         assert command == ["docker", "network", "rm", "nvflare-recipe-run"]
-        if len(network_calls) == 1:
+        if not network_recovered and (len(network_calls) == 1 or failure == "persistent_endpoints"):
             if failure == "os_error":
                 raise OSError("Docker unavailable")
             if failure == "timeout":
                 raise subprocess.TimeoutExpired(command, timeout=5)
-            message = "network has active endpoints" if failure == "active_endpoints" else "Docker daemon unavailable"
+            message = "network has active endpoints" if "endpoints" in failure else "Docker daemon unavailable"
             return SimpleNamespace(returncode=1, stdout="", stderr=message)
         return SimpleNamespace(returncode=0, stdout="nvflare-recipe-run\n", stderr="")
 
     monkeypatch.setattr(poc_env_module.subprocess, "run", remove_network)
     env.stop(clean_up=True)
+
+    if failure == "active_endpoints":
+        # A single stop must finish cleanup once auto-removed job containers detach.
+        assert not workspace.exists()
+        assert env._docker_network_name is None
+        assert env._services_may_have_started is False
+        assert env._session_manager is None
+        assert len(network_calls) == 2
+        assert len(stop_calls) == int(initially_running)
+        assert "preserving workspace" not in caplog.text
+        return
 
     assert retained_result.read_text() == "keep me"
     assert env._docker_network_name == "nvflare-recipe-run"
@@ -1040,13 +1062,21 @@ def test_stop_preserves_workspace_on_network_failure_and_can_retry(
     assert env._session_manager is None
     assert f"preserving workspace {workspace}" in caplog.text
     assert "retry PocEnv.stop(clean_up=True)" in caplog.text
+    if failure == "persistent_endpoints":
+        assert len(network_calls) > 1
+        assert clock["now"] <= poc_env_module.STOP_POC_TIMEOUT
+        assert "active endpoints" in caplog.text
+    else:
+        assert len(network_calls) == 1
 
+    attempts_before_recovery = len(network_calls)
+    network_recovered = True
     env.stop(clean_up=True)
 
     assert not workspace.exists()
     assert env._docker_network_name is None
     assert env._services_may_have_started is False
-    assert len(network_calls) == 2
+    assert len(network_calls) == attempts_before_recovery + 1
     assert len(stop_calls) == int(initially_running)
 
 

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -522,7 +522,7 @@ def test_concurrent_docker_deploy_failure_stops_only_its_own_containers(tmp_path
             for container_name in names.values():
                 running_containers.discard(container_name)
 
-    def remove_network(env):
+    def remove_network(env, deadline=None):
         removed_networks.append(env._docker_network_name)
         env._docker_network_name = None
 
@@ -1078,6 +1078,100 @@ def test_stop_retries_busy_docker_network_and_preserves_on_failure(
     assert env._services_may_have_started is False
     assert len(network_calls) == attempts_before_recovery + 1
     assert len(stop_calls) == int(initially_running)
+
+
+@pytest.mark.parametrize("expired_before_lookup", [False, True])
+def test_network_cleanup_does_not_run_after_shared_deadline(monkeypatch, expired_before_lookup):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    env = PocEnv()
+    env._docker_network_name = "nvflare-recipe-run"
+    clock = {"now": 1.0 if expired_before_lookup else 0.0}
+    monkeypatch.setattr(poc_env_module, "time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    def docker_env():
+        assert not expired_before_lookup
+        clock["now"] = 1.0
+        return {}
+
+    monkeypatch.setattr(poc_env_module, "_docker_cli_env", docker_env)
+    monkeypatch.setattr(
+        poc_env_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("network removal must not start after the shared deadline"),
+    )
+    with pytest.raises(RuntimeError, match="deadline") as exc_info:
+        env._remove_docker_network(deadline=1.0)
+
+    assert "nvflare-recipe-run" in str(exc_info.value)
+    assert env._docker_network_name == "nvflare-recipe-run"
+
+
+@pytest.mark.parametrize("network_release_time", [1.4, None])
+def test_stop_shares_service_wait_deadline_with_network_cleanup(tmp_path, monkeypatch, caplog, network_release_time):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv(docker_image="nvflare:test")
+    workspace = Path(env.poc_workspace)
+    workspace.mkdir()
+    env._docker_network_name = "nvflare-recipe-run"
+    env._services_may_have_started = True
+    env._session_manager = object()
+    clock = {"now": 0.0}
+    monkeypatch.setattr(poc_env_module, "STOP_POC_TIMEOUT", 2.0)
+    monkeypatch.setattr(
+        poc_env_module,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda duration: clock.update(now=clock["now"] + duration),
+        ),
+    )
+    monkeypatch.setattr(poc_env_module, "_docker_cli_env", lambda: {})
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}),
+    )
+    stop_requested = False
+
+    def stop(**kwargs):
+        nonlocal stop_requested
+        stop_requested = True
+
+    monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
+    network_calls = []
+
+    def docker(command, **kwargs):
+        if command[:2] == ["docker", "inspect"]:
+            # Parent services finish one second after receiving the stop request.
+            running = not stop_requested or clock["now"] < 1.0
+            return SimpleNamespace(returncode=0, stdout=str(running).lower(), stderr="")
+        assert command == ["docker", "network", "rm", "nvflare-recipe-run"]
+        network_calls.append((clock["now"], kwargs["timeout"]))
+        if network_release_time is not None and clock["now"] >= network_release_time:
+            return SimpleNamespace(returncode=0, stdout="nvflare-recipe-run", stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="network has active endpoints")
+
+    monkeypatch.setattr(poc_env_module.subprocess, "run", docker)
+    env.stop(clean_up=True)
+
+    assert stop_requested
+    assert network_calls[0][0] == 1.0
+    assert all(0 < timeout <= 2.0 - started for started, timeout in network_calls)
+    assert clock["now"] <= 2.0
+    assert env._session_manager is None
+    if network_release_time is None:
+        assert clock["now"] == pytest.approx(2.0)
+        assert workspace.exists()
+        assert env._docker_network_name == "nvflare-recipe-run"
+        assert env._services_may_have_started is True
+        assert "active endpoints" in caplog.text
+    else:
+        assert not workspace.exists()
+        assert env._docker_network_name is None
+        assert env._services_may_have_started is False
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -347,13 +347,14 @@ def test_deploy_rechecks_ports_after_provision(tmp_path, monkeypatch):
     assert not os.path.exists(env.poc_workspace)
 
 
-def test_remote_docker_daemon_skips_local_loopback_port_preflight(monkeypatch):
+@pytest.mark.parametrize("endpoint", ["ssh://docker.example", "tcp://docker.example:2375"])
+def test_remote_docker_daemon_skips_local_loopback_port_preflight(monkeypatch, endpoint):
     import nvflare.recipe.poc_env as poc_env_module
 
     docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
     monkeypatch.setenv("DOCKER_CONTEXT", "remote-builder")
     monkeypatch.delenv("DOCKER_HOST", raising=False)
-    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: "ssh://docker.example")
+    monkeypatch.setattr(poc_env_module, "_get_docker_endpoint", lambda docker_env: endpoint)
     monkeypatch.setattr(
         poc_env_module,
         "_build_poc_port_preflight",
@@ -381,6 +382,68 @@ def test_local_or_unknown_docker_endpoint_keeps_local_loopback_port_preflight(mo
     PocEnv._ensure_shared_resources_available(PROJECT_CONFIG, docker_service_config)
 
     assert port_checks == [PROJECT_CONFIG]
+
+
+@pytest.mark.parametrize("lookup_stage", ["show", "inspect"])
+@pytest.mark.parametrize("lookup_result", ["nonzero", "empty", "os_error", "timeout"])
+def test_context_lookup_failure_rejects_port_conflict_without_consuming_env(
+    tmp_path, monkeypatch, lookup_stage, lookup_result
+):
+    import nvflare.recipe.poc_env as poc_env_module
+    import nvflare.tool.poc.poc_commands as poc_commands
+
+    for name in ("DOCKER_HOST", "DOCKER_CONTEXT", "NVFL_DOCKER_SOCK"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    env = PocEnv(docker_image="nvflare:test")
+    monkeypatch.setattr(env, "_is_poc_workspace_running", lambda workspace: False)
+    monkeypatch.setattr(
+        poc_env_module,
+        "prepare_poc_provision",
+        lambda **kwargs: pytest.fail("a port conflict must be rejected before provisioning"),
+    )
+    monkeypatch.setattr(
+        poc_env_module,
+        "_start_poc",
+        lambda **kwargs: pytest.fail("a port conflict must be rejected before starting services"),
+    )
+    context_calls = []
+
+    def lookup_context(command, **kwargs):
+        context_calls.append(command)
+        assert command[:2] == ["docker", "context"]
+        if command[2] != lookup_stage:
+            assert command == ["docker", "context", "show"]
+            return SimpleNamespace(returncode=0, stdout="default\n")
+        if lookup_result == "os_error":
+            raise OSError("Docker context lookup unavailable")
+        if lookup_result == "timeout":
+            raise subprocess.TimeoutExpired(command, timeout=5)
+        return SimpleNamespace(returncode=1 if lookup_result == "nonzero" else 0, stdout="")
+
+    checked_ports = []
+
+    def check_port(port, host):
+        checked_ports.append((port, host))
+        return (False, "in_use") if port == 8002 else (True, None)
+
+    monkeypatch.setattr(poc_commands.subprocess, "run", lookup_context)
+    monkeypatch.setattr(poc_commands, "_is_local_port_available", check_port)
+
+    # Retrying the same instance must reach preflight again, not the one-shot guard.
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="POC service port preflight failed.*8002"):
+            env.deploy(object())
+        assert env._deployment_started is False
+        assert env._services_may_have_started is False
+        assert not Path(env.poc_workspace).exists()
+
+    expected_calls = [["docker", "context", "show"]]
+    if lookup_stage == "inspect":
+        expected_calls.append(["docker", "context", "inspect", "default", "--format", "{{.Endpoints.docker.Host}}"])
+    assert context_calls == expected_calls * 2
+    assert checked_ports == [(8002, "127.0.0.1"), (8003, "127.0.0.1")] * 2
 
 
 def test_deploy_rejects_existing_docker_participant_name_without_stopping_it(tmp_path, monkeypatch):
@@ -780,6 +843,41 @@ def test_stop_cleanup_removes_only_run_workspace(tmp_path, monkeypatch):
     assert retained_result.read_text() == "keep me"
 
 
+@pytest.mark.parametrize(
+    "workspace_name",
+    [
+        "poc",
+        "poc.recipe-",
+        f"poc.recipe-{'a' * 31}",
+        f"poc.recipe-{'a' * 33}",
+        f"poc.recipe-{'g' * 32}",
+        f"other.recipe-{'a' * 32}",
+        f"nested/poc.recipe-{'a' * 32}",
+    ],
+)
+def test_cleanup_refuses_unmanaged_workspaces(tmp_path, monkeypatch, caplog, workspace_name):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv()
+    workspace = tmp_path / workspace_name
+    workspace.mkdir(parents=True)
+    retained_result = workspace / "result.txt"
+    retained_result.write_text("keep me")
+    env.poc_workspace = str(workspace)
+
+    with pytest.raises(RuntimeError, match="refusing to remove unmanaged POC workspace"):
+        env._remove_recipe_workspace()
+    with pytest.raises(RuntimeError, match="refusing to clean unmanaged POC workspace"):
+        env._clean_up_failed_deployment()
+
+    monkeypatch.setattr(env, "_check_poc_running", lambda: False)
+    env.stop(clean_up=True)
+
+    assert retained_result.read_text() == "keep me"
+    assert "refusing to remove unmanaged POC workspace" in caplog.text
+
+
 def test_wait_for_services_ready_rejects_an_exited_client(monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
@@ -884,6 +982,72 @@ def test_remove_docker_network_uses_selected_daemon_and_clears_identity(monkeypa
     assert calls[0][0][0] == ["docker", "network", "rm", "nvflare-recipe-run"]
     assert calls[0][1]["env"] is docker_env
     assert env._docker_network_name is None
+
+
+@pytest.mark.parametrize("initially_running", [False, True])
+@pytest.mark.parametrize("failure", ["active_endpoints", "daemon_error", "os_error", "timeout"])
+def test_stop_preserves_workspace_on_network_failure_and_can_retry(
+    tmp_path, monkeypatch, caplog, initially_running, failure
+):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
+    env = PocEnv(docker_image="nvflare:test")
+    workspace = Path(env.poc_workspace)
+    workspace.mkdir()
+    retained_result = workspace / "result.txt"
+    retained_result.write_text("keep me")
+    env._docker_network_name = "nvflare-recipe-run"
+    env._services_may_have_started = True
+    env._session_manager = object()
+    running = {"value": initially_running}
+    stop_calls = []
+    monkeypatch.setattr(env, "_check_poc_running", lambda: running["value"])
+    monkeypatch.setattr(env, "_running_services", lambda *args: ["server"] if running["value"] else [])
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}),
+    )
+
+    def stop(**kwargs):
+        stop_calls.append(kwargs)
+        running["value"] = False
+
+    monkeypatch.setattr(poc_env_module, "_stop_poc", stop)
+    # Exercise network removal itself; other Docker environment probes are unrelated here.
+    monkeypatch.setattr(poc_env_module, "_docker_cli_env", lambda: {})
+    network_calls = []
+
+    def remove_network(command, **kwargs):
+        network_calls.append(command)
+        assert command == ["docker", "network", "rm", "nvflare-recipe-run"]
+        if len(network_calls) == 1:
+            if failure == "os_error":
+                raise OSError("Docker unavailable")
+            if failure == "timeout":
+                raise subprocess.TimeoutExpired(command, timeout=5)
+            message = "network has active endpoints" if failure == "active_endpoints" else "Docker daemon unavailable"
+            return SimpleNamespace(returncode=1, stdout="", stderr=message)
+        return SimpleNamespace(returncode=0, stdout="nvflare-recipe-run\n", stderr="")
+
+    monkeypatch.setattr(poc_env_module.subprocess, "run", remove_network)
+    env.stop(clean_up=True)
+
+    assert retained_result.read_text() == "keep me"
+    assert env._docker_network_name == "nvflare-recipe-run"
+    assert env._services_may_have_started is True
+    assert env._session_manager is None
+    assert f"preserving workspace {workspace}" in caplog.text
+    assert "retry PocEnv.stop(clean_up=True)" in caplog.text
+
+    env.stop(clean_up=True)
+
+    assert not workspace.exists()
+    assert env._docker_network_name is None
+    assert env._services_may_have_started is False
+    assert len(network_calls) == 2
+    assert len(stop_calls) == int(initially_running)
 
 
 @patch("nvflare.recipe.poc_env.get_poc_workspace")

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pwd
 import subprocess
 import tempfile
 import threading
@@ -23,7 +22,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.recipe.poc_env import PocEnv, _recipe_runtime_lock_paths
+from nvflare.recipe.poc_env import PocEnv, _host_user_runtime_dir, _recipe_runtime_lock_path
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
 PROJECT_CONFIG = {"name": "poc"}
@@ -37,7 +36,6 @@ def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
 
     lock_path = str(tmp_path / "recipe-poc.lock")
     monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: lock_path)
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [lock_path])
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -77,65 +75,109 @@ def test_poc_env_initialization():
 
 
 def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_path, monkeypatch):
-    expected = os.path.join(pwd.getpwuid(os.geteuid()).pw_dir, ".nvflare", "recipe-poc-runtime.lock")
+    import nvflare.recipe.poc_env as poc_env_module
+
+    runtime_root = str(tmp_path / "host-runtime")
+    expected = os.path.join(runtime_root, "nvflare-recipe-poc", "runtime.lock")
+    monkeypatch.setattr(poc_env_module, "_host_user_runtime_dir", lambda: runtime_root)
 
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
     monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
-    first_path = _recipe_runtime_lock_paths()[0]
+    first_path = _recipe_runtime_lock_path()
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
     monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
 
     assert first_path == expected
-    assert _recipe_runtime_lock_paths()[0] == expected
+    assert _recipe_runtime_lock_path() == expected
 
 
-def test_recipe_runtime_lock_paths_ignore_environment_home_without_passwd_entry(tmp_path, monkeypatch):
-    effective_uid = os.geteuid()
-    runtime_root = f"/run/user/{effective_uid}"
-    original_isdir = os.path.isdir
-    monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
-    monkeypatch.setattr(os.path, "isdir", lambda path: path == runtime_root or original_isdir(path))
-    monkeypatch.setenv("HOME", str(tmp_path / "container-home-a"))
-    first_paths = _recipe_runtime_lock_paths()
-    monkeypatch.setenv("HOME", str(tmp_path / "container-home-b"))
-    second_paths = _recipe_runtime_lock_paths()
-
-    assert first_paths == second_paths
-    assert os.path.join(runtime_root, "nvflare", "recipe-poc-runtime.lock") in first_paths
-    assert all(str(tmp_path / "container-home") not in path for path in first_paths)
-
-
-def test_runtime_lock_falls_back_when_preferred_home_is_not_writable(tmp_path, monkeypatch):
+def test_host_user_runtime_dir_is_uid_based_and_ignores_process_environment(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
-    preferred = str(tmp_path / "read-only-home" / ".nvflare" / "recipe-poc-runtime.lock")
-    fallback = str(tmp_path / "writable-home" / ".nvflare" / "recipe-poc-runtime.lock")
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [preferred, fallback])
-    original_open = os.open
+    effective_uid = os.geteuid()
+    shared_root = tmp_path / "tmp"
+    shared_root.mkdir(mode=0o1777)
+    shared_root.chmod(0o1777)
+    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
+    first_path = _host_user_runtime_dir()
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
+    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
+    second_path = _host_user_runtime_dir()
 
-    def open_lock(path, flags, mode=0o777):
-        if path == preferred:
-            raise PermissionError("preferred home is read-only")
-        return original_open(path, flags, mode)
+    assert first_path == second_path
+    assert Path(first_path).parent == shared_root
+    assert Path(first_path).name.startswith(f".nvflare-recipe-poc-{effective_uid}-")
 
-    monkeypatch.setattr(poc_env_module.os, "open", open_lock)
+
+def test_host_user_runtime_dir_bootstraps_private_uid_directory_without_os_runtime(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    effective_uid = os.geteuid()
+    home = tmp_path / "writable-home"
+    home.mkdir(mode=0o700)
+    shared_root = tmp_path / "tmp"
+    shared_root.mkdir(mode=0o1777)
+    shared_root.chmod(0o1777)
+    symlink_target = tmp_path / "attacker-target"
+    symlink_target.mkdir()
+    attacker_path = shared_root / f".nvflare-recipe-poc-{effective_uid}-precreated"
+    attacker_path.symlink_to(symlink_target, target_is_directory=True)
+    attacker_file = shared_root / f".nvflare-recipe-poc-{effective_uid}-precreated-file"
+    attacker_file.write_text("not a runtime directory")
+    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
+    monkeypatch.setenv("HOME", str(home))
+    first_path = _host_user_runtime_dir()
+    monkeypatch.setenv("HOME", str(tmp_path / "different-home"))
+    second_path = _host_user_runtime_dir()
+
+    assert first_path == second_path
+    assert Path(first_path).parent == shared_root
+    assert Path(first_path).name.startswith(f".nvflare-recipe-poc-{effective_uid}-")
+    assert Path(first_path) != attacker_path
+    assert Path(first_path) != attacker_file
+    assert Path(first_path).stat().st_mode & 0o777 == 0o700
+
+
+def test_host_user_runtime_dir_rejects_nonsticky_shared_root(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    shared_root = tmp_path / "unsafe-tmp"
+    shared_root.mkdir(mode=0o777)
+    shared_root.chmod(0o777)
+    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
+
+    with pytest.raises(RuntimeError, match="Refusing to bootstrap"):
+        _host_user_runtime_dir()
+
+
+def test_runtime_lock_normalizes_owned_lock_directory(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    lock_dir = tmp_path / "nvflare-recipe-poc"
+    lock_dir.mkdir(mode=0o775)
+    lock_dir.chmod(0o775)
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(lock_dir / "runtime.lock"))
     env = PocEnv()
-
     env._acquire_runtime_lock()
 
-    assert env._runtime_lock_path == fallback
+    assert lock_dir.stat().st_mode & 0o777 == 0o700
     env._release_runtime_lock()
 
 
 def test_runtime_lock_rejects_unsafe_lock_directory(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
-    unsafe_dir = tmp_path / "unsafe-lock-dir"
-    unsafe_dir.mkdir(mode=0o777)
-    unsafe_dir.chmod(0o777)
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [str(unsafe_dir / "recipe.lock")])
+    target_dir = tmp_path / "target-lock-dir"
+    target_dir.mkdir()
+    unsafe_dir = tmp_path / "symlinked-lock-dir"
+    unsafe_dir.symlink_to(target_dir, target_is_directory=True)
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(unsafe_dir / "runtime.lock"))
     env = PocEnv()
 
     with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock directory"):
@@ -180,6 +222,62 @@ def test_runtime_workspace_record_requires_lock():
         env._record_runtime_workspace()
 
 
+def test_deploy_records_workspace_after_provisioning_and_before_start(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    observed_records = {}
+
+    def prepare(**kwargs):
+        observed_records["during_provisioning"] = lock_path.read_text()
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
+
+    def start(**kwargs):
+        observed_records["at_start"] = lock_path.read_text()
+
+    monkeypatch.setattr(poc_env_module, "_start_poc", start)
+
+    assert env.deploy(object()) == "job-id"
+    assert observed_records == {
+        "during_provisioning": "",
+        "at_start": os.path.abspath(env.poc_workspace),
+    }
+    env.stop(clean_up=False)
+
+
+def test_stop_clears_runtime_record_before_removing_workspace(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv()
+    _configure_successful_deploy(monkeypatch, env)
+    assert env.deploy(object()) == "job-id"
+    monkeypatch.setattr(env, "_check_poc_running", lambda: True)
+    monkeypatch.setattr(env, "_running_services", lambda *args, **kwargs: [])
+    monkeypatch.setattr(poc_env_module, "is_poc_running", lambda *args, **kwargs: True)
+    monkeypatch.setattr(poc_env_module, "_stop_poc", lambda **kwargs: None)
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    original_remove = env._remove_recipe_workspace
+    record_at_removal = []
+
+    def remove_workspace():
+        record_at_removal.append(lock_path.read_text())
+        original_remove()
+
+    monkeypatch.setattr(env, "_remove_recipe_workspace", remove_workspace)
+
+    env.stop(clean_up=True)
+
+    assert record_at_removal == [""]
+    assert not os.path.exists(env.poc_workspace)
+
+
 def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
@@ -219,6 +317,7 @@ def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypa
     active_workspaces.clear()
 
     def prepare(**kwargs):
+        assert lock_path.read_text() == ""
         provisioned_workspaces.append(kwargs["workspace"])
         Path(kwargs["workspace"]).mkdir(parents=True)
 
@@ -487,13 +586,14 @@ def test_deploy_rejects_running_configured_cli_workspace(tmp_path, monkeypatch):
     assert env._runtime_lock_file is None
 
 
-def test_deploy_rejects_another_active_recipe_environment(tmp_path, monkeypatch):
+def test_deploy_rejects_active_recipe_environment_with_different_workspace_root(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
-    configured_workspace = tmp_path / "poc"
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    configured_workspaces = iter((tmp_path / "poc-a", tmp_path / "poc-b"))
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(next(configured_workspaces)))
     first = PocEnv()
     second = PocEnv()
+    assert first._poc_workspace_root != second._poc_workspace_root
     provisioned_workspaces = []
 
     def prepare(**kwargs):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -22,20 +22,11 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.recipe.poc_env import PocEnv, _host_user_runtime_dir, _recipe_runtime_lock_path
+from nvflare.recipe.poc_env import PocEnv
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
 PROJECT_CONFIG = {"name": "poc"}
 SERVICE_CONFIG = {SC.FLARE_SERVER: "server", SC.FLARE_CLIENTS: ["site-1"]}
-
-
-@pytest.fixture(autouse=True)
-def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
-    """Keep process-held Recipe POC locks independent across unit tests."""
-    import nvflare.recipe.poc_env as poc_env_module
-
-    lock_path = str(tmp_path / "recipe-poc.lock")
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: lock_path)
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -72,329 +63,6 @@ def test_poc_env_initialization():
     assert env.gpu_ids == []
     assert env.study == "default"
     assert env.poc_workspace.startswith(f"{env._poc_workspace_root}.recipe-")
-
-
-def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    runtime_root = str(tmp_path / "host-runtime")
-    expected = os.path.join(runtime_root, "nvflare-recipe-poc", "runtime.lock")
-    monkeypatch.setattr(poc_env_module, "_host_user_runtime_dir", lambda: runtime_root)
-
-    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
-    monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
-    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
-    first_path = _recipe_runtime_lock_path()
-    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
-    monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
-    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
-
-    assert first_path == expected
-    assert _recipe_runtime_lock_path() == expected
-
-
-def test_host_user_runtime_dir_is_uid_based_and_ignores_process_environment(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    effective_uid = os.geteuid()
-    shared_root = tmp_path / "tmp"
-    shared_root.mkdir(mode=0o1777)
-    shared_root.chmod(0o1777)
-    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
-    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
-    monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
-    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
-    first_path = _host_user_runtime_dir()
-    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
-    monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
-    monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
-    second_path = _host_user_runtime_dir()
-
-    assert first_path == second_path
-    assert Path(first_path).parent == shared_root
-    assert Path(first_path).name.startswith(f".nvflare-recipe-poc-{effective_uid}-")
-
-
-def test_host_user_runtime_dir_bootstraps_private_uid_directory_without_os_runtime(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    effective_uid = os.geteuid()
-    home = tmp_path / "writable-home"
-    home.mkdir(mode=0o700)
-    shared_root = tmp_path / "tmp"
-    shared_root.mkdir(mode=0o1777)
-    shared_root.chmod(0o1777)
-    symlink_target = tmp_path / "attacker-target"
-    symlink_target.mkdir()
-    attacker_path = shared_root / f".nvflare-recipe-poc-{effective_uid}-precreated"
-    attacker_path.symlink_to(symlink_target, target_is_directory=True)
-    attacker_file = shared_root / f".nvflare-recipe-poc-{effective_uid}-precreated-file"
-    attacker_file.write_text("not a runtime directory")
-    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
-    monkeypatch.setenv("HOME", str(home))
-    first_path = _host_user_runtime_dir()
-    monkeypatch.setenv("HOME", str(tmp_path / "different-home"))
-    second_path = _host_user_runtime_dir()
-
-    assert first_path == second_path
-    assert Path(first_path).parent == shared_root
-    assert Path(first_path).name.startswith(f".nvflare-recipe-poc-{effective_uid}-")
-    assert Path(first_path) != attacker_path
-    assert Path(first_path) != attacker_file
-    assert Path(first_path).stat().st_mode & 0o777 == 0o700
-
-
-def test_host_user_runtime_dir_rejects_nonsticky_shared_root(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    shared_root = tmp_path / "unsafe-tmp"
-    shared_root.mkdir(mode=0o777)
-    shared_root.chmod(0o777)
-    monkeypatch.setattr(poc_env_module, "_SHARED_RUNTIME_ROOT", str(shared_root))
-
-    with pytest.raises(RuntimeError, match="Refusing to bootstrap"):
-        _host_user_runtime_dir()
-
-
-def test_runtime_lock_normalizes_owned_lock_directory(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    lock_dir = tmp_path / "nvflare-recipe-poc"
-    lock_dir.mkdir(mode=0o775)
-    lock_dir.chmod(0o775)
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(lock_dir / "runtime.lock"))
-    env = PocEnv()
-    env._acquire_runtime_lock()
-
-    assert lock_dir.stat().st_mode & 0o777 == 0o700
-    env._release_runtime_lock()
-
-
-def test_runtime_lock_rejects_unsafe_lock_directory(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    target_dir = tmp_path / "target-lock-dir"
-    target_dir.mkdir()
-    unsafe_dir = tmp_path / "symlinked-lock-dir"
-    unsafe_dir.symlink_to(target_dir, target_is_directory=True)
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(unsafe_dir / "runtime.lock"))
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock directory"):
-        env._acquire_runtime_lock()
-
-    assert env._runtime_lock_file is None
-
-
-def test_runtime_lock_rejects_unsafe_lock_file(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    env = PocEnv()
-    monkeypatch.setattr(poc_env_module.stat, "S_ISREG", lambda mode: False)
-
-    with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock"):
-        env._acquire_runtime_lock()
-
-    assert env._runtime_lock_file is None
-
-
-def test_runtime_lock_propagates_unexpected_lock_error(monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    env = PocEnv()
-    monkeypatch.setattr(
-        poc_env_module.fcntl,
-        "flock",
-        lambda fd, operation: (_ for _ in ()).throw(OSError("lock failed")),
-    )
-
-    with pytest.raises(OSError, match="lock failed"):
-        env._acquire_runtime_lock()
-
-    assert env._runtime_lock_file is None
-    env._release_runtime_lock()
-
-
-def test_runtime_workspace_record_requires_lock():
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="runtime lock is not held"):
-        env._record_runtime_workspace()
-
-
-def test_deploy_records_workspace_after_provisioning_and_before_start(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    configured_workspace = tmp_path / "poc"
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
-    env = PocEnv()
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
-    observed_records = {}
-
-    def prepare(**kwargs):
-        observed_records["during_provisioning"] = lock_path.read_text()
-        Path(kwargs["workspace"]).mkdir(parents=True)
-
-    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
-
-    def start(**kwargs):
-        observed_records["at_start"] = lock_path.read_text()
-
-    monkeypatch.setattr(poc_env_module, "_start_poc", start)
-
-    assert env.deploy(object()) == "job-id"
-    assert observed_records == {
-        "during_provisioning": "",
-        "at_start": os.path.abspath(env.poc_workspace),
-    }
-    env.stop(clean_up=False)
-
-
-def test_stop_clears_runtime_record_before_removing_workspace(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    configured_workspace = tmp_path / "poc"
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
-    env = PocEnv()
-    _configure_successful_deploy(monkeypatch, env)
-    assert env.deploy(object()) == "job-id"
-    monkeypatch.setattr(env, "_check_poc_running", lambda: True)
-    monkeypatch.setattr(env, "_running_services", lambda *args, **kwargs: [])
-    monkeypatch.setattr(poc_env_module, "is_poc_running", lambda *args, **kwargs: True)
-    monkeypatch.setattr(poc_env_module, "_stop_poc", lambda **kwargs: None)
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
-    original_remove = env._remove_recipe_workspace
-    record_at_removal = []
-
-    def remove_workspace():
-        record_at_removal.append(lock_path.read_text())
-        original_remove()
-
-    monkeypatch.setattr(env, "_remove_recipe_workspace", remove_workspace)
-
-    env.stop(clean_up=True)
-
-    assert record_at_removal == [""]
-    assert not os.path.exists(env.poc_workspace)
-
-
-def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    configured_workspace = tmp_path / "current-poc"
-    prior_workspace = tmp_path / f"prior-poc.recipe-{'a' * 32}"
-    prior_workspace.mkdir()
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
-    lock_path.write_text(str(prior_workspace))
-    provisioned_workspaces = []
-    active_workspaces = {str(prior_workspace)}
-
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: (PROJECT_CONFIG, SERVICE_CONFIG))
-    monkeypatch.setattr(
-        PocEnv,
-        "_running_services",
-        staticmethod(
-            lambda project_config, service_config, workspace: ["server"] if workspace in active_workspaces else []
-        ),
-    )
-    monkeypatch.setattr(
-        poc_env_module,
-        "prepare_poc_provision",
-        lambda **kwargs: provisioned_workspaces.append(kwargs["workspace"]),
-    )
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="prior Recipe PocEnv deployment is still active") as exc_info:
-        env.deploy(object())
-
-    assert str(prior_workspace) in str(exc_info.value)
-    assert provisioned_workspaces == []
-    assert lock_path.read_text() == str(prior_workspace)
-    assert env._runtime_lock_file is None
-
-    active_workspaces.clear()
-
-    def prepare(**kwargs):
-        assert lock_path.read_text() == ""
-        provisioned_workspaces.append(kwargs["workspace"])
-        Path(kwargs["workspace"]).mkdir(parents=True)
-
-    _configure_successful_deploy(monkeypatch, env, prepare=prepare)
-    assert env.deploy(object()) == "job-id"
-    assert lock_path.read_text() == os.path.abspath(env.poc_workspace)
-    env.stop(clean_up=False)
-    assert lock_path.read_text() == ""
-
-
-def test_deploy_fails_closed_when_prior_runtime_workspace_is_unreadable(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    configured_workspace = tmp_path / "current-poc"
-    missing_prior_workspace = tmp_path / f"missing-poc.recipe-{'b' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
-    lock_path.write_text(str(missing_prior_workspace))
-    provision_calls = []
-
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(
-        poc_env_module,
-        "setup_service_config",
-        lambda path: (_ for _ in ()).throw(ValueError("project configuration is unavailable")),
-    )
-    monkeypatch.setattr(
-        poc_env_module,
-        "prepare_poc_provision",
-        lambda **kwargs: provision_calls.append(kwargs),
-    )
-    env = PocEnv()
-
-    with pytest.raises(RuntimeError, match="Could not determine service state") as exc_info:
-        env.deploy(object())
-
-    assert str(missing_prior_workspace) in str(exc_info.value)
-    assert str(lock_path) in str(exc_info.value)
-    assert provision_calls == []
-    assert lock_path.read_text() == str(missing_prior_workspace)
-    assert env._runtime_lock_file is None
-
-
-def test_deploy_fails_closed_when_prior_runtime_service_state_is_unreadable(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    configured_workspace = tmp_path / "current-poc"
-    prior_workspace = tmp_path / f"prior-poc.recipe-{'c' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
-    lock_path.write_text(str(prior_workspace))
-    provision_calls = []
-
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
-    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
-    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: (object(), object()))
-    monkeypatch.setattr(
-        poc_env_module,
-        "prepare_poc_provision",
-        lambda **kwargs: provision_calls.append(kwargs),
-    )
-    env = PocEnv()
-    monkeypatch.setattr(
-        env,
-        "_running_services",
-        lambda project_config, service_config, workspace: (_ for _ in ()).throw(
-            ValueError("service configuration is unusable")
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="Could not determine service state") as exc_info:
-        env.deploy(object())
-
-    assert str(prior_workspace) in str(exc_info.value)
-    assert str(lock_path) in str(exc_info.value)
-    assert provision_calls == []
-    assert lock_path.read_text() == str(prior_workspace)
-    assert env._runtime_lock_file is None
 
 
 def test_deploy_rejects_overlapping_calls_on_same_environment():
@@ -583,39 +251,91 @@ def test_deploy_rejects_running_configured_cli_workspace(tmp_path, monkeypatch):
     assert provision_calls == []
     assert retained_result.read_text() == "keep me"
     assert not os.path.exists(env.poc_workspace)
-    assert env._runtime_lock_file is None
 
 
-def test_deploy_rejects_active_recipe_environment_with_different_workspace_root(tmp_path, monkeypatch):
+def test_deploy_rejects_unavailable_shared_port_before_start(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
+    import nvflare.tool.poc.poc_commands as poc_commands
 
-    configured_workspaces = iter((tmp_path / "poc-a", tmp_path / "poc-b"))
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(next(configured_workspaces)))
-    first = PocEnv()
-    second = PocEnv()
-    assert first._poc_workspace_root != second._poc_workspace_root
+    configured_workspace = tmp_path / "poc"
+    project_config = {
+        "name": "poc",
+        "participants": [
+            {
+                "name": "server",
+                "type": "server",
+                "fed_learn_port": 18002,
+                "admin_port": 18003,
+            }
+        ],
+    }
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
     provisioned_workspaces = []
+    start_calls = []
+    checked_ports = []
 
     def prepare(**kwargs):
         provisioned_workspaces.append(kwargs["workspace"])
         Path(kwargs["workspace"]).mkdir(parents=True)
 
-    _configure_successful_deploy(monkeypatch, first, prepare=prepare)
-    assert first.deploy(object()) == "job-id"
-    held_lock = first._runtime_lock_file
-    first._acquire_runtime_lock()
-    assert first._runtime_lock_file is held_lock
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
+    monkeypatch.setattr(poc_env_module, "setup_service_config", lambda path: (project_config, SERVICE_CONFIG))
 
-    _configure_successful_deploy(monkeypatch, second, prepare=prepare)
-    with pytest.raises(RuntimeError, match="Another Recipe PocEnv deployment is active"):
-        second.deploy(object())
+    def check_port(port, host):
+        checked_ports.append((port, host))
+        return (False, "in_use") if port == 18002 else (True, None)
 
-    assert provisioned_workspaces == [first.poc_workspace]
+    monkeypatch.setattr(poc_commands, "_is_local_port_available", check_port)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: start_calls.append(kwargs))
+    env = PocEnv()
 
-    first.stop(clean_up=False)
-    assert second.deploy(object()) == "job-id"
-    assert provisioned_workspaces == [first.poc_workspace, second.poc_workspace]
-    second.stop(clean_up=False)
+    with pytest.raises(RuntimeError, match="POC service port preflight failed") as exc_info:
+        env.deploy(object())
+
+    assert "18002" in str(exc_info.value)
+    assert checked_ports == [(18002, "127.0.0.1"), (18003, "127.0.0.1")]
+    assert provisioned_workspaces == [env.poc_workspace]
+    assert start_calls == []
+    assert not os.path.exists(env.poc_workspace)
+
+
+def test_deploy_rejects_existing_docker_participant_name_without_stopping_it(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    docker_service_config = {**SERVICE_CONFIG, SC.IS_DOCKER_RUN: True}
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    env = PocEnv(docker_image="nvflare:test")
+    start_calls = []
+    stop_calls = []
+
+    def prepare(**kwargs):
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
+    monkeypatch.setattr(
+        poc_env_module,
+        "setup_service_config",
+        lambda path: (PROJECT_CONFIG, docker_service_config),
+    )
+    monkeypatch.setattr(poc_env_module, "_build_poc_port_preflight", lambda project_config: {"conflicts": []})
+    monkeypatch.setattr(
+        PocEnv,
+        "_get_docker_service_state",
+        staticmethod(lambda service_name: False if service_name == "server" else None),
+    )
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: start_calls.append(kwargs))
+    monkeypatch.setattr(poc_env_module, "_stop_poc", lambda **kwargs: stop_calls.append(kwargs))
+
+    with pytest.raises(RuntimeError, match=r"container name\(s\) already exist") as exc_info:
+        env.deploy(object())
+
+    assert "server" in str(exc_info.value)
+    assert start_calls == []
+    assert stop_calls == []
+    assert not os.path.exists(env.poc_workspace)
 
 
 def test_deploy_does_not_modify_configured_cli_workspace(tmp_path, monkeypatch):
@@ -765,40 +485,40 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
     assert stop_args == [True]
 
 
-def test_deploy_preserves_workspace_and_lock_when_metadata_is_lost_after_start(tmp_path, monkeypatch):
+def test_deploy_preserves_workspace_when_metadata_is_lost_after_start(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
     configured_workspace = tmp_path / "poc"
     monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
     monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+    startup_attempted = False
 
     def prepare(**kwargs):
         Path(kwargs["workspace"]).mkdir(parents=True)
 
     def setup(workspace):
-        if workspace == str(configured_workspace):
+        if workspace == str(configured_workspace) or not startup_attempted:
             return PROJECT_CONFIG, SERVICE_CONFIG
         raise RuntimeError("service configuration unavailable after startup")
 
+    def start(**kwargs):
+        nonlocal startup_attempted
+        startup_attempted = True
+        raise RuntimeError("start failed after losing service configuration")
+
     monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
-    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(poc_env_module, "_start_poc", start)
     monkeypatch.setattr(poc_env_module, "setup_service_config", setup)
     monkeypatch.setattr(PocEnv, "_running_services", staticmethod(lambda *args: []))
     env = PocEnv()
     run_workspace = env.poc_workspace
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
 
-    try:
-        with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:
-            env.deploy(object())
+    with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:
+        env.deploy(object())
 
-        assert "service configuration unavailable after startup" in str(exc_info.value)
-        assert "Could not determine service state" in str(exc_info.value.__cause__)
-        assert Path(run_workspace).is_dir()
-        assert env._runtime_lock_file is not None
-        assert lock_path.read_text() == os.path.abspath(run_workspace)
-    finally:
-        env._release_runtime_lock()
+    assert "service configuration unavailable after startup" in str(exc_info.value)
+    assert "Could not determine service state" in str(exc_info.value.__cause__)
+    assert Path(run_workspace).is_dir()
 
 
 @pytest.mark.parametrize("interruption", [KeyboardInterrupt(), SystemExit(2)])

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pwd
 import subprocess
 import tempfile
 import threading
@@ -74,16 +75,33 @@ def test_poc_env_initialization():
 
 
 def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_path, monkeypatch):
-    expected = os.path.join(os.path.realpath("/tmp"), f".nvflare-recipe-poc-{os.geteuid()}.lock")
+    expected = os.path.join(pwd.getpwuid(os.geteuid()).pw_dir, ".nvflare", "recipe-poc-runtime.lock")
 
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
     first_path = _recipe_runtime_lock_path()
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
 
     assert first_path == expected
     assert _recipe_runtime_lock_path() == expected
+
+
+def test_runtime_lock_rejects_unsafe_lock_directory(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    unsafe_dir = tmp_path / "unsafe-lock-dir"
+    unsafe_dir.mkdir(mode=0o777)
+    unsafe_dir.chmod(0o777)
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(unsafe_dir / "recipe.lock"))
+    env = PocEnv()
+
+    with pytest.raises(RuntimeError, match="unsafe Recipe POC runtime lock directory"):
+        env._acquire_runtime_lock()
+
+    assert env._runtime_lock_file is None
 
 
 def test_runtime_lock_rejects_unsafe_lock_file(tmp_path, monkeypatch):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nvflare.recipe.poc_env import PocEnv, _recipe_runtime_lock_path
+from nvflare.recipe.poc_env import PocEnv, _recipe_runtime_lock_paths
 from nvflare.tool.poc.service_constants import FlareServiceConstants as SC
 
 PROJECT_CONFIG = {"name": "poc"}
@@ -37,6 +37,7 @@ def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
 
     lock_path = str(tmp_path / "recipe-poc.lock")
     monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: lock_path)
+    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_paths", lambda: [lock_path])
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -81,20 +82,29 @@ def test_recipe_runtime_lock_path_is_independent_of_process_configuration(tmp_pa
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
     monkeypatch.setenv("HOME", str(tmp_path / "home-a"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-a"))
-    first_path = _recipe_runtime_lock_path()
+    first_path = _recipe_runtime_lock_paths()[0]
     monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
     monkeypatch.setenv("HOME", str(tmp_path / "home-b"))
     monkeypatch.setenv("NVFLARE_POC_WORKSPACE", str(tmp_path / "workspace-b"))
 
     assert first_path == expected
-    assert _recipe_runtime_lock_path() == expected
+    assert _recipe_runtime_lock_paths()[0] == expected
 
 
-def test_recipe_runtime_lock_path_uses_environment_home_without_passwd_entry(tmp_path, monkeypatch):
+def test_recipe_runtime_lock_paths_ignore_environment_home_without_passwd_entry(tmp_path, monkeypatch):
+    effective_uid = os.geteuid()
+    runtime_root = f"/run/user/{effective_uid}"
+    original_isdir = os.path.isdir
     monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
-    monkeypatch.setenv("HOME", str(tmp_path / "container-home"))
+    monkeypatch.setattr(os.path, "isdir", lambda path: path == runtime_root or original_isdir(path))
+    monkeypatch.setenv("HOME", str(tmp_path / "container-home-a"))
+    first_paths = _recipe_runtime_lock_paths()
+    monkeypatch.setenv("HOME", str(tmp_path / "container-home-b"))
+    second_paths = _recipe_runtime_lock_paths()
 
-    assert _recipe_runtime_lock_path() == str(tmp_path / "container-home" / ".nvflare" / "recipe-poc-runtime.lock")
+    assert first_paths == second_paths
+    assert os.path.join(runtime_root, "nvflare", "recipe-poc-runtime.lock") in first_paths
+    assert all(str(tmp_path / "container-home") not in path for path in first_paths)
 
 
 def test_runtime_lock_falls_back_when_preferred_home_is_not_writable(tmp_path, monkeypatch):

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -34,7 +34,9 @@ def _isolated_recipe_runtime_lock(tmp_path, monkeypatch):
     """Keep process-held Recipe POC locks independent across unit tests."""
     import nvflare.recipe.poc_env as poc_env_module
 
-    monkeypatch.setattr(poc_env_module, "_recipe_runtime_lock_path", lambda: str(tmp_path / "recipe-poc.lock"))
+    monkeypatch.setattr(
+        poc_env_module, "_recipe_runtime_lock_path", lambda _workspace_root: str(tmp_path / "recipe-poc.lock")
+    )
 
 
 def _configure_successful_deploy(monkeypatch, env, prepare=None, submit=None):
@@ -73,10 +75,16 @@ def test_poc_env_initialization():
     assert env.poc_workspace.startswith(f"{env._poc_workspace_root}.recipe-")
 
 
-def test_recipe_runtime_lock_path_is_host_and_user_scoped():
-    assert _recipe_runtime_lock_path() == os.path.join(
-        tempfile.gettempdir(), f".nvflare-recipe-poc-{os.geteuid()}.lock"
-    )
+def test_recipe_runtime_lock_path_is_independent_of_process_temp_dir(tmp_path, monkeypatch):
+    configured_workspace = tmp_path / "shared" / "poc"
+    expected = f"{configured_workspace}.recipe-{os.geteuid()}.lock"
+
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-a"))
+    first_path = _recipe_runtime_lock_path(str(configured_workspace))
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "process-b"))
+
+    assert first_path == expected
+    assert _recipe_runtime_lock_path(str(configured_workspace)) == expected
 
 
 def test_runtime_lock_rejects_unsafe_lock_file(tmp_path, monkeypatch):
@@ -121,7 +129,7 @@ def test_deploy_rejects_services_left_by_prior_recipe_process(tmp_path, monkeypa
     configured_workspace = tmp_path / "current-poc"
     prior_workspace = tmp_path / f"prior-poc.recipe-{'a' * 32}"
     prior_workspace.mkdir()
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
     lock_path.write_text(str(prior_workspace))
     provisioned_workspaces = []
     active_workspaces = {str(prior_workspace)}
@@ -169,7 +177,7 @@ def test_deploy_fails_closed_when_prior_runtime_workspace_is_unreadable(tmp_path
 
     configured_workspace = tmp_path / "current-poc"
     missing_prior_workspace = tmp_path / f"missing-poc.recipe-{'b' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
     lock_path.write_text(str(missing_prior_workspace))
     provision_calls = []
 
@@ -202,7 +210,7 @@ def test_deploy_fails_closed_when_prior_runtime_service_state_is_unreadable(tmp_
 
     configured_workspace = tmp_path / "current-poc"
     prior_workspace = tmp_path / f"prior-poc.recipe-{'c' * 32}"
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
     lock_path.write_text(str(prior_workspace))
     provision_calls = []
 
@@ -584,7 +592,8 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
         raise RuntimeError("submission failed")
 
     _configure_successful_deploy(monkeypatch, env, prepare=prepare, submit=fail_submission)
-    monkeypatch.setattr(env, "stop", lambda clean_up: None)
+    stop_args = []
+    monkeypatch.setattr(env, "_stop", lambda clean_up: stop_args.append(clean_up))
     monkeypatch.setattr(env, "_check_poc_running", lambda: True)
     run_workspace = env.poc_workspace
 
@@ -596,6 +605,7 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
     assert "remove this workspace manually" in str(exc_info.value)
     assert "POC services remain running" in str(exc_info.value.__cause__)
     assert os.path.isdir(run_workspace)
+    assert stop_args == [True]
 
 
 def test_deploy_preserves_workspace_and_lock_when_metadata_is_lost_after_start(tmp_path, monkeypatch):
@@ -619,7 +629,7 @@ def test_deploy_preserves_workspace_and_lock_when_metadata_is_lost_after_start(t
     monkeypatch.setattr(PocEnv, "_running_services", staticmethod(lambda *args: []))
     env = PocEnv()
     run_workspace = env.poc_workspace
-    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path(str(configured_workspace)))
 
     try:
         with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:

--- a/tests/unit_test/recipe/poc_env_test.py
+++ b/tests/unit_test/recipe/poc_env_test.py
@@ -521,6 +521,9 @@ def test_failed_provisioning_cleans_only_run_workspace(tmp_path, monkeypatch):
     assert retained_result.read_text() == "keep me"
     assert not os.path.exists(run_workspace)
 
+    with pytest.raises(RuntimeError, match="already been used"):
+        env.deploy(object())
+
 
 @pytest.mark.parametrize("failure_stage", ["start", "readiness", "submission"])
 def test_deploy_failure_cleans_only_run_workspace(tmp_path, monkeypatch, failure_stage):
@@ -595,6 +598,42 @@ def test_deploy_reports_incomplete_failure_cleanup(tmp_path, monkeypatch):
     assert os.path.isdir(run_workspace)
 
 
+def test_deploy_preserves_workspace_and_lock_when_metadata_is_lost_after_start(tmp_path, monkeypatch):
+    import nvflare.recipe.poc_env as poc_env_module
+
+    configured_workspace = tmp_path / "poc"
+    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(configured_workspace))
+    monkeypatch.setattr(poc_env_module, "collect_non_local_scripts", lambda job: [])
+
+    def prepare(**kwargs):
+        Path(kwargs["workspace"]).mkdir(parents=True)
+
+    def setup(workspace):
+        if workspace == str(configured_workspace):
+            return PROJECT_CONFIG, SERVICE_CONFIG
+        raise RuntimeError("service configuration unavailable after startup")
+
+    monkeypatch.setattr(poc_env_module, "prepare_poc_provision", prepare)
+    monkeypatch.setattr(poc_env_module, "_start_poc", lambda **kwargs: None)
+    monkeypatch.setattr(poc_env_module, "setup_service_config", setup)
+    monkeypatch.setattr(PocEnv, "_running_services", staticmethod(lambda *args: []))
+    env = PocEnv()
+    run_workspace = env.poc_workspace
+    lock_path = Path(poc_env_module._recipe_runtime_lock_path())
+
+    try:
+        with pytest.raises(RuntimeError, match="cleanup could not be completed safely") as exc_info:
+            env.deploy(object())
+
+        assert "service configuration unavailable after startup" in str(exc_info.value)
+        assert "Could not determine service state" in str(exc_info.value.__cause__)
+        assert Path(run_workspace).is_dir()
+        assert env._runtime_lock_file is not None
+        assert lock_path.read_text() == os.path.abspath(run_workspace)
+    finally:
+        env._release_runtime_lock()
+
+
 @pytest.mark.parametrize("interruption", [KeyboardInterrupt(), SystemExit(2)])
 def test_cleanup_interruption_is_not_converted_to_runtime_error(tmp_path, monkeypatch, interruption):
     import nvflare.recipe.poc_env as poc_env_module
@@ -635,7 +674,7 @@ def test_new_env_preserves_retained_recipe_workspace(tmp_path, monkeypatch):
     assert retained_result.read_text() == "keep me"
 
 
-def test_reusing_stopped_env_creates_new_workspace_and_preserves_prior_result(tmp_path, monkeypatch):
+def test_reusing_stopped_env_is_rejected_and_preserves_its_workspace(tmp_path, monkeypatch):
     import nvflare.recipe.poc_env as poc_env_module
 
     configured_workspace = tmp_path / "poc"
@@ -650,32 +689,14 @@ def test_reusing_stopped_env_creates_new_workspace_and_preserves_prior_result(tm
     _configure_successful_deploy(monkeypatch, env, prepare=prepare)
 
     assert env.deploy(object()) == "job-id"
-    first_workspace = env.poc_workspace
+    run_workspace = env.poc_workspace
     env.stop(clean_up=False)
-    assert (Path(first_workspace) / "run-result.txt").read_text() == "complete"
 
-    assert env.deploy(object()) == "job-id"
-    second_workspace = env.poc_workspace
-
-    assert second_workspace != first_workspace
-    assert Path(second_workspace).is_dir()
-    assert (Path(first_workspace) / "run-result.txt").read_text() == "complete"
-
-
-def test_redeploy_rejects_running_workspace_without_rotating(tmp_path, monkeypatch):
-    import nvflare.recipe.poc_env as poc_env_module
-
-    monkeypatch.setattr(poc_env_module, "get_poc_workspace", lambda: str(tmp_path / "poc"))
-    env = PocEnv()
-    _configure_successful_deploy(monkeypatch, env)
-    assert env.deploy(object()) == "job-id"
-    active_workspace = env.poc_workspace
-    monkeypatch.setattr(env, "_check_poc_running", lambda: True)
-
-    with pytest.raises(RuntimeError, match="already has a running deployment"):
+    with pytest.raises(RuntimeError, match="already been used"):
         env.deploy(object())
 
-    assert env.poc_workspace == active_workspace
+    assert env.poc_workspace == run_workspace
+    assert (Path(run_workspace) / "run-result.txt").read_text() == "complete"
 
 
 def test_stop_cleanup_removes_only_run_workspace(tmp_path, monkeypatch):
@@ -817,31 +838,33 @@ def test_get_admin_startup_kit_path_not_found(mock_setup, mock_get_prod_dir, moc
 
 @patch("nvflare.recipe.poc_env.setup_service_config")
 @patch("nvflare.recipe.poc_env._stop_poc")
-@patch("nvflare.recipe.poc_env._clean_poc")
+@patch("nvflare.recipe.poc_env.shutil.rmtree")
 @patch("nvflare.recipe.poc_env.is_poc_running")
-def test_stop_poc(mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup):
+def test_stop_poc(mock_is_running, mock_remove_workspace, mock_stop_poc, mock_setup):
     """Test stop and clean POC functionality."""
     mock_setup.return_value = ({"name": "test"}, {SC.FLARE_SERVER: "server"})
     mock_is_running.return_value = True
     env = PocEnv()
 
-    with patch.object(PocEnv, "_running_services", side_effect=[["server"], []]):
-        env.stop(clean_up=True)
+    with patch("nvflare.tool.poc.poc_commands._clean_poc_config") as mock_clean_poc_config:
+        with patch.object(PocEnv, "_running_services", side_effect=[["server"], []]):
+            env.stop(clean_up=True)
 
     mock_stop_poc.assert_called_once_with(
         poc_workspace=env.poc_workspace,
         excluded=["admin@nvidia.com"],
         services_list=[],
     )
-    mock_clean_poc.assert_called_once_with(env.poc_workspace)
+    mock_remove_workspace.assert_called_once_with(env.poc_workspace)
+    mock_clean_poc_config.assert_not_called()
 
 
 @patch("nvflare.recipe.poc_env.setup_service_config")
 @patch("nvflare.recipe.poc_env._stop_poc")
-@patch("nvflare.recipe.poc_env._clean_poc")
+@patch("nvflare.recipe.poc_env.shutil.rmtree")
 @patch("nvflare.recipe.poc_env.is_poc_running")
 def test_stop_preserves_workspace_when_service_state_is_unknown(
-    mock_is_running, mock_clean_poc, mock_stop_poc, mock_setup, caplog
+    mock_is_running, mock_remove_workspace, mock_stop_poc, mock_setup, caplog
 ):
     mock_setup.return_value = ({"name": "test"}, {SC.FLARE_SERVER: "server"})
     mock_is_running.return_value = True
@@ -855,7 +878,7 @@ def test_stop_preserves_workspace_when_service_state_is_unknown(
         env.stop(clean_up=True)
 
     mock_stop_poc.assert_called_once()
-    mock_clean_poc.assert_not_called()
+    mock_remove_workspace.assert_not_called()
     assert "Stop any remaining services and remove it manually" in caplog.text
 
 

--- a/tests/unit_test/tool/deploy/deploy_commands_test.py
+++ b/tests/unit_test/tool/deploy/deploy_commands_test.py
@@ -293,8 +293,9 @@ def test_prepare_docker_client_copies_and_patches_runtime_files(tmp_path, capsys
     script = script_bytes.decode()
     assert "@@NVFLARE_" not in script
     assert "repo/nvflare:dev" in script
-    assert 'NETWORK_NAME="nvflare-test"' in script
-    assert "--network-alias" not in script
+    assert 'NETWORK_NAME=${NVFLARE_POC_NETWORK_NAME:-"nvflare-test"}' in script
+    assert 'NETWORK_ALIAS_ARGS=(--network-alias "$LOGICAL_CONTAINER_NAME")' in script
+    assert "    --network-alias server " not in script
     assert "/var/tmp/nvflare/workspace/startup/sub_start.sh" not in script
     assert "/usr/local/bin/python3" in script
     assert "nvflare.private.fed.app.client.client_train" in script
@@ -343,6 +344,9 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     capsys.readouterr()
 
     script = (output / "startup" / "start_docker.sh").read_text()
+    assert "LOGICAL_CONTAINER_NAME=site-1" in script
+    assert "CONTAINER_NAME=${NVFLARE_POC_CONTAINER_NAME:-$LOGICAL_CONTAINER_NAME}" in script
+    assert 'NETWORK_NAME=${NVFLARE_POC_NETWORK_NAME:-"nvflare-network"}' in script
     assert 'DOCKER_SOCK="${NVFL_DOCKER_SOCK:-/var/run/docker.sock}"' in script
     assert 'DOCKER_ENDPOINT="${DOCKER_HOST:-}"' in script
     assert "docker context inspect" in script
@@ -359,7 +363,7 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     assert "DOCKER_HOST_URI" not in script
     assert 'DOCKER_CLI_ARGS=(--host "unix://$DOCKER_SOCK")' in script
     assert 'if ! docker "${DOCKER_CLI_ARGS[@]}" info' in script
-    assert 'if ! docker "${DOCKER_CLI_ARGS[@]}" network ls' in script
+    assert 'if ! docker "${DOCKER_CLI_ARGS[@]}" network inspect' in script
     assert 'docker "${DOCKER_CLI_ARGS[@]}" network create' in script
     assert 'docker "${DOCKER_CLI_ARGS[@]}" run' in script
     assert (
@@ -377,6 +381,7 @@ def test_prepare_docker_start_script_handles_docker_socket_path_and_groups(tmp_p
     assert "--entrypoint /usr/local/bin/python3" in script
     assert "stat.S_ISSOCK" in script
     assert '--mount "type=bind,src=$DOCKER_SOCK,dst=/var/run/docker.sock"' in script
+    assert '-e NVFL_DOCKER_NETWORK="$NETWORK_NAME"' in script
     assert '-v "$DOCKER_SOCK":/var/run/docker.sock' not in script
     assert "-v /var/run/docker.sock:/var/run/docker.sock" not in script
 
@@ -400,6 +405,8 @@ def test_prepare_docker_start_script_allows_daemon_host_socket_path(tmp_path, ca
     monkeypatch.setenv("DOCKER_HOST", "tcp://dind:2375")
     monkeypatch.setenv("NVFL_DOCKER_SOCK", str(daemon_socket))
     monkeypatch.setenv("NVFL_TEST_REMOTE_SOCK_GID", "2375")
+    monkeypatch.setenv("NVFLARE_POC_CONTAINER_NAME", "nvflare-recipe-site-1")
+    monkeypatch.setenv("NVFLARE_POC_NETWORK_NAME", "nvflare-recipe-network")
 
     result = subprocess.run(
         ["bash", str(output / "startup" / "start_docker.sh")],
@@ -412,10 +419,14 @@ def test_prepare_docker_start_script_allows_daemon_host_socket_path(tmp_path, ca
     assert "Using Docker socket on daemon host" in result.stdout
     calls = docker_log.read_text().splitlines()
     assert calls[0] == "info"
-    assert calls[1].startswith("network ls")
+    assert calls[1] == "network inspect nvflare-recipe-network"
     probe_call = next(call for call in calls if "--entrypoint /usr/local/bin/python3" in call)
     assert f"--mount type=bind,src={daemon_socket},dst=/var/run/docker.sock" in probe_call
     run_call = next(call for call in calls if call.startswith("run --name"))
+    assert run_call.startswith("run --name nvflare-recipe-site-1")
+    assert "--network nvflare-recipe-network" in run_call
+    assert "--network-alias site-1" in run_call
+    assert "-e NVFL_DOCKER_NETWORK=nvflare-recipe-network" in run_call
     assert "--host" not in run_call
     assert "--group-add 2375" in run_call
     assert f"--mount type=bind,src={daemon_socket},dst=/var/run/docker.sock" in run_call
@@ -596,7 +607,9 @@ def test_prepare_docker_server_adds_logical_server_network_alias(tmp_path, capsy
     capsys.readouterr()
 
     script = (output / "startup" / "start_docker.sh").read_text()
-    assert "--name abc.aws.com" in script
+    assert "LOGICAL_CONTAINER_NAME=abc.aws.com" in script
+    assert "CONTAINER_NAME=${NVFLARE_POC_CONTAINER_NAME:-$LOGICAL_CONTAINER_NAME}" in script
+    assert '--name "$CONTAINER_NAME"' in script
     assert "--network-alias server" in script
 
 


### PR DESCRIPTION
## Summary
- provision each `PocEnv` instance's single deployment in a unique Recipe-owned workspace beside the configured reusable CLI POC workspace
- make each `PocEnv` instance one-shot once provisioning begins, while allowing retry after a non-provisioning preflight rejection
- reject overlapping `deploy()` calls on the same instance and serialize `stop()` with deployment startup
- reject Recipe deployment before provisioning when the configured CLI POC has an active server or client
- probe intended server ports before provisioning and recheck the provisioned configuration immediately before startup
- give Docker Recipe deployments unique container and network identities while preserving logical participant aliases and using the same network for spawned job containers
- treat loopback port probes as authoritative for local or unresolved Docker endpoints; verified remote `DOCKER_HOST` and context deployments rely on daemon-side startup/readiness
- remove the host-wide filesystem lock, durable runtime record, shared-workspace backup/restore, and mutable ownership state machine
- remove Recipe-owned workspaces directly without clearing the reusable CLI POC configuration
- keep stop repeatable when service metadata cannot be inspected: attempt shutdown, clear the session manager, and preserve unverified state/workspace
- verify deployment-failure cleanup stopped all services and removed the current run workspace; otherwise preserve it and report its exact path
- update the current 2.10 Recipe documentation and tutorials without modifying the released 2.9 notes

## Why this is simpler and safer
`PocEnv` starts and stops a complete POC deployment for one integrated Recipe run. Sharing the reusable CLI workspace forced Recipe execution to move, back up, restore, and classify ownership of previously retained state. A unique workspace removes that file-state conflict by construction: Recipe provisioning and cleanup affect only the current run directory, while the configured `nvflare poc` workspace and earlier retained Recipe results are not replaced.

For example, when the configured CLI workspace is `/tmp/nvflare/poc`, Recipe execution uses `/tmp/nvflare/poc.recipe-<unique-id>`. `Run.get_result()` keeps its existing default cleanup behavior; callers can pass `clean_up=False` to preserve the run workspace and logs. A later deployment uses a new `PocEnv` instance and therefore a different unique workspace.

Configured server ports remain shared host resources. `PocEnv` checks the intended ports before consuming the one-shot environment, then rechecks the fully provisioned project just before startup. The probe uses `SO_REUSEADDR` to match the actual listeners and avoid rejecting a reusable port solely because prior connections remain in `TIME_WAIT`. For verified remote Docker daemons, local loopback is a different host, so Docker startup and readiness are authoritative. An empty endpoint-discovery result follows the startup script's local-socket default and keeps the local probe enabled.

Docker Recipe deployments no longer reuse participant names as container identities. Each workspace generates unique parent-container and network names, retains logical participant names as network aliases, and passes the selected network into the Docker job launcher. Concurrent deployments therefore cannot observe or stop each other's containers; if they compete for the same published ports, Docker atomically selects a winner and the loser cleans only its own identities and workspace.

This is a prerequisite for the Hello PyTorch example PRs #5244 and #5255.

## Failure behavior
A provisioning failure removes only the current unique workspace because services have not been started. After startup is attempted, cleanup makes one verified attempt to stop the current run and remove its workspace. If service state cannot be established, services remain running, the Docker network cannot be removed, or the directory cannot be removed, `deploy()` reports the original failure, the cleanup failure, and the exact workspace with manual stop/removal guidance.

Public `stop()` remains repeatable when provisioned service metadata is missing or unreadable: it logs the unknown state, still attempts the normal shutdown path, clears the stale session manager, and preserves the workspace and uncertainty flag for a later retry. Deployment-failure cleanup retains its strict post-check and still fails loudly when cleanup cannot be verified.

`PocEnv` is one-shot after provisioning begins. `Run.abort()` aborts the job but does not stop the environment; call `Run.get_result()` or `PocEnv.stop()`, then create a new `PocEnv` before another execution. This 2.10 behavior is documented in the current Recipe API guide rather than modifying the released 2.9 notes.

## Validation
- `python3 -m pytest tests/unit_test/recipe/poc_env_test.py -q` (47 passed)
- `python3 -m pytest tests/unit_test/recipe tests/unit_test/lighter/poc_commands_test.py tests/unit_test/tool/poc tests/unit_test/tool/deploy/deploy_commands_test.py tests/unit_test/app_opt/job_launcher/docker_launcher_test.py -q` (984 passed, 19 skipped)
- `python3 -m pytest tests/integration_test/slow/recipe_system_test.py::TestRecipeSystemIntegration::test_end_to_end_poc_workflow tests/integration_test/slow/recipe_system_test.py::TestRecipeSystemIntegration::test_recipe_poc_rejects_running_cli_poc -q` (2 passed)
- `./runtest.sh -s`
- `./build_doc.sh --html --skip-api` (succeeded; 120 unrelated repository-wide warnings remain)
- `git diff --check`
