### PR TITLE
Expose Recipe export intent and Run success queries

### DIFF
--- a/nvflare/recipe/__init__.py
+++ b/nvflare/recipe/__init__.py
@@ -19,6 +19,7 @@ from .prod_env import ProdEnv
 from .run import Run
 from .secrets import PotentialSecretWarning, UnsupportedSecretRefWarning, secret_file_ref, secret_ref
 from .sim_env import SimEnv
+from .spec import export_requested
 from .utils import (
     add_cross_site_evaluation,
     add_experiment_tracking,
@@ -32,6 +33,7 @@ __all__ = [
     "PocEnv",
     "ProdEnv",
     "Run",
+    "export_requested",
     "add_experiment_tracking",
     "add_cross_site_evaluation",
     "add_final_global_evaluation",

--- a/nvflare/recipe/run.py
+++ b/nvflare/recipe/run.py
@@ -15,6 +15,7 @@
 import threading
 from typing import Optional
 
+from nvflare.apis.job_def import RunStatus
 from nvflare.fuel.utils.log_utils import get_obj_logger
 from nvflare.recipe.spec import ExecEnv
 
@@ -73,6 +74,16 @@ class Run:
             except Exception as e:
                 self.logger.warning(f"Failed to get job status: {e}")
                 return None
+
+    def succeeded(self) -> bool:
+        """Return whether the job has completed successfully, without waiting.
+
+        Accepts the current completed status and the legacy ``FINISHED_OK``
+        status returned by older admin APIs. Running, failed, aborted, and
+        unavailable statuses return False. After ``get_result()``, this uses
+        the cached status and does not contact the stopped environment.
+        """
+        return self.get_status() in (RunStatus.FINISHED_COMPLETED.value, "FINISHED_OK")
 
     def get_result(self, timeout: float = 0.0, clean_up: bool = True) -> Optional[str]:
         """Get the result workspace of the run.

--- a/nvflare/recipe/spec.py
+++ b/nvflare/recipe/spec.py
@@ -106,6 +106,17 @@ def _peek_recipe_args() -> tuple:
     return _RECIPE_EXPORT, _RECIPE_EXPORT_DIR
 
 
+def export_requested() -> bool:
+    """Return whether the Recipe CLI was invoked with ``--export``.
+
+    Recipe consumes its CLI flags when imported. Use this query after importing
+    ``nvflare.recipe`` to skip checks that require local execution resources
+    when exporting a job for another system. This does not consume flags again
+    or change export settings; ``--export-dir`` alone does not request export.
+    """
+    return _RECIPE_EXPORT
+
+
 from nvflare.apis.filter import Filter
 from nvflare.app_common.widgets.decomposer_reg import DecomposerRegister
 from nvflare.fuel.utils.fobs import Decomposer

--- a/tests/unit_test/recipe/run_test.py
+++ b/tests/unit_test/recipe/run_test.py
@@ -316,3 +316,32 @@ class TestRunIntegration:
             with patch.object(prod_env, "abort_job") as mock_abort:
                 run.abort()
                 mock_abort.assert_called_once_with("prod_test_job")
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("FINISHED:COMPLETED", True),
+        ("FINISHED_OK", True),
+        ("RUNNING", False),
+        ("FINISHED:ABORTED", False),
+        ("FINISHED:EXECUTION_EXCEPTION", False),
+        (None, False),
+    ],
+)
+def test_succeeded_uses_live_and_cached_status(status, expected):
+    env = MagicMock()
+    env.get_job_status.return_value = status
+    env.get_job_result.return_value = "/tmp/result"
+    run = Run(env, "test-job")
+    assert run.succeeded() is expected
+    run.get_result(clean_up=False)
+    env.get_job_status.reset_mock()
+    assert run.succeeded() is expected
+    env.get_job_status.assert_not_called()
+
+
+def test_succeeded_returns_false_when_status_lookup_fails():
+    env = MagicMock()
+    env.get_job_status.side_effect = RuntimeError("admin connection unavailable")
+    assert Run(env, "test-job").succeeded() is False

--- a/tests/unit_test/recipe/spec_test.py
+++ b/tests/unit_test/recipe/spec_test.py
@@ -1136,3 +1136,16 @@ class TestClientPlacementHardening:
         recipe = self._make_recipe()
         with pytest.raises(ValueError, match="invalid client name"):
             recipe.add_client_config({"timeout": 600}, clients=[bad_site])
+
+
+@pytest.mark.parametrize("flags,expected", [([], False), (["--export"], True), (["--export-dir", "/tmp/out"], False)])
+def test_public_export_requested_reflects_consumed_flags(flags, expected):
+    import subprocess
+    import sys
+
+    code = (
+        "from nvflare.recipe import export_requested; import sys; "
+        "print(export_requested()); print(sys.argv[1:]); print(export_requested())"
+    )
+    result = subprocess.run([sys.executable, "-c", code, *flags], capture_output=True, text=True, check=True)
+    assert result.stdout.splitlines() == [str(expected), "[]", str(expected)]


### PR DESCRIPTION
Recipe examples currently inspect private export flags and duplicate successful job status strings. Add `nvflare.recipe.export_requested()` and `Run.succeeded()` so applications can skip local execution checks during export and recognize both current and legacy successful completion through public APIs.

`export_requested()` reports the flags already consumed at import time without changing them. `Run.succeeded()` does not wait; unavailable, running, and failed statuses return false, and completed runs use their cached status.

This is the small framework prerequisite requested in the review of #5255. Example adoption stays in that PR.

Validation: 101 Recipe spec/Run tests passed, 3 existing skips; repository style and `git diff --check` passed. New tests cover real CLI flag consumption, current/legacy/failed/unknown statuses, and cached status after shutdown.
