### PR TITLE
Enable required CI checks for merge queue candidates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,15 @@
 name: "CodeQL"
 
 on:
+  # Queue branches are tested by merge_group, avoiding a duplicate push build.
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+    tags:
+      - '**'
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   analyze:

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -15,9 +15,15 @@
 name: pre-merge
 
 on:
-  # quick tests for pull requests and the releasing branches
+  # Queue branches are tested by merge_group, avoiding a duplicate push build.
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+    tags:
+      - '**'
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:
@@ -34,12 +40,12 @@ jobs:
       - id: select
         name: Select Tier 1 skill security validation
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha || github.event.before }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # A manual dispatch deliberately runs the gate. For push and pull-request
-          # events, restrict the expensive scans to changes that can affect shipped
-          # skills or this gate's implementation and dependencies.
+          # A manual dispatch deliberately runs the gate. For push, pull-request,
+          # and merge-group events, inspect all changes since the event's base,
+          # including earlier queued PRs, for skill-security validation changes.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ -z "$BASE_SHA" ] || \
             [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo "run-tier1-security=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description

Enable the required pre-merge and CodeQL checks on GitHub merge queue candidates by adding the `merge_group` event with `checks_requested`. Exclude temporary `gh-readonly-queue/**` branches from push triggers to avoid duplicate builds while preserving other branch and tag push builds.

Use the merge group's base SHA for Tier 1 skill-security change detection so the selector considers all changes in the queue candidate, including earlier queued PRs. Existing required check names remain unchanged.

Merge this workflow update into `main` before activating the main-branch merge queue rule. Queue execution must then be verified by enqueueing a PR.

### Types of changes

- [x] Non-breaking CI configuration change.

### Validation

- `./runtest.sh -s --skip-install` passed using the existing development environment (Black skipped notebooks because its Jupyter dependency is not installed).
- Parsed both workflow YAML files and checked queue triggers, push filters, and preserved job IDs.
- Tier 1 changed-path selector tests: 7 passed.
- `git diff --check` passed.
