### PR TITLE
Fix configuration format detection for multi-dot filenames

### DIFF
--- a/nvflare/utils/cli_utils.py
+++ b/nvflare/utils/cli_utils.py
@@ -256,8 +256,8 @@ def save_config(dst_config: ConfigTree, dst_path, keep_origin_format: bool = Tru
 
     require_clean_up = False
     if keep_origin_format:
-        original_ext = os.path.basename(dst_path).split(".")[1]
-        fmt = ConfigFormat.config_ext_formats().get(f".{original_ext}", None)
+        filename = os.path.basename(dst_path)
+        fmt = next((fmt for ext, fmt in ConfigFormat.config_ext_formats().items() if filename.endswith(ext)), None)
         if fmt is None:
             raise ValueError(f"invalid file extension {dst_path}, no corresponding configuration format")
         dst_config_path = dst_path

--- a/tests/unit_test/utils/cli_utils_test.py
+++ b/tests/unit_test/utils/cli_utils_test.py
@@ -169,6 +169,15 @@ poc_workspace {
 
         assert json.loads(config_path.read_text())["version"] == 2
 
+    def test_save_config_rejects_unsupported_trailing_suffix(self, tmp_path):
+        config_path = tmp_path / "client.json.backup"
+        config = CF.parse_string("version = 2")
+
+        with pytest.raises(ValueError, match="invalid file extension"):
+            save_config(config, str(config_path))
+
+        assert not config_path.exists()
+
     @pytest.mark.parametrize(
         "inputs, result", [(([], "a"), ["a"]), ((["a"], "a"), ["a"]), ((["a", "b"], "b"), ["a", "b"])]
     )

--- a/tests/unit_test/utils/cli_utils_test.py
+++ b/tests/unit_test/utils/cli_utils_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from pathlib import Path
 
 import pytest
@@ -151,6 +152,22 @@ poc_workspace {
         assert "version = 2" in persisted
         assert 'workspace = "/tmp/nvflare/poc"' in persisted
         assert list(tmp_path.glob("tmp*")) == []
+
+    def test_save_config_uses_final_filename_extension(self, tmp_path):
+        config_path = tmp_path / "client.backup.json"
+        config = CF.parse_string("version = 2")
+
+        save_config(config, str(config_path))
+
+        assert json.loads(config_path.read_text())["version"] == 2
+
+    def test_save_config_supports_compound_default_extension(self, tmp_path):
+        config_path = tmp_path / "client.json.default"
+        config = CF.parse_string("version = 2")
+
+        save_config(config, str(config_path))
+
+        assert json.loads(config_path.read_text())["version"] == 2
 
     @pytest.mark.parametrize(
         "inputs, result", [(([], "a"), ["a"]), ((["a"], "a"), ["a"]), ((["a", "b"], "b"), ["a", "b"])]


### PR DESCRIPTION
Fixes #5271.

### Description

`save_config()` currently reads the second dot-separated filename component to choose the output format, so a valid destination such as `client.backup.json` is rejected.

Match the registered configuration suffixes against the basename instead. Add regression coverage for multi-dot JSON filenames, the supported compound `.json.default` suffix, and rejection of `client.json.backup` without creating an output file. Unsupported trailing suffixes such as `.json.backup` are rejected instead of being mistaken for JSON.

### Types of changes

- [x] Bug fix for supported configuration filenames.
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtest.sh`.

### Validation

- The unsupported-suffix regression test fails with the original second-component parsing (`DID NOT RAISE`) and passes with the suffix-matching fix.
- 195 relevant unit tests passed across `tests/unit_test/utils`, `tests/unit_test/tool/job/config`, `tests/unit_test/tool/cli_arg_utils_test.py`, and `tests/unit_test/tool/config_output_test.py`.
- Black 25.9.0, isort, flake8, license headers, byte compilation, and `git diff --check` passed for the two changed files.
- The scoped style check is appropriate for this two-file utility fix; the full `./runtest.sh` suite was not run.